### PR TITLE
Use mockgen version from go.mod instead of from "make bootstrap"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ VERSION ?= $(GIT_REF)
 SHELL := /bin/bash
 
 .PHONY: bootstrap
-bootstrap:
-	go get github.com/golang/mock/mockgen@v1.4.1
+bootstrap: ;
 
 define REDIS_STUNNEL
 cert = private.pem

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -1,6 +1,6 @@
 package mocks
 
-//go:generate mockgen -destination ./runtime/snapshot/snapshot.go github.com/lyft/goruntime/snapshot IFace
-//go:generate mockgen -destination ./runtime/loader/loader.go github.com/lyft/goruntime/loader IFace
-//go:generate mockgen -destination ./config/config.go github.com/envoyproxy/ratelimit/src/config RateLimitConfig,RateLimitConfigLoader
-//go:generate mockgen -destination ./redis/redis.go github.com/envoyproxy/ratelimit/src/redis RateLimitCache,Pool,Connection,Response,TimeSource,JitterRandSource
+//go:generate go run github.com/golang/mock/mockgen -destination ./runtime/snapshot/snapshot.go github.com/lyft/goruntime/snapshot IFace
+//go:generate go run github.com/golang/mock/mockgen -destination ./runtime/loader/loader.go github.com/lyft/goruntime/loader IFace
+//go:generate go run github.com/golang/mock/mockgen -destination ./config/config.go github.com/envoyproxy/ratelimit/src/config RateLimitConfig,RateLimitConfigLoader
+//go:generate go run github.com/golang/mock/mockgen -destination ./redis/redis.go github.com/envoyproxy/ratelimit/src/redis RateLimitCache,Pool,Connection,Response,TimeSource,JitterRandSource


### PR DESCRIPTION
Even though the Makefile wants to encourage using mockgen@1.4.1, it
seems like the mocks have been generated using a pre-1.0 version of
mockgen. Using "go run github.com/golang/mock/mockgen" as a go:generate
command instead of just "mockgen" avoids the need to pre-install into
the developer's $PATH and uses the go.mod-specified version

Minor notes:
- I did not actually regenerate the mocks with a newer mockgen version in this PR
- This will have merge conflicts with with #142