### PR TITLE
client supports handling multi descriptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,17 @@ Output example:
 For information on the fields of a Ratelimit gRPC request please read the information
 on the RateLimitRequest message type in the Ratelimit [proto file.](https://github.com/envoyproxy/envoy/blob/master/api/envoy/service/ratelimit/v3/rls.proto)
 
+# GRPC Client
+The [gRPC client](https://github.com/envoyproxy/ratelimit/blob/master/src/client_cmd/main.go) will interact with ratelimit server and tell you if the requests are over limit.
+## Commandline flags
+* `-dial_string`: used to specify the address of ratelimit server. It defaults to `localhost:8081`.
+* `-domain`: used to specify the domain.
+* `-descriptors`: used to specify one descriptor. You can pass multiple descriptors like following:
+```
+go run main.go -domain test \
+-descriptors name=foo,age=14 -descriptors name=bar,age=18
+```
+
 # Statistics
 
 The rate limit service generates various statistics for each configured rate limit rule that will be useful for end

--- a/src/client_cmd/main.go
+++ b/src/client_cmd/main.go
@@ -33,15 +33,15 @@ func (this *descriptorsValue) Set(arg string) error {
 }
 
 func (this *descriptorsValue) String() string {
-	res := ""
+	ret := ""
 	for _, descriptor := range this.descriptors {
 		tmp := ""
 		for _, entry := range descriptor.Entries {
 			tmp += fmt.Sprintf(" <key=%s, value=%s> ", entry.Key, entry.Value)
 		}
-		res += fmt.Sprintf("[%s] ", tmp)
+		ret += fmt.Sprintf("[%s] ", tmp)
 	}
-	return res
+	return ret
 }
 
 func main() {
@@ -82,5 +82,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("response:\n %s\n", response.String())
+	fmt.Printf("response: %s\n", response.String())
 }

--- a/src/client_cmd/main.go
+++ b/src/client_cmd/main.go
@@ -13,42 +13,50 @@ import (
 	"google.golang.org/grpc"
 )
 
-type descriptorValue struct {
-	descriptor *pb_struct.RateLimitDescriptor
+type descriptorsValue struct {
+	descriptors []*pb_struct.RateLimitDescriptor
 }
 
-func (this *descriptorValue) Set(arg string) error {
+func (this *descriptorsValue) Set(arg string) error {
 	pairs := strings.Split(arg, ",")
-	for _, pair := range pairs {
+	entries := make([]*pb_struct.RateLimitDescriptor_Entry, len(pairs))
+	for i, pair := range pairs {
 		parts := strings.Split(pair, "=")
 		if len(parts) != 2 {
 			return errors.New("invalid descriptor list")
 		}
-
-		this.descriptor.Entries = append(
-			this.descriptor.Entries, &pb_struct.RateLimitDescriptor_Entry{Key: parts[0], Value: parts[1]})
+		entries[i] = &pb_struct.RateLimitDescriptor_Entry{Key: parts[0], Value: parts[1]}
 	}
+	this.descriptors = append(this.descriptors, &pb_struct.RateLimitDescriptor{Entries: entries})
 
 	return nil
 }
 
-func (this *descriptorValue) String() string {
-	return this.descriptor.String()
+func (this *descriptorsValue) String() string {
+	res := ""
+	for _, descriptor := range this.descriptors {
+		tmp := ""
+		for _, entry := range descriptor.Entries {
+			tmp += fmt.Sprintf(" <key=%s, value=%s> ", entry.Key, entry.Value)
+		}
+		res += fmt.Sprintf("[%s] ", tmp)
+	}
+	return res
 }
 
 func main() {
 	dialString := flag.String(
 		"dial_string", "localhost:8081", "url of ratelimit server in <host>:<port> form")
 	domain := flag.String("domain", "", "rate limit configuration domain to query")
-	descriptorValue := descriptorValue{&pb_struct.RateLimitDescriptor{}}
+	descriptorsValue := descriptorsValue{[]*pb_struct.RateLimitDescriptor{}}
 	flag.Var(
-		&descriptorValue, "descriptors",
+		&descriptorsValue, "descriptors",
 		"descriptor list to query in <key>=<value>,<key>=<value>,... form")
 	flag.Parse()
 
 	fmt.Printf("dial string: %s\n", *dialString)
 	fmt.Printf("domain: %s\n", *domain)
-	fmt.Printf("descriptors: %s\n", &descriptorValue)
+	fmt.Printf("descriptors: %s\n", &descriptorsValue)
 
 	conn, err := grpc.Dial(*dialString, grpc.WithInsecure())
 	if err != nil {
@@ -58,11 +66,15 @@ func main() {
 
 	defer conn.Close()
 	c := pb.NewRateLimitServiceClient(conn)
+	desc := make([]*pb_struct.RateLimitDescriptor, len(descriptorsValue.descriptors))
+	for i, v := range descriptorsValue.descriptors {
+		desc[i] = v
+	}
 	response, err := c.ShouldRateLimit(
 		context.Background(),
 		&pb.RateLimitRequest{
 			Domain:      *domain,
-			Descriptors: []*pb_struct.RateLimitDescriptor{descriptorValue.descriptor},
+			Descriptors: desc,
 			HitsAddend:  1,
 		})
 	if err != nil {
@@ -70,5 +82,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("response: %s\n", response.String())
+	fmt.Printf("response:\n %s\n", response.String())
 }


### PR DESCRIPTION
This client supports handling multi descriptors by flag `-descriptors`, e.g.
**cmd:**
go run main -domain test -descriptors name=foo,age=18 -descriptors name=bar,age=14 ,
the grpc server will return a overall response for all of descriptors.
**output:**
dial string: localhost:8081
domain: test
descriptors: [ <key=name, value=foo>  <key=age, value=18> ] [ <key=name, value=bar>  <key=age, value=14> ] 
response:
 overall_code:OK  statuses:{code:OK  current_limit:{requests_per_unit:2  unit:MINUTE}  limit_remaining:1  duration_until_reset:{seconds:6}}  statuses:{code:OK  current_limit:{requests_per_unit:2  unit:MINUTE}  duration_until_reset:{seconds:6}}

@mattklein123   cloud you please check this PR?