### PR TITLE
refactor NearLimitRatio to environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ STAT:
 * over_limit: Number of rule hits exceeding the threshold rate
 * total_hits: Number of rule hits in total
 
-These are examples of generated stats for some configured rate limit rules from the above examples:
+To costum near_limit ratio threshold, you can specify with `NEAR_LIMIT_RATIO` environment variable. It defaults to `0.8` (0-1 scale). These are examples of generated stats for some configured rate limit rules from the above examples:
 
 ```
 ratelimit.service.rate_limit.mongo_cps.database_default.over_limit: 0

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ STAT:
 * over_limit: Number of rule hits exceeding the threshold rate
 * total_hits: Number of rule hits in total
 
-To costum near_limit ratio threshold, you can specify with `NEAR_LIMIT_RATIO` environment variable. It defaults to `0.8` (0-1 scale). These are examples of generated stats for some configured rate limit rules from the above examples:
+To use a custom near_limit ratio threshold, you can specify with `NEAR_LIMIT_RATIO` environment variable. It defaults to `0.8` (0-1 scale). These are examples of generated stats for some configured rate limit rules from the above examples:
 
 ```
 ratelimit.service.rate_limit.mongo_cps.database_default.over_limit: 0

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -7,11 +7,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// The NearLimitRation constant defines the ratio of total_hits over
-// the Limit's RequestPerUnit that need to happen before triggering a near_limit
-// stat increase
-const NearLimitRatio = 0.8
-
 // Errors that may be raised during config parsing.
 type RateLimitConfigError string
 

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -42,7 +42,7 @@ type Settings struct {
 	RedisPerSecondPipelineLimit  int           `envconfig:"REDIS_PERSECOND_PIPELINE_LIMIT" default:"0"`
 	ExpirationJitterMaxSeconds   int64         `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
 	LocalCacheSizeInBytes        int           `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
-	NearLimitRatio				 float32	   `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
+	NearLimitRatio               float32       `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
 }
 
 type Option func(*Settings)

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -42,6 +42,7 @@ type Settings struct {
 	RedisPerSecondPipelineLimit  int           `envconfig:"REDIS_PERSECOND_PIPELINE_LIMIT" default:"0"`
 	ExpirationJitterMaxSeconds   int64         `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
 	LocalCacheSizeInBytes        int           `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
+	NearLimitRatio				 float32	   `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
 }
 
 type Option func(*Settings)

--- a/test/redis/bench_test.go
+++ b/test/redis/bench_test.go
@@ -44,7 +44,7 @@ func BenchmarkParallelDoLimit(b *testing.B) {
 			client := redis.NewClientImpl(statsStore, false, "", "single", "127.0.0.1:6379", poolSize, pipelineWindow, pipelineLimit)
 			defer client.Close()
 
-			cache := redis.NewRateLimitCacheImpl(client, nil, limiter.NewTimeSourceImpl(), rand.New(limiter.NewLockedSource(time.Now().Unix())), 10, nil)
+			cache := redis.NewRateLimitCacheImpl(client, nil, limiter.NewTimeSourceImpl(), rand.New(limiter.NewLockedSource(time.Now().Unix())), 10, nil, 0.8)
 			request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
 			limits := []*config.RateLimit{config.NewRateLimit(1000000000, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
 

--- a/test/redis/cache_impl_test.go
+++ b/test/redis/cache_impl_test.go
@@ -43,9 +43,9 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 		timeSource := mock_limiter.NewMockTimeSource(controller)
 		var cache limiter.RateLimitCache
 		if usePerSecondRedis {
-			cache = redis.NewRateLimitCacheImpl(client, perSecondClient, timeSource, rand.New(rand.NewSource(1)), 0, nil)
+			cache = redis.NewRateLimitCacheImpl(client, perSecondClient, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8)
 		} else {
-			cache = redis.NewRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil)
+			cache = redis.NewRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8)
 		}
 		statsStore := stats.NewStore(stats.NewNullSink(), false)
 
@@ -172,7 +172,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_limiter.NewMockTimeSource(controller)
 	localCache := freecache.NewCache(100)
-	cache := redis.NewRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, localCache)
+	cache := redis.NewRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, localCache, 0.8)
 	sink := &common.TestStatSink{}
 	statsStore := stats.NewStore(sink, true)
 	localCacheStats := limiter.NewLocalCacheStats(localCache, statsStore.Scope("localcache"))
@@ -264,7 +264,7 @@ func TestNearLimit(t *testing.T) {
 
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_limiter.NewMockTimeSource(controller)
-	cache := redis.NewRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil)
+	cache := redis.NewRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	// Test Near Limit Stats. Under Near Limit Ratio
@@ -424,7 +424,7 @@ func TestRedisWithJitter(t *testing.T) {
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_limiter.NewMockTimeSource(controller)
 	jitterSource := mock_limiter.NewMockJitterRandSource(controller)
-	cache := redis.NewRateLimitCacheImpl(client, nil, timeSource, rand.New(jitterSource), 3600, nil)
+	cache := redis.NewRateLimitCacheImpl(client, nil, timeSource, rand.New(jitterSource), 3600, nil, 0.8)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)


### PR DESCRIPTION
Issue: https://github.com/envoyproxy/ratelimit/issues/159

According to this issue, I am moving NearLimitRatio constant 0.8 to a configurable environment variable with default is 0.8