### PR TITLE
Fix error when set REDIS_PIPELINE_WINDOW and REDIS_PERSECOND_PIPELINE_WINDOW

### DIFF
--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -1,8 +1,6 @@
 package settings
 
 import (
-	"time"
-
 	"github.com/kelseyhightower/envconfig"
 	"google.golang.org/grpc"
 )
@@ -11,45 +9,38 @@ type Settings struct {
 	// runtime options
 	GrpcUnaryInterceptor grpc.ServerOption
 	// env config
-	Port                                int    `envconfig:"PORT" default:"8080"`
-	GrpcPort                            int    `envconfig:"GRPC_PORT" default:"8081"`
-	DebugPort                           int    `envconfig:"DEBUG_PORT" default:"6070"`
-	UseStatsd                           bool   `envconfig:"USE_STATSD" default:"true"`
-	StatsdHost                          string `envconfig:"STATSD_HOST" default:"localhost"`
-	StatsdPort                          int    `envconfig:"STATSD_PORT" default:"8125"`
-	RuntimePath                         string `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`
-	RuntimeSubdirectory                 string `envconfig:"RUNTIME_SUBDIRECTORY"`
-	RuntimeIgnoreDotFiles               bool   `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
-	RuntimeWatchRoot                    bool   `envconfig:"RUNTIME_WATCH_ROOT" default:"true"`
-	LogLevel                            string `envconfig:"LOG_LEVEL" default:"WARN"`
-	LogFormat                           string `envconfig:"LOG_FORMAT" default:"text"`
-	RedisSocketType                     string `envconfig:"REDIS_SOCKET_TYPE" default:"unix"`
-	RedisType                           string `envconfig:"REDIS_TYPE" default:"SINGLE"`
-	RedisUrl                            string `envconfig:"REDIS_URL" default:"/var/run/nutcracker/ratelimit.sock"`
-	RedisPoolSize                       int    `envconfig:"REDIS_POOL_SIZE" default:"10"`
-	RedisAuth                           string `envconfig:"REDIS_AUTH" default:""`
-	RedisTls                            bool   `envconfig:"REDIS_TLS" default:"false"`
-	RedisPipelineWindow                 time.Duration
-	RedisPipelineWindowInInt64          int64  `envconfig:"REDIS_PIPELINE_WINDOW" default:"0"`
-	RedisPipelineLimit                  int    `envconfig:"REDIS_PIPELINE_LIMIT" default:"0"`
-	RedisPerSecond                      bool   `envconfig:"REDIS_PERSECOND" default:"false"`
-	RedisPerSecondSocketType            string `envconfig:"REDIS_PERSECOND_SOCKET_TYPE" default:"unix"`
-	RedisPerSecondType                  string `envconfig:"REDIS_PERSECOND_TYPE" default:"SINGLE"`
-	RedisPerSecondUrl                   string `envconfig:"REDIS_PERSECOND_URL" default:"/var/run/nutcracker/ratelimitpersecond.sock"`
-	RedisPerSecondPoolSize              int    `envconfig:"REDIS_PERSECOND_POOL_SIZE" default:"10"`
-	RedisPerSecondAuth                  string `envconfig:"REDIS_PERSECOND_AUTH" default:""`
-	RedisPerSecondTls                   bool   `envconfig:"REDIS_PERSECOND_TLS" default:"false"`
-	RedisPerSecondPipelineWindow        time.Duration
-	RedisPerSecondPipelineWindowInInt64 int64   `envconfig:"REDIS_PERSECOND_PIPELINE_WINDOW" default:"0"`
-	RedisPerSecondPipelineLimit         int     `envconfig:"REDIS_PERSECOND_PIPELINE_LIMIT" default:"0"`
-	ExpirationJitterMaxSeconds          int64   `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
-	LocalCacheSizeInBytes               int     `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
-	NearLimitRatio                      float32 `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
-}
-
-func (s *Settings) ConvertRedisPipelineValueToTimeDuration() {
-	s.RedisPipelineWindow = time.Duration(s.RedisPipelineWindowInInt64) * time.Second
-	s.RedisPerSecondPipelineWindow = time.Duration(s.RedisPerSecondPipelineWindowInInt64) * time.Second
+	Port                         int     `envconfig:"PORT" default:"8080"`
+	GrpcPort                     int     `envconfig:"GRPC_PORT" default:"8081"`
+	DebugPort                    int     `envconfig:"DEBUG_PORT" default:"6070"`
+	UseStatsd                    bool    `envconfig:"USE_STATSD" default:"true"`
+	StatsdHost                   string  `envconfig:"STATSD_HOST" default:"localhost"`
+	StatsdPort                   int     `envconfig:"STATSD_PORT" default:"8125"`
+	RuntimePath                  string  `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`
+	RuntimeSubdirectory          string  `envconfig:"RUNTIME_SUBDIRECTORY"`
+	RuntimeIgnoreDotFiles        bool    `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
+	RuntimeWatchRoot             bool    `envconfig:"RUNTIME_WATCH_ROOT" default:"true"`
+	LogLevel                     string  `envconfig:"LOG_LEVEL" default:"WARN"`
+	LogFormat                    string  `envconfig:"LOG_FORMAT" default:"text"`
+	RedisSocketType              string  `envconfig:"REDIS_SOCKET_TYPE" default:"unix"`
+	RedisType                    string  `envconfig:"REDIS_TYPE" default:"SINGLE"`
+	RedisUrl                     string  `envconfig:"REDIS_URL" default:"/var/run/nutcracker/ratelimit.sock"`
+	RedisPoolSize                int     `envconfig:"REDIS_POOL_SIZE" default:"10"`
+	RedisAuth                    string  `envconfig:"REDIS_AUTH" default:""`
+	RedisTls                     bool    `envconfig:"REDIS_TLS" default:"false"`
+	RedisPipelineWindow          int64   `envconfig:"REDIS_PIPELINE_WINDOW" default:"0"`
+	RedisPipelineLimit           int     `envconfig:"REDIS_PIPELINE_LIMIT" default:"0"`
+	RedisPerSecond               bool    `envconfig:"REDIS_PERSECOND" default:"false"`
+	RedisPerSecondSocketType     string  `envconfig:"REDIS_PERSECOND_SOCKET_TYPE" default:"unix"`
+	RedisPerSecondType           string  `envconfig:"REDIS_PERSECOND_TYPE" default:"SINGLE"`
+	RedisPerSecondUrl            string  `envconfig:"REDIS_PERSECOND_URL" default:"/var/run/nutcracker/ratelimitpersecond.sock"`
+	RedisPerSecondPoolSize       int     `envconfig:"REDIS_PERSECOND_POOL_SIZE" default:"10"`
+	RedisPerSecondAuth           string  `envconfig:"REDIS_PERSECOND_AUTH" default:""`
+	RedisPerSecondTls            bool    `envconfig:"REDIS_PERSECOND_TLS" default:"false"`
+	RedisPerSecondPipelineWindow int64   `envconfig:"REDIS_PERSECOND_PIPELINE_WINDOW" default:"0"`
+	RedisPerSecondPipelineLimit  int     `envconfig:"REDIS_PERSECOND_PIPELINE_LIMIT" default:"0"`
+	ExpirationJitterMaxSeconds   int64   `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
+	LocalCacheSizeInBytes        int     `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
+	NearLimitRatio               float32 `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
 }
 
 type Option func(*Settings)
@@ -61,8 +52,6 @@ func NewSettings() Settings {
 	if err != nil {
 		panic(err)
 	}
-
-	s.ConvertRedisPipelineValueToTimeDuration()
 
 	return s
 }

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -11,38 +11,45 @@ type Settings struct {
 	// runtime options
 	GrpcUnaryInterceptor grpc.ServerOption
 	// env config
-	Port                         int           `envconfig:"PORT" default:"8080"`
-	GrpcPort                     int           `envconfig:"GRPC_PORT" default:"8081"`
-	DebugPort                    int           `envconfig:"DEBUG_PORT" default:"6070"`
-	UseStatsd                    bool          `envconfig:"USE_STATSD" default:"true"`
-	StatsdHost                   string        `envconfig:"STATSD_HOST" default:"localhost"`
-	StatsdPort                   int           `envconfig:"STATSD_PORT" default:"8125"`
-	RuntimePath                  string        `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`
-	RuntimeSubdirectory          string        `envconfig:"RUNTIME_SUBDIRECTORY"`
-	RuntimeIgnoreDotFiles        bool          `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
-	RuntimeWatchRoot             bool          `envconfig:"RUNTIME_WATCH_ROOT" default:"true"`
-	LogLevel                     string        `envconfig:"LOG_LEVEL" default:"WARN"`
-	LogFormat                    string        `envconfig:"LOG_FORMAT" default:"text"`
-	RedisSocketType              string        `envconfig:"REDIS_SOCKET_TYPE" default:"unix"`
-	RedisType                    string        `envconfig:"REDIS_TYPE" default:"SINGLE"`
-	RedisUrl                     string        `envconfig:"REDIS_URL" default:"/var/run/nutcracker/ratelimit.sock"`
-	RedisPoolSize                int           `envconfig:"REDIS_POOL_SIZE" default:"10"`
-	RedisAuth                    string        `envconfig:"REDIS_AUTH" default:""`
-	RedisTls                     bool          `envconfig:"REDIS_TLS" default:"false"`
-	RedisPipelineWindow          time.Duration `envconfig:"REDIS_PIPELINE_WINDOW" default:"0"`
-	RedisPipelineLimit           int           `envconfig:"REDIS_PIPELINE_LIMIT" default:"0"`
-	RedisPerSecond               bool          `envconfig:"REDIS_PERSECOND" default:"false"`
-	RedisPerSecondSocketType     string        `envconfig:"REDIS_PERSECOND_SOCKET_TYPE" default:"unix"`
-	RedisPerSecondType           string        `envconfig:"REDIS_PERSECOND_TYPE" default:"SINGLE"`
-	RedisPerSecondUrl            string        `envconfig:"REDIS_PERSECOND_URL" default:"/var/run/nutcracker/ratelimitpersecond.sock"`
-	RedisPerSecondPoolSize       int           `envconfig:"REDIS_PERSECOND_POOL_SIZE" default:"10"`
-	RedisPerSecondAuth           string        `envconfig:"REDIS_PERSECOND_AUTH" default:""`
-	RedisPerSecondTls            bool          `envconfig:"REDIS_PERSECOND_TLS" default:"false"`
-	RedisPerSecondPipelineWindow time.Duration `envconfig:"REDIS_PERSECOND_PIPELINE_WINDOW" default:"0"`
-	RedisPerSecondPipelineLimit  int           `envconfig:"REDIS_PERSECOND_PIPELINE_LIMIT" default:"0"`
-	ExpirationJitterMaxSeconds   int64         `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
-	LocalCacheSizeInBytes        int           `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
-	NearLimitRatio               float32       `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
+	Port                                int    `envconfig:"PORT" default:"8080"`
+	GrpcPort                            int    `envconfig:"GRPC_PORT" default:"8081"`
+	DebugPort                           int    `envconfig:"DEBUG_PORT" default:"6070"`
+	UseStatsd                           bool   `envconfig:"USE_STATSD" default:"true"`
+	StatsdHost                          string `envconfig:"STATSD_HOST" default:"localhost"`
+	StatsdPort                          int    `envconfig:"STATSD_PORT" default:"8125"`
+	RuntimePath                         string `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`
+	RuntimeSubdirectory                 string `envconfig:"RUNTIME_SUBDIRECTORY"`
+	RuntimeIgnoreDotFiles               bool   `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
+	RuntimeWatchRoot                    bool   `envconfig:"RUNTIME_WATCH_ROOT" default:"true"`
+	LogLevel                            string `envconfig:"LOG_LEVEL" default:"WARN"`
+	LogFormat                           string `envconfig:"LOG_FORMAT" default:"text"`
+	RedisSocketType                     string `envconfig:"REDIS_SOCKET_TYPE" default:"unix"`
+	RedisType                           string `envconfig:"REDIS_TYPE" default:"SINGLE"`
+	RedisUrl                            string `envconfig:"REDIS_URL" default:"/var/run/nutcracker/ratelimit.sock"`
+	RedisPoolSize                       int    `envconfig:"REDIS_POOL_SIZE" default:"10"`
+	RedisAuth                           string `envconfig:"REDIS_AUTH" default:""`
+	RedisTls                            bool   `envconfig:"REDIS_TLS" default:"false"`
+	RedisPipelineWindow                 time.Duration
+	RedisPipelineWindowInInt64          int64  `envconfig:"REDIS_PIPELINE_WINDOW" default:"0"`
+	RedisPipelineLimit                  int    `envconfig:"REDIS_PIPELINE_LIMIT" default:"0"`
+	RedisPerSecond                      bool   `envconfig:"REDIS_PERSECOND" default:"false"`
+	RedisPerSecondSocketType            string `envconfig:"REDIS_PERSECOND_SOCKET_TYPE" default:"unix"`
+	RedisPerSecondType                  string `envconfig:"REDIS_PERSECOND_TYPE" default:"SINGLE"`
+	RedisPerSecondUrl                   string `envconfig:"REDIS_PERSECOND_URL" default:"/var/run/nutcracker/ratelimitpersecond.sock"`
+	RedisPerSecondPoolSize              int    `envconfig:"REDIS_PERSECOND_POOL_SIZE" default:"10"`
+	RedisPerSecondAuth                  string `envconfig:"REDIS_PERSECOND_AUTH" default:""`
+	RedisPerSecondTls                   bool   `envconfig:"REDIS_PERSECOND_TLS" default:"false"`
+	RedisPerSecondPipelineWindow        time.Duration
+	RedisPerSecondPipelineWindowInInt64 int64   `envconfig:"REDIS_PERSECOND_PIPELINE_WINDOW" default:"0"`
+	RedisPerSecondPipelineLimit         int     `envconfig:"REDIS_PERSECOND_PIPELINE_LIMIT" default:"0"`
+	ExpirationJitterMaxSeconds          int64   `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
+	LocalCacheSizeInBytes               int     `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
+	NearLimitRatio                      float32 `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
+}
+
+func (s *Settings) ConvertRedisPipelineValueToTimeDuration() {
+	s.RedisPipelineWindow = time.Duration(s.RedisPipelineWindowInInt64) * time.Second
+	s.RedisPerSecondPipelineWindow = time.Duration(s.RedisPerSecondPipelineWindowInInt64) * time.Second
 }
 
 type Option func(*Settings)
@@ -54,6 +61,8 @@ func NewSettings() Settings {
 	if err != nil {
 		panic(err)
 	}
+
+	s.ConvertRedisPipelineValueToTimeDuration()
 
 	return s
 }

--- a/test/settings/settings_test.go
+++ b/test/settings/settings_test.go
@@ -1,0 +1,49 @@
+package settings_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/envoyproxy/ratelimit/src/settings"
+)
+
+func TestShouldReturnDefaultValueForRedisPipelineWindow(t *testing.T) {
+	expectedValue := time.Duration(0) * time.Second
+
+	s := settings.NewSettings()
+	if s.RedisPipelineWindow != expectedValue {
+		t.Errorf("Got %s, expected %s", s.RedisPipelineWindow, expectedValue)
+	}
+}
+
+func TestShouldReturnCorrectValueForRedisPipelineWindow(t *testing.T) {
+	os.Setenv("REDIS_PIPELINE_WINDOW", "100")
+
+	expectedValue := time.Duration(100) * time.Second
+
+	s := settings.NewSettings()
+	if s.RedisPipelineWindow != expectedValue {
+		t.Errorf("Got %s, expected %s", s.RedisPipelineWindow, expectedValue)
+	}
+}
+
+func TestShouldReturnDefaultValueForRedisPerSecondPipelineWindow(t *testing.T) {
+	expectedValue := time.Duration(0) * time.Second
+
+	s := settings.NewSettings()
+	if s.RedisPerSecondPipelineWindow != expectedValue {
+		t.Errorf("Got %s, expected %s", s.RedisPerSecondPipelineWindow, expectedValue)
+	}
+}
+
+func TestShouldReturnCorrectValueForRedisPerSecondPipelineWindow(t *testing.T) {
+	os.Setenv("REDIS_PERSECOND_PIPELINE_WINDOW", "200")
+
+	expectedValue := time.Duration(200) * time.Second
+
+	s := settings.NewSettings()
+	if s.RedisPerSecondPipelineWindow != expectedValue {
+		t.Errorf("Got %s, expected %s", s.RedisPerSecondPipelineWindow, expectedValue)
+	}
+}

--- a/test/settings/settings_test.go
+++ b/test/settings/settings_test.go
@@ -6,44 +6,99 @@ import (
 	"time"
 
 	"github.com/envoyproxy/ratelimit/src/settings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestShouldReturnDefaultValueForRedisPipelineWindow(t *testing.T) {
-	expectedValue := time.Duration(0) * time.Second
-
-	s := settings.NewSettings()
-	if s.RedisPipelineWindow != expectedValue {
-		t.Errorf("Got %s, expected %s", s.RedisPipelineWindow, expectedValue)
-	}
+type TestSettings struct {
+	suite.Suite
 }
 
-func TestShouldReturnCorrectValueForRedisPipelineWindow(t *testing.T) {
+func (ts *TestSettings) SetupTest() {
+	os.Setenv("PORT", "8080")
+	os.Setenv("GRPC_PORT", "8081")
+	os.Setenv("DEBUG_PORT", "6070")
+	os.Setenv("USE_STATSD", "true")
+	os.Setenv("STATSD_HOST", "localhost")
+	os.Setenv("STATSD_PORT", "8125")
+	os.Setenv("RUNTIME_ROOT", "/srv/runtime_data/current")
+	os.Setenv("RUNTIME_SUBDIRECTORY", "")
+	os.Setenv("RUNTIME_IGNOREDOTFILES", "false")
+	os.Setenv("RUNTIME_WATCH_ROOT", "true")
+	os.Setenv("LOG_LEVEL", "WARN")
+	os.Setenv("LOG_FORMAT", "test")
+	os.Setenv("REDIS_SOCKET_TYPE", "unix")
+	os.Setenv("REDIS_TYPE", "SINGLE")
+	os.Setenv("REDIS_URL", "/var/run/nutcracker/ratelimit.sock")
+	os.Setenv("REDIS_POOL_SIZE", "10")
+	os.Setenv("REDIS_AUTH", "")
+	os.Setenv("REDIS_TLS", "false")
+	os.Setenv("REDIS_PIPELINE_WINDOW", "0")
+	os.Setenv("REDIS_PIPELINE_LIMIT", "0")
+	os.Setenv("REDIS_PERSECOND", "false")
+	os.Setenv("REDIS_PERSECOND_SOCKET_TYPE", "unix")
+	os.Setenv("REDIS_PERSECOND_TYPE", "SINGLE")
+	os.Setenv("REDIS_PERSECOND_URL", "/var/run/nutcracker/ratelimit.sock")
+	os.Setenv("REDIS_PERSECOND_POOL_SIZE", "10")
+	os.Setenv("REDIS_PERSECOND_AUTH", "")
+	os.Setenv("REDIS_PERSECOND_TLS", "false")
+	os.Setenv("REDIS_PERSECOND_PIPELINE_WINDOW", "0")
+	os.Setenv("REDIS_PERSECOND_PIPELINE_LIMIT", "0")
+	os.Setenv("EXPIRATION_JITTER_MAX_SECONDS", "300")
+	os.Setenv("LOCAL_CACHE_SIZE_IN_BYTES", "0")
+	os.Setenv("NEAR_LIMIT_RATIO", "0.8")
+}
+
+func (ts *TestSettings) TestShouldReturnDefaultValueIfNotSet() {
+	s := settings.NewSettings()
+
+	assert.Equal(ts.T(), 8080, s.Port)
+	assert.Equal(ts.T(), 8081, s.GrpcPort)
+	assert.Equal(ts.T(), 6070, s.DebugPort)
+	assert.Equal(ts.T(), true, s.UseStatsd)
+	assert.Equal(ts.T(), "localhost", s.StatsdHost)
+	assert.Equal(ts.T(), 8125, s.StatsdPort)
+	assert.Equal(ts.T(), "/srv/runtime_data/current", s.RuntimePath)
+	assert.Equal(ts.T(), "", s.RuntimeSubdirectory)
+	assert.Equal(ts.T(), false, s.RuntimeIgnoreDotFiles)
+	assert.Equal(ts.T(), true, s.RuntimeWatchRoot)
+	assert.Equal(ts.T(), "WARN", s.LogLevel)
+	assert.Equal(ts.T(), "test", s.LogFormat)
+	assert.Equal(ts.T(), "unix", s.RedisSocketType)
+	assert.Equal(ts.T(), "SINGLE", s.RedisType)
+	assert.Equal(ts.T(), "/var/run/nutcracker/ratelimit.sock", s.RedisUrl)
+	assert.Equal(ts.T(), 10, s.RedisPoolSize)
+	assert.Equal(ts.T(), "", s.RedisAuth)
+	assert.Equal(ts.T(), false, s.RedisTls)
+	assert.Equal(ts.T(), time.Duration(0)*time.Second, s.RedisPipelineWindow)
+	assert.Equal(ts.T(), 0, s.RedisPipelineLimit)
+	assert.Equal(ts.T(), false, s.RedisPerSecond)
+	assert.Equal(ts.T(), "unix", s.RedisPerSecondSocketType)
+	assert.Equal(ts.T(), "SINGLE", s.RedisPerSecondType)
+	assert.Equal(ts.T(), "/var/run/nutcracker/ratelimit.sock", s.RedisPerSecondUrl)
+	assert.Equal(ts.T(), 10, s.RedisPerSecondPoolSize)
+	assert.Equal(ts.T(), "", s.RedisPerSecondAuth)
+	assert.Equal(ts.T(), false, s.RedisPerSecondTls)
+	assert.Equal(ts.T(), time.Duration(0)*time.Second, s.RedisPerSecondPipelineWindow)
+	assert.Equal(ts.T(), 0, s.RedisPerSecondPipelineLimit)
+	assert.Equal(ts.T(), int64(300), s.ExpirationJitterMaxSeconds)
+	assert.Equal(ts.T(), 0, s.LocalCacheSizeInBytes)
+	assert.Equal(ts.T(), float32(0.8), s.NearLimitRatio)
+}
+
+func (ts *TestSettings) TestShouldReturnCorrectValue() {
 	os.Setenv("REDIS_PIPELINE_WINDOW", "100")
-
-	expectedValue := time.Duration(100) * time.Second
-
-	s := settings.NewSettings()
-	if s.RedisPipelineWindow != expectedValue {
-		t.Errorf("Got %s, expected %s", s.RedisPipelineWindow, expectedValue)
-	}
-}
-
-func TestShouldReturnDefaultValueForRedisPerSecondPipelineWindow(t *testing.T) {
-	expectedValue := time.Duration(0) * time.Second
-
-	s := settings.NewSettings()
-	if s.RedisPerSecondPipelineWindow != expectedValue {
-		t.Errorf("Got %s, expected %s", s.RedisPerSecondPipelineWindow, expectedValue)
-	}
-}
-
-func TestShouldReturnCorrectValueForRedisPerSecondPipelineWindow(t *testing.T) {
 	os.Setenv("REDIS_PERSECOND_PIPELINE_WINDOW", "200")
 
-	expectedValue := time.Duration(200) * time.Second
+	expectedRedisPipelineWindowExpectedValue := time.Duration(100) * time.Second
+	expectedRedisPerSecondPipelineWindowValue := time.Duration(200) * time.Second
 
 	s := settings.NewSettings()
-	if s.RedisPerSecondPipelineWindow != expectedValue {
-		t.Errorf("Got %s, expected %s", s.RedisPerSecondPipelineWindow, expectedValue)
-	}
+
+	assert.Equal(ts.T(), expectedRedisPipelineWindowExpectedValue, s.RedisPipelineWindow)
+	assert.Equal(ts.T(), expectedRedisPerSecondPipelineWindowValue, s.RedisPerSecondPipelineWindow)
+}
+
+func TestSettingsSuite(t *testing.T) {
+	suite.Run(t, new(TestSettings))
 }

--- a/test/settings/settings_test.go
+++ b/test/settings/settings_test.go
@@ -3,7 +3,6 @@ package settings_test
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/envoyproxy/ratelimit/src/settings"
 	"github.com/stretchr/testify/assert"
@@ -70,7 +69,7 @@ func (ts *TestSettings) TestShouldReturnDefaultValueIfNotSet() {
 	assert.Equal(ts.T(), 10, s.RedisPoolSize)
 	assert.Equal(ts.T(), "", s.RedisAuth)
 	assert.Equal(ts.T(), false, s.RedisTls)
-	assert.Equal(ts.T(), time.Duration(0)*time.Second, s.RedisPipelineWindow)
+	assert.Equal(ts.T(), int64(0), s.RedisPipelineWindow)
 	assert.Equal(ts.T(), 0, s.RedisPipelineLimit)
 	assert.Equal(ts.T(), false, s.RedisPerSecond)
 	assert.Equal(ts.T(), "unix", s.RedisPerSecondSocketType)
@@ -79,7 +78,7 @@ func (ts *TestSettings) TestShouldReturnDefaultValueIfNotSet() {
 	assert.Equal(ts.T(), 10, s.RedisPerSecondPoolSize)
 	assert.Equal(ts.T(), "", s.RedisPerSecondAuth)
 	assert.Equal(ts.T(), false, s.RedisPerSecondTls)
-	assert.Equal(ts.T(), time.Duration(0)*time.Second, s.RedisPerSecondPipelineWindow)
+	assert.Equal(ts.T(), int64(0), s.RedisPerSecondPipelineWindow)
 	assert.Equal(ts.T(), 0, s.RedisPerSecondPipelineLimit)
 	assert.Equal(ts.T(), int64(300), s.ExpirationJitterMaxSeconds)
 	assert.Equal(ts.T(), 0, s.LocalCacheSizeInBytes)
@@ -90,13 +89,10 @@ func (ts *TestSettings) TestShouldReturnCorrectValue() {
 	os.Setenv("REDIS_PIPELINE_WINDOW", "100")
 	os.Setenv("REDIS_PERSECOND_PIPELINE_WINDOW", "200")
 
-	expectedRedisPipelineWindowExpectedValue := time.Duration(100) * time.Second
-	expectedRedisPerSecondPipelineWindowValue := time.Duration(200) * time.Second
-
 	s := settings.NewSettings()
 
-	assert.Equal(ts.T(), expectedRedisPipelineWindowExpectedValue, s.RedisPipelineWindow)
-	assert.Equal(ts.T(), expectedRedisPerSecondPipelineWindowValue, s.RedisPerSecondPipelineWindow)
+	assert.Equal(ts.T(), int64(100), s.RedisPipelineWindow)
+	assert.Equal(ts.T(), int64(200), s.RedisPerSecondPipelineWindow)
 }
 
 func TestSettingsSuite(t *testing.T) {


### PR DESCRIPTION
According to https://github.com/envoyproxy/ratelimit/issues/199 issue, we fix it by adding new field in the settings struct and adding additional function to convert from int64 into time.Duration.

Co-authored-by: zufardhiyaulhaq <zufardhiyaulhaq@gmail.com>