### PR TITLE
Introduce a Dockerfile for running integration tests

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -17,18 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: deps
-        run: sudo apt-get update -y && sudo apt-get install stunnel4 redis -y
-
       - name: build and push docker image
         run: |
-          redis-server --port 6380 &
-          redis-server --port 6381 --requirepass password123 &
-          redis-server --port 6382 --requirepass password123 &
-          redis-server --port 6384 --requirepass password123 &
-          redis-server --port 6385 --requirepass password123 &
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          make bootstrap bootstrap_redis_tls docker_push
+          make docker_push
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -16,14 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: deps
-        run: sudo apt-get update -y && sudo apt-get install stunnel4 redis -y
-
       - name: build and test
         run: |
-          redis-server --port 6380 &
-          redis-server --port 6381 --requirepass password123 &
-          redis-server --port 6382 --requirepass password123 &
-          redis-server --port 6384 --requirepass password123 &
-          redis-server --port 6385 --requirepass password123 &
-          make bootstrap bootstrap_redis_tls tests_unit tests
+          make docker_tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,18 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: deps
-        run: sudo apt-get update -y && sudo apt-get install stunnel4 redis -y
-
       - name: build and push docker image
         run: |
-          redis-server --port 6380 &
-          redis-server --port 6381 --requirepass password123 &
-          redis-server --port 6382 --requirepass password123 &
-          redis-server --port 6384 --requirepass password123 &
-          redis-server --port 6385 --requirepass password123 &
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          make bootstrap bootstrap_redis_tls docker_push
+          make docker_push
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,0 +1,17 @@
+# Running this docker image runs the integration tests.
+FROM golang:1.14
+
+RUN apt-get update -y && apt-get install sudo stunnel4 redis -y && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workdir
+
+ENV GOPROXY=https://proxy.golang.org
+COPY go.mod go.sum /workdir/
+RUN go mod download
+
+COPY Makefile /workdir
+RUN make bootstrap
+
+COPY src /workdir/src
+COPY test /workdir/test
+CMD make tests_with_redis

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,8 @@ tests_with_redis: bootstrap_redis_tls tests_unit
 
 .PHONY: docker_tests
 docker_tests:
-	docker build -f Dockerfile.integration . -t $(INTEGRATION_IMAGE):$(VERSION) && docker run -it $(INTEGRATION_IMAGE):$(VERSION)
+	docker build -f Dockerfile.integration . -t $(INTEGRATION_IMAGE):$(VERSION) && \
+	docker run $$(tty -s && echo "-it" || echo) $(INTEGRATION_IMAGE):$(VERSION)
 
 .PHONY: docker_image
 docker_image: docker_tests


### PR DESCRIPTION
This diff creates Dockerfile.integration for running integration tests with clearly-defined dependencies. Previously the dependencies of the integration tests were defined within the github actions config.

The new "make docker_tests" target should work for any developer with Docker installed.

Previously there was no single command that would run integration tests across platforms, which makes development and onboarding harder. Even copying the command from github actions wouldn't have worked before, since that command quietly assumed that redis was already running on port 6379.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>