### PR TITLE
adding cpu profiling endpoint

### DIFF
--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -236,6 +236,14 @@ func newServer(s settings.Settings, name string, store stats.Store, localCache *
 			pprof.Index(writer, request)
 		})
 
+	// setup cpu profiling endpoint
+	ret.AddDebugHttpEndpoint(
+		"/debug/pprof/profile",
+		"root of various pprof endpoints. hit for help.",
+		func(writer http.ResponseWriter, request *http.Request) {
+			pprof.Profile(writer, request)
+		})
+
 	// setup stats endpoint
 	ret.AddDebugHttpEndpoint(
 		"/stats",


### PR DESCRIPTION
Previously, requests to the cpu profiling endpoint returned a 404:

```
go tool pprof -png http://localhost:6070/debug/pprof/profile > ratelimit.png
Fetching profile over HTTP from http://localhost:6070/debug/pprof/profile
http://localhost:6070/debug/pprof/profile: server response: 404 Not Found - Unknown profile
```

After registering the endpoint, the ratelimit service is able to correctly serve cpu profiling details
```
go tool pprof -png http://localhost:6070/debug/pprof/profile > rl.png
Fetching profile over HTTP from http://localhost:6070/debug/pprof/profile
Saved profile in /Users/smercatoris/pprof/pprof.samples.cpu.001.pb.gz
```

