### PR TITLE
Add EXTRA_TAGS config option to tag all stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,10 @@ ratelimit.service.rate_limit.messaging.message_type_marketing.to_number.over_lim
 ratelimit.service.rate_limit.messaging.message_type_marketing.to_number.total_hits: 0
 ```
 
+## Statistics options
+
+1. `EXTRA_TAGS==<k1:v1>,<k2:v2>` tags all emitted stats with the provided tags. You might want to tag build commit or release version, for example.
+
 # HTTP Port
 
 The ratelimit service listens to HTTP 1.1 (by default on port 8080) with two endpoints:

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ ratelimit.service.rate_limit.messaging.message_type_marketing.to_number.total_hi
 
 ## Statistics options
 
-1. `EXTRA_TAGS==<k1:v1>,<k2:v2>` tags all emitted stats with the provided tags. You might want to tag build commit or release version, for example.
+1. `EXTRA_TAGS`: set to `"<k1:v1>,<k2:v2>"` to tag all emitted stats with the provided tags. You might want to tag build commit or release version, for example.
 
 # HTTP Port
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/gorilla/mux v1.7.4-0.20191121170500-49c01487a141
 	github.com/kavu/go_reuseport v1.2.0
-	github.com/kelseyhightower/envconfig v1.1.0
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lyft/goruntime v0.2.5
 	github.com/lyft/gostats v0.4.0
 	github.com/mediocregopher/radix/v3 v3.5.1

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/gorilla/mux v1.7.4-0.20191121170500-49c01487a141 h1:VQjjMh+uElTfioy6G
 github.com/gorilla/mux v1.7.4-0.20191121170500-49c01487a141/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/kavu/go_reuseport v1.2.0 h1:YO+pt6m5Z3WkVH9DjaDJzoSS/0FO2Q8x3CfObxk/i2E=
 github.com/kavu/go_reuseport v1.2.0/go.mod h1:CG8Ee7ceMFSMnx/xr25Vm0qXaj2Z4i5PWoUx+JZ5/CU=
-github.com/kelseyhightower/envconfig v1.1.0 h1:4htXR8ameS6KBfrNBoqEgpg0IK2D6rozN9ATOPwRfM0=
-github.com/kelseyhightower/envconfig v1.1.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/lyft/goruntime v0.2.5 h1:yRmwOXl3Zns3+Z03fDMWt5+p609rfhIErh7HYCayODg=

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -187,7 +187,7 @@ func newServer(s settings.Settings, name string, store stats.Store, localCache *
 
 	// setup stats
 	ret.store = store
-	ret.scope = ret.store.Scope(name)
+	ret.scope = ret.store.ScopeWithTags(name, s.ExtraTags)
 	ret.store.AddStatGenerator(stats.NewRuntimeStats(ret.scope.Scope("go")))
 	if localCache != nil {
 		ret.store.AddStatGenerator(limiter.NewLocalCacheStats(localCache, ret.scope.Scope("localcache")))
@@ -205,7 +205,7 @@ func newServer(s settings.Settings, name string, store stats.Store, localCache *
 		ret.runtime = loader.New(
 			s.RuntimePath,
 			s.RuntimeSubdirectory,
-			ret.store.Scope("runtime"),
+			ret.store.ScopeWithTags("runtime", s.ExtraTags),
 			&loader.SymlinkRefresher{RuntimePath: s.RuntimePath},
 			loaderOpts...)
 
@@ -213,7 +213,7 @@ func newServer(s settings.Settings, name string, store stats.Store, localCache *
 		ret.runtime = loader.New(
 			filepath.Join(s.RuntimePath, s.RuntimeSubdirectory),
 			"config",
-			ret.store.Scope("runtime"),
+			ret.store.ScopeWithTags("runtime", s.ExtraTags),
 			&loader.DirectoryRefresher{},
 			loaderOpts...)
 	}

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -11,18 +11,34 @@ type Settings struct {
 	// runtime options
 	GrpcUnaryInterceptor grpc.ServerOption
 	// env config
-	Port                         int           `envconfig:"PORT" default:"8080"`
-	GrpcPort                     int           `envconfig:"GRPC_PORT" default:"8081"`
-	DebugPort                    int           `envconfig:"DEBUG_PORT" default:"6070"`
-	UseStatsd                    bool          `envconfig:"USE_STATSD" default:"true"`
-	StatsdHost                   string        `envconfig:"STATSD_HOST" default:"localhost"`
-	StatsdPort                   int           `envconfig:"STATSD_PORT" default:"8125"`
-	RuntimePath                  string        `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`
-	RuntimeSubdirectory          string        `envconfig:"RUNTIME_SUBDIRECTORY"`
-	RuntimeIgnoreDotFiles        bool          `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
-	RuntimeWatchRoot             bool          `envconfig:"RUNTIME_WATCH_ROOT" default:"true"`
-	LogLevel                     string        `envconfig:"LOG_LEVEL" default:"WARN"`
-	LogFormat                    string        `envconfig:"LOG_FORMAT" default:"text"`
+	Port      int `envconfig:"PORT" default:"8080"`
+	GrpcPort  int `envconfig:"GRPC_PORT" default:"8081"`
+	DebugPort int `envconfig:"DEBUG_PORT" default:"6070"`
+
+	// Logging settings
+	LogLevel  string `envconfig:"LOG_LEVEL" default:"WARN"`
+	LogFormat string `envconfig:"LOG_FORMAT" default:"text"`
+
+	// Stats-related settings
+	UseStatsd  bool              `envconfig:"USE_STATSD" default:"true"`
+	StatsdHost string            `envconfig:"STATSD_HOST" default:"localhost"`
+	StatsdPort int               `envconfig:"STATSD_PORT" default:"8125"`
+	ExtraTags  map[string]string `envconfig:"EXTRA_TAGS" default:""`
+
+	// Settings for rate limit configuration
+	RuntimePath           string `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`
+	RuntimeSubdirectory   string `envconfig:"RUNTIME_SUBDIRECTORY"`
+	RuntimeIgnoreDotFiles bool   `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
+	RuntimeWatchRoot      bool   `envconfig:"RUNTIME_WATCH_ROOT" default:"true"`
+
+	// Settings for all cache types
+	ExpirationJitterMaxSeconds int64   `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
+	LocalCacheSizeInBytes      int     `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
+	NearLimitRatio             float32 `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
+	CacheKeyPrefix             string  `envconfig:"CACHE_KEY_PREFIX" default:""`
+	BackendType                string  `envconfig:"BACKEND_TYPE" default:"redis"`
+
+	// Redis settings
 	RedisSocketType              string        `envconfig:"REDIS_SOCKET_TYPE" default:"unix"`
 	RedisType                    string        `envconfig:"REDIS_TYPE" default:"SINGLE"`
 	RedisUrl                     string        `envconfig:"REDIS_URL" default:"/var/run/nutcracker/ratelimit.sock"`
@@ -40,12 +56,9 @@ type Settings struct {
 	RedisPerSecondTls            bool          `envconfig:"REDIS_PERSECOND_TLS" default:"false"`
 	RedisPerSecondPipelineWindow time.Duration `envconfig:"REDIS_PERSECOND_PIPELINE_WINDOW" default:"0"`
 	RedisPerSecondPipelineLimit  int           `envconfig:"REDIS_PERSECOND_PIPELINE_LIMIT" default:"0"`
-	ExpirationJitterMaxSeconds   int64         `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
-	LocalCacheSizeInBytes        int           `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
-	NearLimitRatio               float32       `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
-	MemcacheHostPort             string        `envconfig:"MEMCACHE_HOST_PORT" default:""`
-	BackendType                  string        `envconfig:"BACKEND_TYPE" default:"redis"`
-	CacheKeyPrefix               string        `envconfig:"CACHE_KEY_PREFIX" default:""`
+
+	// Memcache settings
+	MemcacheHostPort string `envconfig:"MEMCACHE_HOST_PORT" default:""`
 }
 
 type Option func(*Settings)


### PR DESCRIPTION
This is useful for tagging all stats with things like build commit or host name.

Additionally:
- Reformat settings.go to make merge conflicts less common
- Factor out some common logic in integration_test.go
- Make integration_test.go slightly smarter & faster about
  waiting for test instances to come up instead of always waiting
  a full second.
- Upgrades the envconfig library to a version that supports map configs

Signed-off-by: David Weitzman <dweitzman@pinterest.com>