### PR TITLE
Add CACHE_KEY_PREFIX for an optional redis/memcache key prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ As well Ratelimit supports TLS connections and authentication. These can be conf
 
 1. `REDIS_TLS` & `REDIS_PERSECOND_TLS`: set to `"true"` to enable a TLS connection for the specific connection type.
 1. `REDIS_AUTH` & `REDIS_PERSECOND_AUTH`: set to `"password"` to enable authentication to the redis host.
+1. `CACHE_KEY_PREFIX`: a string to prepend to all cache keys
 
 ## Redis type
 
@@ -563,6 +564,7 @@ To configure a Memcache instance use the following environment variables instead
 
 1. `MEMCACHE_HOST_PORT=<host:port>`
 1. `BACKEND_TYPE=memcache`
+1. `CACHE_KEY_PREFIX`: a string to prepend to all cache keys
 
 With memcache mode increments will happen asynchronously, so it's technically possible for
 a client to exceed quota briefly if multiple requests happen at exactly the same time.

--- a/src/limiter/base_limiter.go
+++ b/src/limiter/base_limiter.go
@@ -115,12 +115,12 @@ func (this *BaseRateLimiter) GetResponseDescriptorStatus(key string, limitInfo *
 }
 
 func NewBaseRateLimit(timeSource utils.TimeSource, jitterRand *rand.Rand, expirationJitterMaxSeconds int64,
-	localCache *freecache.Cache, nearLimitRatio float32) *BaseRateLimiter {
+	localCache *freecache.Cache, nearLimitRatio float32, cacheKeyPrefix string) *BaseRateLimiter {
 	return &BaseRateLimiter{
 		timeSource:                 timeSource,
 		JitterRand:                 jitterRand,
 		ExpirationJitterMaxSeconds: expirationJitterMaxSeconds,
-		cacheKeyGenerator:          NewCacheKeyGenerator(),
+		cacheKeyGenerator:          NewCacheKeyGenerator(cacheKeyPrefix),
 		localCache:                 localCache,
 		nearLimitRatio:             nearLimitRatio,
 	}

--- a/src/limiter/cache_key.go
+++ b/src/limiter/cache_key.go
@@ -19,14 +19,14 @@ type CacheKeyGenerator struct {
 
 func NewCacheKeyGenerator(prefix string) CacheKeyGenerator {
 	return CacheKeyGenerator{
-	  prefix: prefix,
-	  bufferPool: sync.Pool{
-		New: func() interface{} {
-		  return new(bytes.Buffer)
+		prefix: prefix,
+		bufferPool: sync.Pool{
+			New: func() interface{} {
+				return new(bytes.Buffer)
+			},
 		},
-	  },
 	}
-  }
+}
 
 type CacheKey struct {
 	Key string

--- a/src/limiter/cache_key.go
+++ b/src/limiter/cache_key.go
@@ -12,17 +12,21 @@ import (
 )
 
 type CacheKeyGenerator struct {
+	prefix string
 	// bytes.Buffer pool used to efficiently generate cache keys.
 	bufferPool sync.Pool
 }
 
-func NewCacheKeyGenerator() CacheKeyGenerator {
-	return CacheKeyGenerator{bufferPool: sync.Pool{
+func NewCacheKeyGenerator(prefix string) CacheKeyGenerator {
+	return CacheKeyGenerator{
+	  prefix: prefix,
+	  bufferPool: sync.Pool{
 		New: func() interface{} {
-			return new(bytes.Buffer)
+		  return new(bytes.Buffer)
 		},
-	}}
-}
+	  },
+	}
+  }
 
 type CacheKey struct {
 	Key string
@@ -54,6 +58,7 @@ func (this *CacheKeyGenerator) GenerateCacheKey(
 	defer this.bufferPool.Put(b)
 	b.Reset()
 
+	b.WriteString(this.prefix)
 	b.WriteString(domain)
 	b.WriteByte('_')
 

--- a/src/memcached/cache_impl.go
+++ b/src/memcached/cache_impl.go
@@ -41,7 +41,6 @@ type rateLimitMemcacheImpl struct {
 	timeSource                 utils.TimeSource
 	jitterRand                 *rand.Rand
 	expirationJitterMaxSeconds int64
-	cacheKeyGenerator          limiter.CacheKeyGenerator
 	localCache                 *freecache.Cache
 	waitGroup                  sync.WaitGroup
 	nearLimitRatio             float32
@@ -170,16 +169,15 @@ func (this *rateLimitMemcacheImpl) Flush() {
 }
 
 func NewRateLimitCacheImpl(client Client, timeSource utils.TimeSource, jitterRand *rand.Rand,
-	expirationJitterMaxSeconds int64, localCache *freecache.Cache, scope stats.Scope, nearLimitRatio float32) limiter.RateLimitCache {
+	expirationJitterMaxSeconds int64, localCache *freecache.Cache, scope stats.Scope, nearLimitRatio float32, cacheKeyPrefix string) limiter.RateLimitCache {
 	return &rateLimitMemcacheImpl{
 		client:                     client,
 		timeSource:                 timeSource,
-		cacheKeyGenerator:          limiter.NewCacheKeyGenerator(),
 		jitterRand:                 jitterRand,
 		expirationJitterMaxSeconds: expirationJitterMaxSeconds,
 		localCache:                 localCache,
 		nearLimitRatio:             nearLimitRatio,
-		baseRateLimiter:            limiter.NewBaseRateLimit(timeSource, jitterRand, expirationJitterMaxSeconds, localCache, nearLimitRatio),
+		baseRateLimiter:            limiter.NewBaseRateLimit(timeSource, jitterRand, expirationJitterMaxSeconds, localCache, nearLimitRatio, cacheKeyPrefix),
 	}
 }
 
@@ -193,5 +191,6 @@ func NewRateLimitCacheImplFromSettings(s settings.Settings, timeSource utils.Tim
 		localCache,
 		scope,
 		s.NearLimitRatio,
+		s.CacheKeyPrefix,
 	)
 }

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -27,5 +27,7 @@ func NewRateLimiterCacheImplFromSettings(s settings.Settings, localCache *freeca
 		jitterRand,
 		expirationJitterMaxSeconds,
 		localCache,
-		s.NearLimitRatio)
+		s.NearLimitRatio,
+        s.CacheKeyPrefix,
+	)
 }

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -28,6 +28,6 @@ func NewRateLimiterCacheImplFromSettings(s settings.Settings, localCache *freeca
 		expirationJitterMaxSeconds,
 		localCache,
 		s.NearLimitRatio,
-        s.CacheKeyPrefix,
+		s.CacheKeyPrefix,
 	)
 }

--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -107,10 +107,10 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 func (this *fixedRateLimitCacheImpl) Flush() {}
 
 func NewFixedRateLimitCacheImpl(client Client, perSecondClient Client, timeSource utils.TimeSource,
-	jitterRand *rand.Rand, expirationJitterMaxSeconds int64, localCache *freecache.Cache, nearLimitRatio float32) limiter.RateLimitCache {
+	jitterRand *rand.Rand, expirationJitterMaxSeconds int64, localCache *freecache.Cache, nearLimitRatio float32, cacheKeyPrefix string) limiter.RateLimitCache {
 	return &fixedRateLimitCacheImpl{
 		client:          client,
 		perSecondClient: perSecondClient,
-		baseRateLimiter: limiter.NewBaseRateLimit(timeSource, jitterRand, expirationJitterMaxSeconds, localCache, nearLimitRatio),
+		baseRateLimiter: limiter.NewBaseRateLimit(timeSource, jitterRand, expirationJitterMaxSeconds, localCache, nearLimitRatio, cacheKeyPrefix),
 	}
 }

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -45,6 +45,7 @@ type Settings struct {
 	NearLimitRatio               float32       `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
 	MemcacheHostPort             string        `envconfig:"MEMCACHE_HOST_PORT" default:""`
 	BackendType                  string        `envconfig:"BACKEND_TYPE" default:"redis"`
+	CacheKeyPrefix               string        `envconfig:"CACHE_KEY_PREFIX" default:""`
 }
 
 type Option func(*Settings)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -53,6 +53,10 @@ func TestBasicConfig(t *testing.T) {
 	t.Run("WithPerSecondRedisWithLocalCache", testBasicConfig("18085", "true", "1000", "redis"))
 }
 
+func TestBasicConfigCachePrefix(t *testing.T) {
+	t.Run("WithoutPerSecondRedis", testBasicConfigPrefix("8083", "false", "0", "", "prefix:"))
+}
+
 func TestBasicTLSConfig(t *testing.T) {
 	t.Run("WithoutPerSecondRedisTLS", testBasicConfigAuthTLS("8087", "false", "0"))
 	t.Run("WithPerSecondRedisTLS", testBasicConfigAuthTLS("8089", "true", "0"))
@@ -91,6 +95,10 @@ func TestBasicConfigMemcache(t *testing.T) {
 	t.Run("MemcacheWithLocalCache", testBasicConfig("18099", "false", "1000", "memcache"))
 }
 
+func TestBasicConfigMemcacheCachePrefix(t *testing.T) {
+	t.Run("Memcache", testBasicConfigPrefix("8098", "false", "0", "memcache", "prefix:"))
+}
+
 func testBasicConfigAuthTLS(grpcPort, perSecond string, local_cache_size string) func(*testing.T) {
 	os.Setenv("REDIS_PERSECOND_URL", "localhost:16382")
 	os.Setenv("REDIS_URL", "localhost:16381")
@@ -101,7 +109,7 @@ func testBasicConfigAuthTLS(grpcPort, perSecond string, local_cache_size string)
 	os.Setenv("REDIS_TYPE", "single")
 	os.Setenv("REDIS_PERSECOND_TYPE", "single")
 
-	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "")
+	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "", "")
 }
 
 func testBasicConfig(grpcPort, perSecond string, local_cache_size string, backend_type string) func(*testing.T) {
@@ -115,7 +123,21 @@ func testBasicConfig(grpcPort, perSecond string, local_cache_size string, backen
 	os.Setenv("REDIS_TYPE", "single")
 	os.Setenv("REDIS_PERSECOND_TYPE", "single")
 
-	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, backend_type)
+	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, backend_type, "")
+}
+
+func testBasicConfigPrefix(grpcPort, perSecond string, local_cache_size string, backend_type string, cacheKeyPrefix string) func(*testing.T) {
+	os.Setenv("REDIS_PERSECOND_URL", "localhost:6380")
+	os.Setenv("REDIS_URL", "localhost:6379")
+	os.Setenv("MEMCACHE_HOST_PORT", "localhost:6394")
+	os.Setenv("REDIS_AUTH", "")
+	os.Setenv("REDIS_TLS", "false")
+	os.Setenv("REDIS_PERSECOND_AUTH", "")
+	os.Setenv("REDIS_PERSECOND_TLS", "false")
+	os.Setenv("REDIS_TYPE", "single")
+	os.Setenv("REDIS_PERSECOND_TYPE", "single")
+
+	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, backend_type, cacheKeyPrefix)
 }
 
 func testBasicConfigAuth(grpcPort, perSecond string, local_cache_size string) func(*testing.T) {
@@ -128,7 +150,7 @@ func testBasicConfigAuth(grpcPort, perSecond string, local_cache_size string) fu
 	os.Setenv("REDIS_TYPE", "single")
 	os.Setenv("REDIS_PERSECOND_TYPE", "single")
 
-	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "")
+	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "", "")
 }
 
 func testBasicConfigAuthWithRedisCluster(grpcPort, perSecond string, local_cache_size string) func(*testing.T) {
@@ -143,7 +165,7 @@ func testBasicConfigAuthWithRedisCluster(grpcPort, perSecond string, local_cache
 	os.Setenv("REDIS_PERSECOND_PIPELINE_LIMIT", "8")
 	os.Setenv("REDIS_PIPELINE_LIMIT", "8")
 
-	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "")
+	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "", "")
 }
 
 func testBasicAuthConfigWithRedisSentinel(grpcPort, perSecond string, local_cache_size string) func(*testing.T) {
@@ -154,7 +176,7 @@ func testBasicAuthConfigWithRedisSentinel(grpcPort, perSecond string, local_cach
 	os.Setenv("REDIS_URL", "mymaster,localhost:26394,localhost:26395,localhost:26396")
 	os.Setenv("REDIS_TLS", "false")
 
-	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "")
+	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "", "")
 }
 
 func testBasicConfigWithoutWatchRoot(grpcPort, perSecond string, local_cache_size string) func(*testing.T) {
@@ -167,7 +189,7 @@ func testBasicConfigWithoutWatchRoot(grpcPort, perSecond string, local_cache_siz
 	os.Setenv("RUNTIME_WATCH_ROOT", "false")
 	os.Setenv("REDIS_TYPE", "single")
 	os.Setenv("REDIS_PERSECOND_TYPE", "single")
-	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "")
+	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "", "")
 }
 
 func testBasicConfigWithoutWatchRootWithRedisCluster(grpcPort, perSecond string, local_cache_size string) func(*testing.T) {
@@ -183,7 +205,7 @@ func testBasicConfigWithoutWatchRootWithRedisCluster(grpcPort, perSecond string,
 	os.Setenv("REDIS_PERSECOND_PIPELINE_LIMIT", "8")
 	os.Setenv("REDIS_PIPELINE_LIMIT", "8")
 
-	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "")
+	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "", "")
 }
 
 func testBasicConfigWithoutWatchRootWithRedisSentinel(grpcPort, perSecond string, local_cache_size string) func(*testing.T) {
@@ -195,7 +217,7 @@ func testBasicConfigWithoutWatchRootWithRedisSentinel(grpcPort, perSecond string
 	os.Setenv("REDIS_PERSECOND_TLS", "false")
 	os.Setenv("RUNTIME_WATCH_ROOT", "false")
 
-	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "")
+	return testBasicBaseConfig(grpcPort, perSecond, local_cache_size, "", "")
 }
 
 func testBasicConfigReload(grpcPort, perSecond string, local_cache_size, runtimeWatchRoot string) func(*testing.T) {
@@ -248,7 +270,7 @@ func getCacheKey(cacheKey string, enableLocalCache bool) string {
 	return cacheKey
 }
 
-func testBasicBaseConfig(grpcPort, perSecond string, local_cache_size string, backend_type string) func(*testing.T) {
+func testBasicBaseConfig(grpcPort, perSecond string, local_cache_size string, backend_type string, cacheKeyPrefix string) func(*testing.T) {
 	return func(t *testing.T) {
 		os.Setenv("REDIS_PERSECOND", perSecond)
 		os.Setenv("PORT", "8082")
@@ -261,6 +283,7 @@ func testBasicBaseConfig(grpcPort, perSecond string, local_cache_size string, ba
 		os.Setenv("LOCAL_CACHE_SIZE_IN_BYTES", local_cache_size)
 		os.Setenv("USE_STATSD", "false")
 		os.Setenv("BACKEND_TYPE", backend_type)
+		os.Setenv("CACHE_KEY_PREFIX", cacheKeyPrefix)
 
 		local_cache_size_val, _ := strconv.Atoi(local_cache_size)
 		enable_local_cache := local_cache_size_val > 0
@@ -502,6 +525,7 @@ func TestBasicConfigLegacy(t *testing.T) {
 	os.Setenv("REDIS_PERSECOND_TLS", "false")
 	os.Setenv("REDIS_PERSECOND_AUTH", "")
 	os.Setenv("BACKEND_TYPE", "")
+	os.Setenv("CACHE_KEY_PREFIX", "")
 	os.Setenv("REDIS_TYPE", "single")
 	os.Setenv("REDIS_PERSECOND_TYPE", "single")
 
@@ -613,6 +637,7 @@ func testConfigReload(grpcPort, perSecond string, local_cache_size string) func(
 		os.Setenv("LOCAL_CACHE_SIZE_IN_BYTES", local_cache_size)
 		os.Setenv("USE_STATSD", "false")
 		os.Setenv("BACKEND_TYPE", "")
+		os.Setenv("CACHE_KEY_PREFIX", "")
 
 		local_cache_size_val, _ := strconv.Atoi(local_cache_size)
 		enable_local_cache := local_cache_size_val > 0

--- a/test/limiter/base_limiter_test.go
+++ b/test/limiter/base_limiter_test.go
@@ -1,6 +1,9 @@
 package limiter
 
 import (
+	"math/rand"
+	"testing"
+
 	"github.com/coocood/freecache"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	"github.com/envoyproxy/ratelimit/src/config"
@@ -10,8 +13,6 @@ import (
 	"github.com/golang/mock/gomock"
 	stats "github.com/lyft/gostats"
 	"github.com/stretchr/testify/assert"
-	"math/rand"
-	"testing"
 )
 
 func TestGenerateCacheKeys(t *testing.T) {
@@ -22,7 +23,7 @@ func TestGenerateCacheKeys(t *testing.T) {
 	jitterSource := mock_utils.NewMockJitterRandSource(controller)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 	timeSource.EXPECT().UnixNow().Return(int64(1234))
-	baseRateLimit := limiter.NewBaseRateLimit(timeSource, rand.New(jitterSource), 3600, nil, 0.8)
+	baseRateLimit := limiter.NewBaseRateLimit(timeSource, rand.New(jitterSource), 3600, nil, 0.8, "")
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
 	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
@@ -32,13 +33,31 @@ func TestGenerateCacheKeys(t *testing.T) {
 	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
 }
 
+func TestGenerateCacheKeysPrefix(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	jitterSource := mock_utils.NewMockJitterRandSource(controller)
+	statsStore := stats.NewStore(stats.NewNullSink(), false)
+	timeSource.EXPECT().UnixNow().Return(int64(1234))
+	baseRateLimit := limiter.NewBaseRateLimit(timeSource, rand.New(jitterSource), 3600, nil, 0.8, "prefix:")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
+	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
+	cacheKeys := baseRateLimit.GenerateCacheKeys(request, limits, 1)
+	assert.Equal(1, len(cacheKeys))
+	assert.Equal("prefix:domain_key_value_1234", cacheKeys[0].Key)
+	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
+}
+
 func TestOverLimitWithLocalCache(t *testing.T) {
 	assert := assert.New(t)
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 	localCache := freecache.NewCache(100)
 	localCache.Set([]byte("key"), []byte("value"), 100)
-	baseRateLimit := limiter.NewBaseRateLimit(nil, nil, 3600, localCache, 0.8)
+	baseRateLimit := limiter.NewBaseRateLimit(nil, nil, 3600, localCache, 0.8, "")
 	// Returns true, as local cache contains over limit value for the key.
 	assert.Equal(true, baseRateLimit.IsOverLimitWithLocalCache("key"))
 }
@@ -47,11 +66,11 @@ func TestNoOverLimitWithLocalCache(t *testing.T) {
 	assert := assert.New(t)
 	controller := gomock.NewController(t)
 	defer controller.Finish()
-	baseRateLimit := limiter.NewBaseRateLimit(nil, nil, 3600, nil, 0.8)
+	baseRateLimit := limiter.NewBaseRateLimit(nil, nil, 3600, nil, 0.8, "")
 	// Returns false, as local cache is nil.
 	assert.Equal(false, baseRateLimit.IsOverLimitWithLocalCache("domain_key_value_1234"))
 	localCache := freecache.NewCache(100)
-	baseRateLimitWithLocalCache := limiter.NewBaseRateLimit(nil, nil, 3600, localCache, 0.8)
+	baseRateLimitWithLocalCache := limiter.NewBaseRateLimit(nil, nil, 3600, localCache, 0.8, "")
 	// Returns false, as local cache does not contain value for cache key.
 	assert.Equal(false, baseRateLimitWithLocalCache.IsOverLimitWithLocalCache("domain_key_value_1234"))
 }
@@ -60,7 +79,7 @@ func TestGetResponseStatusEmptyKey(t *testing.T) {
 	assert := assert.New(t)
 	controller := gomock.NewController(t)
 	defer controller.Finish()
-	baseRateLimit := limiter.NewBaseRateLimit(nil, nil, 3600, nil, 0.8)
+	baseRateLimit := limiter.NewBaseRateLimit(nil, nil, 3600, nil, 0.8, "")
 	responseStatus := baseRateLimit.GetResponseDescriptorStatus("", nil, false, 1)
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
@@ -73,7 +92,7 @@ func TestGetResponseStatusOverLimitWithLocalCache(t *testing.T) {
 	timeSource := mock_utils.NewMockTimeSource(controller)
 	timeSource.EXPECT().UnixNow().Return(int64(1234))
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
-	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, nil, 0.8)
+	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, nil, 0.8, "")
 	limits := []*config.RateLimit{config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 6, 4, 5)
 	// As `isOverLimitWithLocalCache` is passed as `true`, immediate response is returned with no checks of the limits.
@@ -93,7 +112,7 @@ func TestGetResponseStatusOverLimit(t *testing.T) {
 	timeSource.EXPECT().UnixNow().Return(int64(1234))
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 	localCache := freecache.NewCache(100)
-	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, localCache, 0.8)
+	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, localCache, 0.8, "")
 	limits := []*config.RateLimit{config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 7, 4, 5)
 	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1)
@@ -114,7 +133,7 @@ func TestGetResponseStatusBelowLimit(t *testing.T) {
 	timeSource := mock_utils.NewMockTimeSource(controller)
 	timeSource.EXPECT().UnixNow().Return(int64(1234))
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
-	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, nil, 0.8)
+	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, nil, 0.8, "")
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 6, 9, 10)
 	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1)

--- a/test/memcached/cache_impl_test.go
+++ b/test/memcached/cache_impl_test.go
@@ -34,7 +34,7 @@ func TestMemcached(t *testing.T) {
 	timeSource := mock_utils.NewMockTimeSource(controller)
 	client := mock_memcached.NewMockClient(controller)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
-	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, statsStore, 0.8)
+	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, statsStore, 0.8, "")
 
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
 	client.EXPECT().GetMulti([]string{"domain_key_value_1234"}).Return(
@@ -120,7 +120,7 @@ func TestMemcachedGetError(t *testing.T) {
 	timeSource := mock_utils.NewMockTimeSource(controller)
 	client := mock_memcached.NewMockClient(controller)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
-	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, statsStore, 0.8)
+	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, statsStore, 0.8, "")
 
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
 	client.EXPECT().GetMulti([]string{"domain_key_value_1234"}).Return(
@@ -204,7 +204,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	localCache := freecache.NewCache(100)
 	sink := &common.TestStatSink{}
 	statsStore := stats.NewStore(sink, true)
-	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, localCache, statsStore, 0.8)
+	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, localCache, statsStore, 0.8, "")
 	localCacheStats := limiter.NewLocalCacheStats(localCache, statsStore.Scope("localcache"))
 
 	// Test Near Limit Stats. Under Near Limit Ratio
@@ -296,7 +296,7 @@ func TestNearLimit(t *testing.T) {
 	timeSource := mock_utils.NewMockTimeSource(controller)
 	client := mock_memcached.NewMockClient(controller)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
-	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, statsStore, 0.8)
+	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, statsStore, 0.8, "")
 
 	// Test Near Limit Stats. Under Near Limit Ratio
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(3)
@@ -464,7 +464,7 @@ func TestMemcacheWithJitter(t *testing.T) {
 	client := mock_memcached.NewMockClient(controller)
 	jitterSource := mock_utils.NewMockJitterRandSource(controller)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
-	cache := memcached.NewRateLimitCacheImpl(client, timeSource, rand.New(jitterSource), 3600, nil, statsStore, 0.8)
+	cache := memcached.NewRateLimitCacheImpl(client, timeSource, rand.New(jitterSource), 3600, nil, statsStore, 0.8, "")
 
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
 	jitterSource.EXPECT().Int63().Return(int64(100))
@@ -505,7 +505,7 @@ func TestMemcacheAdd(t *testing.T) {
 	timeSource := mock_utils.NewMockTimeSource(controller)
 	client := mock_memcached.NewMockClient(controller)
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
-	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, statsStore, 0.8)
+	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, statsStore, 0.8, "")
 
 	// Test a race condition with the initial add
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)

--- a/test/redis/bench_test.go
+++ b/test/redis/bench_test.go
@@ -44,7 +44,7 @@ func BenchmarkParallelDoLimit(b *testing.B) {
 			client := redis.NewClientImpl(statsStore, false, "", "single", "127.0.0.1:6379", poolSize, pipelineWindow, pipelineLimit)
 			defer client.Close()
 
-			cache := redis.NewFixedRateLimitCacheImpl(client, nil, utils.NewTimeSourceImpl(), rand.New(utils.NewLockedSource(time.Now().Unix())), 10, nil, 0.8)
+			cache := redis.NewFixedRateLimitCacheImpl(client, nil, utils.NewTimeSourceImpl(), rand.New(utils.NewLockedSource(time.Now().Unix())), 10, nil, 0.8, "")
 			request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
 			limits := []*config.RateLimit{config.NewRateLimit(1000000000, pb.RateLimitResponse_RateLimit_SECOND, "key_value", statsStore)}
 

--- a/test/redis/fixed_cache_impl_test.go
+++ b/test/redis/fixed_cache_impl_test.go
@@ -42,9 +42,9 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 		timeSource := mock_utils.NewMockTimeSource(controller)
 		var cache limiter.RateLimitCache
 		if usePerSecondRedis {
-			cache = redis.NewFixedRateLimitCacheImpl(client, perSecondClient, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8)
+			cache = redis.NewFixedRateLimitCacheImpl(client, perSecondClient, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "")
 		} else {
-			cache = redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8)
+			cache = redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "")
 		}
 		statsStore := stats.NewStore(stats.NewNullSink(), false)
 
@@ -171,7 +171,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_utils.NewMockTimeSource(controller)
 	localCache := freecache.NewCache(100)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, localCache, 0.8)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, localCache, 0.8, "")
 	sink := &common.TestStatSink{}
 	statsStore := stats.NewStore(sink, true)
 	localCacheStats := limiter.NewLocalCacheStats(localCache, statsStore.Scope("localcache"))
@@ -263,7 +263,7 @@ func TestNearLimit(t *testing.T) {
 
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_utils.NewMockTimeSource(controller)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "")
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	// Test Near Limit Stats. Under Near Limit Ratio
@@ -423,7 +423,7 @@ func TestRedisWithJitter(t *testing.T) {
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_utils.NewMockTimeSource(controller)
 	jitterSource := mock_utils.NewMockJitterRandSource(controller)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(jitterSource), 3600, nil, 0.8)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(jitterSource), 3600, nil, 0.8, "")
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)


### PR DESCRIPTION
k/v store proxies like envoy with redis protocol or mcrouter with memcached
protocol often support prefix-specific routing rules to direct different types
of cache traffic to different backend clusters.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>