### PR TITLE
ci: Update github action to push docker image tagged with sha

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -20,8 +20,8 @@ jobs:
       - name: build and push docker image
         run: |
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          make docker_push
+          VERSION=master make docker_push     # Push image tagged with "master"
+          make docker_push                    # Push image tagged with git sha
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          VERSION: master

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ REGISTRY ?= envoyproxy
 IMAGE := $(REGISTRY)/$(PROJECT)
 INTEGRATION_IMAGE := $(REGISTRY)/$(PROJECT)_integration
 MODULE = github.com/envoyproxy/ratelimit
-GIT_REF = $(shell git describe --tags || git rev-parse --short=8 --verify HEAD)
+GIT_REF = $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short=8 --verify HEAD)
 VERSION ?= $(GIT_REF)
 SHELL := /bin/bash
 


### PR DESCRIPTION

Updates the github action to also push a tagged image based upon the git sha. The tag also
includes the current version of the release.

Example tag: envoyproxy/ratelimit:f1758150b6dfed3e5c0ae13fb7bb6b8f6ae00b0e

Fixes #174

Signed-off-by: Steve Sloka <slokas@vmware.com>