### PR TITLE
Add debug logging to indicate descriptor and limit

### DIFF
--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -114,23 +114,27 @@ func (this *service) shouldRateLimitWorker(
 
 	limitsToCheck := make([]*config.RateLimit, len(request.Descriptors))
 	for i, descriptor := range request.Descriptors {
-		var descriptorEntryStrings []string
-		for _, descriptorEntry := range descriptor.GetEntries() {
-			descriptorEntryStrings = append(
-				descriptorEntryStrings,
-				fmt.Sprintf("(%s=%s)", descriptorEntry.Key, descriptorEntry.Value),
-			)
+		if logger.IsLevelEnabled(logger.DebugLevel) {
+			var descriptorEntryStrings []string
+			for _, descriptorEntry := range descriptor.GetEntries() {
+				descriptorEntryStrings = append(
+					descriptorEntryStrings,
+					fmt.Sprintf("(%s=%s)", descriptorEntry.Key, descriptorEntry.Value),
+				)
+			}
+			logger.Debugf("got descriptor: %s", strings.Join(descriptorEntryStrings, ","))
 		}
-		logger.Debugf("got descriptor: %s", strings.Join(descriptorEntryStrings, ","))
 		limitsToCheck[i] = snappedConfig.GetLimit(ctx, request.Domain, descriptor)
-		if limitsToCheck[i] == nil {
-			logger.Debugf("descriptor does not match any limit, no limits applied")
-		} else {
-			logger.Debugf(
-				"applying limit: %d requests per %s",
-				limitsToCheck[i].Limit.RequestsPerUnit,
-				limitsToCheck[i].Limit.Unit.String(),
-			)
+		if logger.IsLevelEnabled(logger.DebugLevel) {
+			if limitsToCheck[i] == nil {
+				logger.Debugf("descriptor does not match any limit, no limits applied")
+			} else {
+				logger.Debugf(
+					"applying limit: %d requests per %s",
+					limitsToCheck[i].Limit.RequestsPerUnit,
+					limitsToCheck[i].Limit.Unit.String(),
+				)
+			}
 		}
 	}
 

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 
@@ -113,7 +114,24 @@ func (this *service) shouldRateLimitWorker(
 
 	limitsToCheck := make([]*config.RateLimit, len(request.Descriptors))
 	for i, descriptor := range request.Descriptors {
+		var descriptorEntryStrings []string
+		for _, descriptorEntry := range descriptor.GetEntries() {
+			descriptorEntryStrings = append(
+				descriptorEntryStrings,
+				fmt.Sprintf("(%s=%s)", descriptorEntry.Key, descriptorEntry.Value),
+			)
+		}
+		logger.Debugf("got descriptor: %s", strings.Join(descriptorEntryStrings, ","))
 		limitsToCheck[i] = snappedConfig.GetLimit(ctx, request.Domain, descriptor)
+		if limitsToCheck[i] == nil {
+			logger.Debugf("descriptor does not match any limit, no limits applied")
+		} else {
+			logger.Debugf(
+				"applying limit: %d requests per %s",
+				limitsToCheck[i].Limit.RequestsPerUnit,
+				limitsToCheck[i].Limit.Unit.String(),
+			)
+		}
 	}
 
 	responseDescriptorStatuses := this.cache.DoLimit(ctx, request, limitsToCheck)


### PR DESCRIPTION
We are actively using ratelimit service with istio. With multiple levels of abstraction (Istio EnvoyFilter -> Envoy configuration -> ratelimit descriptor) it's sometimes hard to understand how does the descriptor received by the specific request look like.

This PR adds three debug level log messages, which should help understanding what exactly is used by the rate limit at moment.

Example messages:

simple descriptor:
```
time="2020-11-26T16:10:43Z" level=debug msg="got descriptor: (header_match=path)"
```

compound descriptor:
```
time="2020-11-26T17:10:22Z" level=debug msg="got descriptor: (header_match=get),(generic_key=foo)"
```

rate limit applied:
```
time="2020-11-26T16:10:43Z" level=debug msg="applying limit: 20 requests per SECOND"
```

no matches:
```
time="2020-11-26T16:22:27Z" level=debug msg="descriptor does not match any limit, no limits applied"
```