### PR TITLE
Fix flaky non-string config test

### DIFF
--- a/test/config/non_string_key.yaml
+++ b/test/config/non_string_key.yaml
@@ -2,6 +2,6 @@
 descriptors:
   - key: key1
     value: value1
-    ratelimit:
+    rate_limit:
       unit: day
       requests_per_unit: 5


### PR DESCRIPTION
@lyft/network-team 

This fixes this [test](https://github.com/lyft/ratelimit/blob/6e3c11c979ed1469c5769713195132aba2406363/test/config/config_test.go#L214) from being flaky. Because validateYaml ranges over a map, it sometimes iterates over the `descriptors` tree before the `0.25`. Because the `descriptors` tree used to have another erroneous (`ratelimit`) key it would error out some of the time with that instead of the expected non string error.