### PR TITLE
Report memcached client hit/miss/error stats to allow monitoring for memcache outages

### DIFF
--- a/src/memcached/cache_impl.go
+++ b/src/memcached/cache_impl.go
@@ -186,7 +186,7 @@ func NewRateLimitCacheImpl(client Client, timeSource utils.TimeSource, jitterRan
 func NewRateLimitCacheImplFromSettings(s settings.Settings, timeSource utils.TimeSource, jitterRand *rand.Rand,
 	localCache *freecache.Cache, scope stats.Scope) limiter.RateLimitCache {
 	return NewRateLimitCacheImpl(
-		collectStats(memcache.New(s.MemcacheHostPort), scope.Scope("memcache")),
+		CollectStats(memcache.New(s.MemcacheHostPort), scope.Scope("memcache")),
 		timeSource,
 		jitterRand,
 		s.ExpirationJitterMaxSeconds,

--- a/src/memcached/cache_impl.go
+++ b/src/memcached/cache_impl.go
@@ -186,7 +186,7 @@ func NewRateLimitCacheImpl(client Client, timeSource utils.TimeSource, jitterRan
 func NewRateLimitCacheImplFromSettings(s settings.Settings, timeSource utils.TimeSource, jitterRand *rand.Rand,
 	localCache *freecache.Cache, scope stats.Scope) limiter.RateLimitCache {
 	return NewRateLimitCacheImpl(
-		memcache.New(s.MemcacheHostPort),
+		collectStats(memcache.New(s.MemcacheHostPort), scope.Scope("memcache")),
 		timeSource,
 		jitterRand,
 		s.ExpirationJitterMaxSeconds,

--- a/src/memcached/stats_collecting_client.go
+++ b/src/memcached/stats_collecting_client.go
@@ -20,7 +20,7 @@ type statsCollectingClient struct {
 	keysFound        stats.Counter
 }
 
-func collectStats(c Client, scope stats.Scope) Client {
+func CollectStats(c Client, scope stats.Scope) Client {
 	return statsCollectingClient{
 		c:                c,
 		multiGetSuccess:  scope.NewCounterWithTags("multiget", map[string]string{"code": "success"}),

--- a/src/memcached/stats_collecting_client.go
+++ b/src/memcached/stats_collecting_client.go
@@ -1,0 +1,80 @@
+package memcached
+
+import (
+	"github.com/bradfitz/gomemcache/memcache"
+	stats "github.com/lyft/gostats"
+)
+
+type statsCollectingClient struct {
+	c Client
+
+	multiGetSuccess  stats.Counter
+	multiGetError    stats.Counter
+	incrementSuccess stats.Counter
+	incrementMiss    stats.Counter
+	incrementError   stats.Counter
+	addSuccess       stats.Counter
+	addError         stats.Counter
+	addNotStored     stats.Counter
+	keysRequested    stats.Counter
+	keysFound        stats.Counter
+}
+
+func collectStats(c Client, scope stats.Scope) Client {
+	return statsCollectingClient{
+		c:                c,
+		multiGetSuccess:  scope.NewCounterWithTags("multiget", map[string]string{"code": "success"}),
+		multiGetError:    scope.NewCounterWithTags("multiget", map[string]string{"code": "error"}),
+		incrementSuccess: scope.NewCounterWithTags("increment", map[string]string{"code": "success"}),
+		incrementMiss:    scope.NewCounterWithTags("increment", map[string]string{"code": "miss"}),
+		incrementError:   scope.NewCounterWithTags("increment", map[string]string{"code": "error"}),
+		addSuccess:       scope.NewCounterWithTags("add", map[string]string{"code": "success"}),
+		addError:         scope.NewCounterWithTags("add", map[string]string{"code": "error"}),
+		addNotStored:     scope.NewCounterWithTags("add", map[string]string{"code": "not_stored"}),
+		keysRequested:    scope.NewCounter("keys_requested"),
+		keysFound:        scope.NewCounter("keys_found"),
+	}
+}
+
+func (scc statsCollectingClient) GetMulti(keys []string) (map[string]*memcache.Item, error) {
+	scc.keysRequested.Add(uint64(len(keys)))
+
+	results, err := scc.c.GetMulti(keys)
+
+	if err != nil {
+		scc.multiGetError.Inc()
+	} else {
+		scc.keysFound.Add(uint64(len(results)))
+		scc.multiGetSuccess.Inc()
+	}
+
+	return results, err
+}
+
+func (scc statsCollectingClient) Increment(key string, delta uint64) (newValue uint64, err error) {
+	newValue, err = scc.c.Increment(key, delta)
+	switch err {
+	case memcache.ErrCacheMiss:
+		scc.incrementMiss.Inc()
+	case nil:
+		scc.incrementSuccess.Inc()
+	default:
+		scc.incrementError.Inc()
+	}
+	return
+}
+
+func (scc statsCollectingClient) Add(item *memcache.Item) error {
+	err := scc.c.Add(item)
+
+	switch err {
+	case memcache.ErrNotStored:
+		scc.addNotStored.Inc()
+	case nil:
+		scc.addSuccess.Inc()
+	default:
+		scc.addError.Inc()
+	}
+
+	return err
+}

--- a/test/memcached/stats_collecting_client_test.go
+++ b/test/memcached/stats_collecting_client_test.go
@@ -62,6 +62,20 @@ func TestStats_MultiGet(t *testing.T) {
 	}, fakeSink.values)
 
 	fakeSink.Reset()
+	returnValue = map[string]*memcache.Item{"foo": nil, "bar": nil}
+	client.EXPECT().GetMulti(arg).Return(returnValue, nil)
+	actualReturnValue, err = sc.GetMulti(arg)
+	statsStore.Flush()
+
+	assert.Equal(returnValue, actualReturnValue)
+	assert.Nil(err)
+	assert.Equal(map[string]uint64{
+		"keys_found":              2,
+		"keys_requested":          1,
+		"multiget.__code=success": 1,
+	}, fakeSink.values)
+
+	fakeSink.Reset()
 	returnValue = map[string]*memcache.Item{}
 	arg = []string{"foo", "bar"}
 

--- a/test/memcached/stats_collecting_client_test.go
+++ b/test/memcached/stats_collecting_client_test.go
@@ -1,0 +1,185 @@
+package memcached_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/envoyproxy/ratelimit/src/memcached"
+	mock_memcached "github.com/envoyproxy/ratelimit/test/mocks/memcached"
+	"github.com/golang/mock/gomock"
+	stats "github.com/lyft/gostats"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeSink struct {
+	values map[string]uint64
+}
+
+func (fs *fakeSink) FlushCounter(name string, value uint64) {
+	if _, ok := fs.values[name]; ok {
+		panic(errors.New("fakeSink wasn't cleared before flushing again"))
+	}
+
+	fs.values[name] = value
+}
+
+func (fs *fakeSink) FlushGauge(name string, value uint64) {}
+
+func (fs *fakeSink) FlushTimer(name string, value float64) {}
+
+func (fs *fakeSink) Flush() {}
+
+func (fs *fakeSink) Reset() {
+	fs.values = make(map[string]uint64)
+}
+
+func TestStats_MultiGet(t *testing.T) {
+	fakeSink := &fakeSink{}
+	fakeSink.Reset()
+
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	client := mock_memcached.NewMockClient(controller)
+	statsStore := stats.NewStore(fakeSink, false)
+
+	sc := memcached.CollectStats(client, statsStore)
+
+	returnValue := map[string]*memcache.Item{"foo": nil}
+	arg := []string{"foo"}
+
+	client.EXPECT().GetMulti(arg).Return(returnValue, nil)
+	actualReturnValue, err := sc.GetMulti(arg)
+	statsStore.Flush()
+
+	assert.Equal(returnValue, actualReturnValue)
+	assert.Nil(err)
+	assert.Equal(map[string]uint64{
+		"keys_found":              1,
+		"keys_requested":          1,
+		"multiget.__code=success": 1,
+	}, fakeSink.values)
+
+	fakeSink.Reset()
+	returnValue = map[string]*memcache.Item{}
+	arg = []string{"foo", "bar"}
+
+	client.EXPECT().GetMulti(arg).Return(returnValue, nil)
+	actualReturnValue, err = sc.GetMulti(arg)
+
+	statsStore.Flush()
+	assert.Equal(returnValue, actualReturnValue)
+	assert.Nil(err)
+
+	assert.Equal(map[string]uint64{
+		"keys_requested":          2,
+		"multiget.__code=success": 1,
+	}, fakeSink.values)
+
+	fakeSink.Reset()
+	returnValue = map[string]*memcache.Item{"ignored": nil}
+	arg = []string{"foo"}
+	returnedErr := errors.New("Random error")
+
+	client.EXPECT().GetMulti(arg).Return(returnValue, returnedErr)
+	actualReturnValue, err = sc.GetMulti(arg)
+
+	statsStore.Flush()
+	assert.Equal(returnValue, actualReturnValue)
+	assert.Equal(returnedErr, err)
+
+	assert.Equal(map[string]uint64{
+		"keys_requested":        1,
+		"multiget.__code=error": 1,
+	}, fakeSink.values)
+}
+
+func TestStats_Increment(t *testing.T) {
+	fakeSink := &fakeSink{}
+
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	client := mock_memcached.NewMockClient(controller)
+	statsStore := stats.NewStore(fakeSink, false)
+
+	sc := memcached.CollectStats(client, statsStore)
+
+	fakeSink.Reset()
+	client.EXPECT().Increment("foo", uint64(5)).Return(uint64(6), nil)
+	newValue, err := sc.Increment("foo", 5)
+	statsStore.Flush()
+
+	assert.Equal(uint64(6), newValue)
+	assert.Nil(err)
+	assert.Equal(map[string]uint64{
+		"increment.__code=success": 1,
+	}, fakeSink.values)
+
+	expectedErr := errors.New("expectedError")
+	fakeSink.Reset()
+	client.EXPECT().Increment("foo", uint64(5)).Return(uint64(0), expectedErr)
+	newValue, err = sc.Increment("foo", 5)
+	statsStore.Flush()
+
+	assert.Equal(expectedErr, err)
+	assert.Equal(map[string]uint64{
+		"increment.__code=error": 1,
+	}, fakeSink.values)
+
+	fakeSink.Reset()
+	client.EXPECT().Increment("foo", uint64(5)).Return(uint64(0), memcache.ErrCacheMiss)
+	newValue, err = sc.Increment("foo", 5)
+	statsStore.Flush()
+
+	assert.Equal(memcache.ErrCacheMiss, err)
+	assert.Equal(map[string]uint64{
+		"increment.__code=miss": 1,
+	}, fakeSink.values)
+}
+
+func TestStats_Add(t *testing.T) {
+	fakeSink := &fakeSink{}
+
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	client := mock_memcached.NewMockClient(controller)
+	statsStore := stats.NewStore(fakeSink, false)
+
+	sc := memcached.CollectStats(client, statsStore)
+	item := &memcache.Item{}
+
+	fakeSink.Reset()
+	client.EXPECT().Add(item).Return(nil)
+	err := sc.Add(item)
+	statsStore.Flush()
+
+	assert.Nil(err)
+	assert.Equal(map[string]uint64{
+		"add.__code=success": 1,
+	}, fakeSink.values)
+
+	expectedErr := errors.New("expected err")
+
+	fakeSink.Reset()
+	client.EXPECT().Add(item).Return(expectedErr)
+	err = sc.Add(item)
+	statsStore.Flush()
+
+	assert.Equal(expectedErr, err)
+	assert.Equal(map[string]uint64{
+		"add.__code=error": 1,
+	}, fakeSink.values)
+
+	fakeSink.Reset()
+	client.EXPECT().Add(item).Return(memcache.ErrNotStored)
+	err = sc.Add(item)
+	statsStore.Flush()
+
+	assert.Equal(memcache.ErrNotStored, err)
+	assert.Equal(map[string]uint64{
+		"add.__code=not_stored": 1,
+	}, fakeSink.values)
+}


### PR DESCRIPTION
The rate limiter itself fails open and swallows errors, so reporting k/v store client statistics
is helpful for catching a backend outage.

(I've chosen not to include latency statistics here because statsd doesn't have an official protocol
and I've found through experimentation that the lyft stats library output format for timing stats
isn't compatible with our metric collector)

Signed-off-by: David Weitzman <dweitzman@pinterest.com>