### PR TITLE
add http 1 `/json` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,9 @@ ratelimit.service.rate_limit.messaging.message_type_marketing.to_number.total_hi
 
 # HTTP Port
 
-The ratelimit service listens to http 1.1 (by default on port 8080) with two endpoints:
+The ratelimit service listens to HTTP 1.1 (by default on port 8080) with two endpoints:
 1. /healthcheck → return a 200 if this service is healthy
-1. /json → http 1.1 endpoint for interacting with ratelimit service
+1. /json → HTTP 1.1 endpoint for interacting with ratelimit service
 
 ## /json endpoint
 
@@ -382,13 +382,8 @@ Takes an HTTP POST with a JSON body of the form e.g.
   ]
 }
 ```
-The service will return an http 200 if this request is allowed (if no ratelimits exceeded) or 409 if one or more 
+The service will return an http 200 if this request is allowed (if no ratelimits exceeded) or 429 if one or more 
 ratelimits were exceeded. Endpoint does not currently return detailed information on which limits were exceeded.
-
-See the test case in `test/integration/integration_test.go` paired with the config file 
-`test/integration/runtime/current/ratelimit/config/basic.yaml` (which configures the `one_per_minute` descriptor in the
- `basic` domain) 
-for an example
 
 # Debug Port
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
   - [Loading Configuration](#loading-configuration)
 - [Request Fields](#request-fields)
 - [Statistics](#statistics)
+- [HTTP Port](#http-port)
+  - [/json endpoint](#json-endpoint)
 - [Debug Port](#debug-port)
 - [Local Cache](#local-cache)
 - [Redis](#redis)
@@ -359,6 +361,34 @@ ratelimit.service.rate_limit.mongo_cps.database_users.total_hits: 2939
 ratelimit.service.rate_limit.messaging.message_type_marketing.to_number.over_limit: 0
 ratelimit.service.rate_limit.messaging.message_type_marketing.to_number.total_hits: 0
 ```
+
+# HTTP Port
+
+The ratelimit service listens to http 1.1 (by default on port 8080) with two endpoints:
+1. /healthcheck → return a 200 if this service is healthy
+1. /json → http 1.1 endpoint for interacting with ratelimit service
+
+## /json endpoint
+
+Takes an HTTP POST with a JSON body of the form e.g. 
+```json
+{
+  "domain": "dummy",
+  "descriptors": [
+    {"entries": [
+      {"key": "one_per_day",
+       "value":  "something"}
+    ]}
+  ]
+}
+```
+The service will return an http 200 if this request is allowed (if no ratelimits exceeded) or 409 if one or more 
+ratelimits were exceeded. Endpoint does not currently return detailed information on which limits were exceeded.
+
+See the test case in `test/integration/integration_test.go` paired with the config file 
+`test/integration/runtime/current/ratelimit/config/basic.yaml` (which configures the `one_per_minute` descriptor in the
+ `basic` domain) 
+for an example
 
 # Debug Port
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,14 @@ services:
       - .:/go/src/github.com/envoyproxy/ratelimit
       - binary:/usr/local/bin/
 
+  ratelimit-client-build:
+    image: golang:1.14-alpine
+    working_dir: /go/src/github.com/envoyproxy/ratelimit
+    command: go build -o /usr/local/bin/ratelimit_client ./src/client_cmd/main.go
+    volumes:
+      - .:/go/src/github.com/envoyproxy/ratelimit
+      - binary:/usr/local/bin/
+
   ratelimit:
     image: alpine:3.6
     command: /usr/local/bin/ratelimit
@@ -29,6 +37,7 @@ services:
     depends_on:
       - redis
       - ratelimit-build
+      - ratelimit-client-build
     networks:
       - ratelimit-network
     volumes:

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v2"
 	"net/http"
 
 	"github.com/lyft/goruntime/loader"
@@ -25,6 +26,7 @@ type Server interface {
 	 * Add an HTTP endpoint to the local debug port.
 	 */
 	AddDebugHttpEndpoint(path string, help string, handler http.HandlerFunc)
+	AddJsonHandler(pb.RateLimitServiceServer)
 
 	/**
 	 * Returns the embedded gRPC server to be used for registering gRPC endpoints.

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"expvar"
 	"fmt"
 	"io"
@@ -17,6 +18,7 @@ import (
 	"net"
 
 	"github.com/coocood/freecache"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v2"
 	"github.com/envoyproxy/ratelimit/src/settings"
 	"github.com/gorilla/mux"
 	reuseport "github.com/kavu/go_reuseport"
@@ -50,6 +52,37 @@ type server struct {
 func (server *server) AddDebugHttpEndpoint(path string, help string, handler http.HandlerFunc) {
 	server.debugListener.debugMux.HandleFunc(path, handler)
 	server.debugListener.endpoints[path] = help
+}
+
+// add an http/1 handler at the /json endpoint which allows this ratelimit service to work with
+// clients that cannot use the gRPC interface (e.g. lua)
+// example usage from cURL with domain "dummy" and descriptor "perday":
+// echo '{"domain": "dummy", "descriptors": [{"entries": [{"key": "perday"}]}]}' | curl -vvvXPOST --data @/dev/stdin localhost:8080/json
+func (server *server) AddJsonHandler(svc pb.RateLimitServiceServer) {
+	handler := func(writer http.ResponseWriter, request *http.Request) {
+		var req pb.RateLimitRequest
+
+		if err := json.NewDecoder(request.Body).Decode(&req); err != nil {
+			logger.Warnf("error: %s", err.Error())
+			http.Error(writer, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		resp, err := svc.ShouldRateLimit(nil, &req)
+		if err != nil {
+			logger.Warnf("error: %s", err.Error())
+			http.Error(writer, err.Error(), http.StatusBadRequest)
+			return
+		}
+		logger.Debugf("resp:%s", resp)
+		if resp.OverallCode == pb.RateLimitResponse_OVER_LIMIT {
+			http.Error(writer, "over limit", http.StatusTooManyRequests)
+		} else if resp.OverallCode == pb.RateLimitResponse_UNKNOWN {
+			http.Error(writer, "unknown", http.StatusInternalServerError)
+		}
+
+	}
+	server.router.HandleFunc("/json", handler)
 }
 
 func (server *server) GrpcServer() *grpc.Server {

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -75,6 +75,8 @@ func (runner *Runner) Run() {
 			io.WriteString(writer, service.GetCurrentConfig().Dump())
 		})
 
+	srv.AddJsonHandler(service)
+
 	// Ratelimit is compatible with two proto definitions
 	// 1. data-plane-api rls.proto: https://github.com/envoyproxy/data-plane-api/blob/master/envoy/service/ratelimit/v2/rls.proto
 	pb.RegisterRateLimitServiceServer(srv.GrpcServer(), service)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -381,6 +381,10 @@ func TestBasicConfigLegacy(t *testing.T) {
 	assert.Equal(http_resp.StatusCode, 429)
 	http_resp.Body.Close()
 
+	invalid_json := []byte(`{"unclosed quote: []}`)
+	http_resp, _ = http.Post("http://localhost:8082/json", "application/json", bytes.NewBuffer(invalid_json))
+	assert.Equal(http_resp.StatusCode, 400)
+
 	response, err = c.ShouldRateLimit(
 		context.Background(),
 		common.NewRateLimitRequestLegacy("basic_legacy", [][][2]string{{{"key1", "foo"}}}, 1))

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -3,8 +3,10 @@
 package integration_test
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
+	"net/http"
 	"os"
 	"strconv"
 	"testing"
@@ -344,6 +346,7 @@ func TestBasicConfigLegacy(t *testing.T) {
 
 	assert := assert.New(t)
 	conn, err := grpc.Dial("localhost:8083", grpc.WithInsecure())
+
 	assert.NoError(err)
 	defer conn.Close()
 	c := pb_legacy.NewRateLimitServiceClient(conn)
@@ -357,6 +360,26 @@ func TestBasicConfigLegacy(t *testing.T) {
 			Statuses:    []*pb_legacy.RateLimitResponse_DescriptorStatus{{Code: pb_legacy.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0}}},
 		response)
 	assert.NoError(err)
+
+	json_body := []byte(`{
+		"domain": "basic",
+		"descriptors": [
+			{
+				"entries": [
+					{
+						"key": "one_per_minute"
+					}
+				]
+			}
+		]
+	}`)
+	http_resp, _ := http.Post("http://localhost:8082/json", "application/json", bytes.NewBuffer(json_body))
+	assert.Equal(http_resp.StatusCode, 200)
+	http_resp.Body.Close()
+
+	http_resp, _ = http.Post("http://localhost:8082/json", "application/json", bytes.NewBuffer(json_body))
+	assert.Equal(http_resp.StatusCode, 429)
+	http_resp.Body.Close()
 
 	response, err = c.ShouldRateLimit(
 		context.Background(),

--- a/test/integration/runtime/current/ratelimit/config/basic.yaml
+++ b/test/integration/runtime/current/ratelimit/config/basic.yaml
@@ -9,3 +9,8 @@ descriptors:
     rate_limit:
       unit: second
       requests_per_unit: 50
+
+  - key: one_per_minute
+    rate_limit:
+      unit: minute
+      requests_per_unit: 1


### PR DESCRIPTION
We want to use envoy's ratelimit service with Istio 1.1 which means we have to use lua scripting to interact with this service. Lua doesn't support gRPC, so this PR adds a `/json` endpoint to allow http 1 clients to hit the ratelimit service.