### PR TITLE
Begin changing integration tests to explicitly run redis/memcache as a subprocess

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,12 +73,8 @@ tests: compile
 
 .PHONY: tests_with_redis
 tests_with_redis: bootstrap_redis_tls tests_unit
-	redis-server --port 6379 &
-	redis-server --port 6380 &
 	redis-server --port 6381 --requirepass password123 &
 	redis-server --port 6382 --requirepass password123 &
-	redis-server --port 6384 --requirepass password123 &
-	redis-server --port 6385 --requirepass password123 &
 
 	redis-server --port 6392 --requirepass password123 &
 	redis-server --port 6393 --requirepass password123 --slaveof 127.0.0.1 6392 --masterauth password123 &
@@ -97,7 +93,6 @@ tests_with_redis: bootstrap_redis_tls tests_unit
 	mkdir 6389 && cd 6389 && redis-server --port 6389 --cluster-enabled yes --requirepass password123 &
 	mkdir 6390 && cd 6390 && redis-server --port 6390 --cluster-enabled yes --requirepass password123 &
 	mkdir 6391 && cd 6391 && redis-server --port 6391 --cluster-enabled yes --requirepass password123 &
-	memcached -u root --port 6394 -m 64 &
 	sleep 2
 	echo "yes" | redis-cli --cluster create -a password123 127.0.0.1:6386 127.0.0.1:6387 127.0.0.1:6388 --cluster-replicas 0
 	echo "yes" | redis-cli --cluster create -a password123 127.0.0.1:6389 127.0.0.1:6390 127.0.0.1:6391 --cluster-replicas 0

--- a/src/memcached/cache_impl.go
+++ b/src/memcached/cache_impl.go
@@ -48,6 +48,8 @@ type rateLimitMemcacheImpl struct {
 	baseRateLimiter            *limiter.BaseRateLimiter
 }
 
+var AutoFlushForIntegrationTests bool = false
+
 var _ limiter.RateLimitCache = (*rateLimitMemcacheImpl)(nil)
 
 func (this *rateLimitMemcacheImpl) DoLimit(
@@ -121,6 +123,9 @@ func (this *rateLimitMemcacheImpl) DoLimit(
 
 	this.waitGroup.Add(1)
 	go this.increaseAsync(cacheKeys, isOverLimitWithLocalCache, limits, uint64(hitsAddend))
+	if AutoFlushForIntegrationTests {
+		this.Flush()
+	}
 
 	return responseDescriptorStatuses
 }

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -116,8 +116,9 @@ func startCacheProcess(ctx context.Context, command string, args []string, port 
 	// Wait up to 1s for the redis instance to start accepting connections.
 	for {
 		var d net.Dialer
-		_, err := d.DialContext(ctx, "tcp", "localhost:"+strconv.Itoa(port))
+		conn, err := d.DialContext(ctx, "tcp", "localhost:"+strconv.Itoa(port))
 		if err == nil {
+			conn.Close()
 			// TCP connections are working. All is well.
 			break
 		}

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -1,10 +1,18 @@
 package common
 
 import (
+	"context"
 	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
-	"sync"
 
 	pb_struct_legacy "github.com/envoyproxy/go-control-plane/envoy/api/v2/ratelimit"
 	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
@@ -76,4 +84,100 @@ func NewRateLimitRequestLegacy(domain string, descriptors [][][2]string, hitsAdd
 func AssertProtoEqual(assert *assert.Assertions, expected proto.Message, actual proto.Message) {
 	assert.True(proto.Equal(expected, actual),
 		fmt.Sprintf("These two protobuf messages are not equal:\nexpected: %v\nactual:  %v", expected, actual))
+}
+
+type RedisConfig struct {
+	Port     int
+	Password string
+	Cluster  bool
+}
+
+type MemcacheConfig struct {
+	Port int
+}
+
+// startCacheProcess starts memcache or redis as a subprocess and waits until the TCP port is open.
+func startCacheProcess(ctx context.Context, command string, args []string, port int) (context.CancelFunc, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(ctx, command, args...)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Start()
+
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("Problem starting %s subprocess: %v", command, err)
+	}
+
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, 1*time.Second)
+	defer timeoutCancel()
+
+	// Wait up to 1s for the redis instance to start accepting connections.
+	for {
+		var d net.Dialer
+		_, err := d.DialContext(ctx, "tcp", "localhost:"+strconv.Itoa(port))
+		if err == nil {
+			// TCP connections are working. All is well.
+			break
+		}
+		// Unable to connect to the TCP port. Wait and try again.
+		select {
+		case <-time.After(100 * time.Millisecond):
+		case <-timeoutCtx.Done():
+			cancel()
+			return nil, fmt.Errorf("Timed out waiting for %s to start up and accept connections: %v", command, err)
+		}
+	}
+
+	return func() {
+		cancel()
+		cmd.Wait()
+	}, nil
+}
+
+func WithMultiRedis(t *testing.T, configs []RedisConfig, f func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, config := range configs {
+		args := []string{"--port", strconv.Itoa(config.Port)}
+		if config.Password != "" {
+			args = append(args, "--requirepass", config.Password)
+		}
+		if config.Cluster {
+			args = append(args, "--cluster-enabled", "yes")
+		}
+
+		cancel, err := startCacheProcess(ctx, "redis-server", args, config.Port)
+		if err != nil {
+			t.Errorf("Error starting redis: %v", err)
+			return
+		}
+		defer cancel()
+	}
+
+	f()
+}
+
+func WithMultiMemcache(t *testing.T, configs []MemcacheConfig, f func()) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, config := range configs {
+		args := []string{"-u", "root", "-m", "64", "--port", strconv.Itoa(config.Port)}
+
+		cancel, err := startCacheProcess(ctx, "memcached", args, config.Port)
+		if err != nil {
+			t.Errorf("Error starting memcache: %v", err)
+			return
+		}
+		defer cancel()
+	}
+
+	f()
 }


### PR DESCRIPTION
The motivation for this is that the "tests_with_redis" rule in the Makefile is a giant
unwieldy mess and it's hard to know which redis/memcache instances are used by which tests.
The tests themselves hardcode mysterious port numbers whose meaning you could only know by
cross-referencing the makefile.

Some benefits to running the cache processes on-demand:

- The tests themselves become more isolated, complete, and clear
- "go test" could work out of the box for many people, no docker
  or pre-configured cache services on special ports necessary.
  That seems like it'd be a big win for ease of testing and development of
  integration tests.
- A next step after making "go test" work out of the box could be
  dynamic free port selection so that if someone happens to already
  have a service running on a particular port it wouldn't block "go test"
  from working.

Another small change included here is to make the memcache integration tests
use synchronous rather than async increments to avoid a race condition checking
whether quota is being depleted.

One last change is ensure that the test name is correctly printed when
a panic() happens within the rate limit service in an integration test.
The slight tradeoff is that the original stack trace is lost, but a
stack trace without a test name in it isn't particularly helpful for
debugging.

Signed-off-by: David Weitzman <dweitzman@pinterest.com>