### PR TITLE
integration test refactoring: better isolation, typed config, and fewer magic numbers

### DIFF
--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -39,22 +39,24 @@ type serverDebugListener struct {
 }
 
 type server struct {
-	port            int
-	grpcPort        int
-	debugPort       int
-	router          *mux.Router
-	grpcServer      *grpc.Server
-	store           stats.Store
-	scope           stats.Scope
-	runtime         loader.IFace
-	debugListener   serverDebugListener
-	debugListenerMu sync.Mutex
-	health          *HealthChecker
+	port          int
+	grpcPort      int
+	debugPort     int
+	router        *mux.Router
+	grpcServer    *grpc.Server
+	store         stats.Store
+	scope         stats.Scope
+	runtime       loader.IFace
+	debugListener serverDebugListener
+	httpListener  net.Listener
+	listenerMu    sync.Mutex
+	health        *HealthChecker
+	stopped       bool
 }
 
 func (server *server) AddDebugHttpEndpoint(path string, help string, handler http.HandlerFunc) {
-	server.debugListenerMu.Lock()
-	defer server.debugListenerMu.Unlock()
+	server.listenerMu.Lock()
+	defer server.listenerMu.Unlock()
 	server.debugListener.debugMux.HandleFunc(path, handler)
 	server.debugListener.endpoints[path] = help
 }
@@ -116,9 +118,9 @@ func (server *server) Start() {
 		addr := fmt.Sprintf(":%d", server.debugPort)
 		logger.Warnf("Listening for debug on '%s'", addr)
 		var err error
-		server.debugListenerMu.Lock()
+		server.listenerMu.Lock()
 		server.debugListener.listener, err = reuseport.Listen("tcp", addr)
-		server.debugListenerMu.Unlock()
+		server.listenerMu.Unlock()
 
 		if err != nil {
 			logger.Errorf("Failed to open debug HTTP listener: '%+v'", err)
@@ -138,7 +140,20 @@ func (server *server) Start() {
 	if err != nil {
 		logger.Fatalf("Failed to open HTTP listener: '%+v'", err)
 	}
-	logger.Fatal(http.Serve(list, server.router))
+	server.listenerMu.Lock()
+	server.httpListener = list
+	server.listenerMu.Unlock()
+	err = http.Serve(list, server.router)
+
+	server.listenerMu.Lock()
+	explicitlyStopped := server.stopped
+	server.listenerMu.Unlock()
+
+	if !explicitlyStopped {
+		logger.Fatal(err)
+	} else {
+		logger.Info(err)
+	}
 }
 
 func (server *server) startGrpc() {
@@ -159,13 +174,11 @@ func (server *server) Runtime() loader.IFace {
 	return server.runtime
 }
 
-func NewServer(name string, store stats.Store, localCache *freecache.Cache, opts ...settings.Option) Server {
-	return newServer(name, store, localCache, opts...)
+func NewServer(s settings.Settings, name string, store stats.Store, localCache *freecache.Cache, opts ...settings.Option) Server {
+	return newServer(s, name, store, localCache, opts...)
 }
 
-func newServer(name string, store stats.Store, localCache *freecache.Cache, opts ...settings.Option) *server {
-	s := settings.NewSettings()
-
+func newServer(s settings.Settings, name string, store stats.Store, localCache *freecache.Cache, opts ...settings.Option) *server {
 	for _, opt := range opts {
 		opt(&s)
 	}
@@ -260,11 +273,15 @@ func newServer(name string, store stats.Store, localCache *freecache.Cache, opts
 
 func (server *server) Stop() {
 	server.grpcServer.GracefulStop()
-	server.debugListenerMu.Lock()
+	server.listenerMu.Lock()
+	server.stopped = true
 	if server.debugListener.listener != nil {
 		server.debugListener.listener.Close()
 	}
-	server.debugListenerMu.Unlock()
+	if server.httpListener != nil {
+		server.httpListener.Close()
+	}
+	server.listenerMu.Unlock()
 }
 
 func (server *server) handleGracefulShutdown() {
@@ -276,11 +293,14 @@ func (server *server) handleGracefulShutdown() {
 
 		logger.Infof("Ratelimit server received %v, shutting down gracefully", sig)
 		server.grpcServer.GracefulStop()
-		server.debugListenerMu.Lock()
+		server.listenerMu.Lock()
 		if server.debugListener.listener != nil {
 			server.debugListener.listener.Close()
 		}
-		server.debugListenerMu.Unlock()
+		if server.httpListener != nil {
+			server.httpListener.Close()
+		}
+		server.listenerMu.Unlock()
 		os.Exit(0)
 	}()
 }

--- a/src/service_cmd/main.go
+++ b/src/service_cmd/main.go
@@ -1,8 +1,11 @@
 package main
 
-import "github.com/envoyproxy/ratelimit/src/service_cmd/runner"
+import (
+	"github.com/envoyproxy/ratelimit/src/service_cmd/runner"
+	"github.com/envoyproxy/ratelimit/src/settings"
+)
 
 func main() {
-	runner := runner.NewRunner()
+	runner := runner.NewRunner(settings.NewSettings())
 	runner.Run()
 }

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -28,12 +28,16 @@ import (
 
 type Runner struct {
 	statsStore stats.Store
+	settings   settings.Settings
 	srv        server.Server
 	mu         sync.Mutex
 }
 
-func NewRunner() Runner {
-	return Runner{statsStore: stats.NewDefaultStore()}
+func NewRunner(s settings.Settings) Runner {
+	return Runner{
+		statsStore: stats.NewDefaultStore(),
+		settings:   s,
+	}
 }
 
 func (runner *Runner) GetStatsStore() stats.Store {
@@ -64,7 +68,7 @@ func createLimiter(srv server.Server, s settings.Settings, localCache *freecache
 }
 
 func (runner *Runner) Run() {
-	s := settings.NewSettings()
+	s := runner.settings
 
 	logLevel, err := logger.ParseLevel(s.LogLevel)
 	if err != nil {
@@ -87,7 +91,7 @@ func (runner *Runner) Run() {
 		localCache = freecache.NewCache(s.LocalCacheSizeInBytes)
 	}
 
-	srv := server.NewServer("ratelimit", runner.statsStore, localCache, settings.GrpcUnaryInterceptor(nil))
+	srv := server.NewServer(s, "ratelimit", runner.statsStore, localCache, settings.GrpcUnaryInterceptor(nil))
 	runner.mu.Lock()
 	runner.srv = srv
 	runner.mu.Unlock()

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -100,6 +100,7 @@ func TestBasicConfig(t *testing.T) {
 		t.Run("WithoutPerSecondRedisWithCachePrefix", testBasicConfig(cacheSettings))
 	})
 }
+
 func TestBasicTLSConfig(t *testing.T) {
 	t.Run("WithoutPerSecondRedisTLS", testBasicConfigAuthTLS(false, 0))
 	t.Run("WithPerSecondRedisTLS", testBasicConfigAuthTLS(true, 0))


### PR DESCRIPTION
1) All tests use the same grpc port now that the Runner.Stop() exists, removing some magic numbers and surface area for mistakes with those numbers

2) Rather than doing os.Setenv(), tests construct a typed new Settings object for each run.

The downside here is that the settings library itself won't get exercised in terms of how it parses env variables.

The upsides are:
- Static type checking gives protection against typos in integration test setup and IDE code completion
- Eliminates the risk of accidentally leaving env variables unchanged between tests, ensuring
  every test starts with a clean slate.

This resolves https://github.com/envoyproxy/ratelimit/issues/119

Signed-off-by: David Weitzman <dweitzman@pinterest.com>