### PR TITLE
Allow statsd protocol to be configurable

### DIFF
--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -17,6 +17,7 @@ type Settings struct {
 	UseStatsd                    bool          `envconfig:"USE_STATSD" default:"true"`
 	StatsdHost                   string        `envconfig:"STATSD_HOST" default:"localhost"`
 	StatsdPort                   int           `envconfig:"STATSD_PORT" default:"8125"`
+	StatsdProtocol               string        `envconfig:"STATSD_PROTOCOL" default:"tcp"`
 	RuntimePath                  string        `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`
 	RuntimeSubdirectory          string        `envconfig:"RUNTIME_SUBDIRECTORY"`
 	RuntimeIgnoreDotFiles        bool          `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`


### PR DESCRIPTION
This capability is already available via [lyft/gostats](https://github.com/lyft/gostats/blob/cf86465edce66ad764b7412ea3dda2800c0bccdc/settings.go#L32), this just exposes it to be configurable in ratelimit. We require this as we only support UDP statsd for performance reasons.

Signed-off-by: Ian Bishop <ibishop@flipboard.com>