### PR TITLE
docker_coverage build target

### DIFF
--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -14,4 +14,5 @@ RUN make bootstrap
 
 COPY src /workdir/src
 COPY test /workdir/test
+COPY script /workdir/script
 CMD make tests_with_redis

--- a/Makefile
+++ b/Makefile
@@ -72,39 +72,26 @@ tests: compile
 	go test -race -tags=integration $(MODULE)/...
 
 .PHONY: tests_with_redis
-tests_with_redis: bootstrap_redis_tls tests_unit
-	redis-server --port 6381 --requirepass password123 &
-	redis-server --port 6382 --requirepass password123 &
-
-	redis-server --port 6392 --requirepass password123 &
-	redis-server --port 6393 --requirepass password123 --slaveof 127.0.0.1 6392 --masterauth password123 &
-	mkdir 26394 && cp test/integration/conf/sentinel.conf 26394/sentinel.conf && redis-server 26394/sentinel.conf --sentinel --port 26394 &
-	mkdir 26395 && cp test/integration/conf/sentinel.conf 26395/sentinel.conf && redis-server 26395/sentinel.conf --sentinel --port 26395 &
-	mkdir 26396 && cp test/integration/conf/sentinel.conf 26396/sentinel.conf && redis-server 26396/sentinel.conf --sentinel --port 26396 &
-	redis-server --port 6397 --requirepass password123 &
-	redis-server --port 6398 --requirepass password123 --slaveof 127.0.0.1 6397 --masterauth password123 &
-	mkdir 26399 && cp test/integration/conf/sentinel-pre-second.conf 26399/sentinel.conf && redis-server 26399/sentinel.conf --sentinel --port 26399 &
-	mkdir 26400 && cp test/integration/conf/sentinel-pre-second.conf 26400/sentinel.conf && redis-server 26400/sentinel.conf --sentinel --port 26400 &
-	mkdir 26401 && cp test/integration/conf/sentinel-pre-second.conf 26401/sentinel.conf && redis-server 26401/sentinel.conf --sentinel --port 26401 &
-
-	mkdir 6386 && cd 6386 && redis-server --port 6386 --cluster-enabled yes --requirepass password123 &
-	mkdir 6387 && cd 6387 && redis-server --port 6387 --cluster-enabled yes --requirepass password123 &
-	mkdir 6388 && cd 6388 && redis-server --port 6388 --cluster-enabled yes --requirepass password123 &
-	mkdir 6389 && cd 6389 && redis-server --port 6389 --cluster-enabled yes --requirepass password123 &
-	mkdir 6390 && cd 6390 && redis-server --port 6390 --cluster-enabled yes --requirepass password123 &
-	mkdir 6391 && cd 6391 && redis-server --port 6391 --cluster-enabled yes --requirepass password123 &
-	sleep 2
-	echo "yes" | redis-cli --cluster create -a password123 127.0.0.1:6386 127.0.0.1:6387 127.0.0.1:6388 --cluster-replicas 0
-	echo "yes" | redis-cli --cluster create -a password123 127.0.0.1:6389 127.0.0.1:6390 127.0.0.1:6391 --cluster-replicas 0
-	redis-cli --cluster check -a password123 127.0.0.1:6386
-	redis-cli --cluster check -a password123 127.0.0.1:6389
-
+tests_with_redis: bootstrap_redis_tls compile
+	./script/run_test_caches.sh &
 	go test -race -tags=integration $(MODULE)/...
 
 .PHONY: docker_tests
 docker_tests:
 	docker build -f Dockerfile.integration . -t $(INTEGRATION_IMAGE):$(VERSION) && \
 	docker run $$(tty -s && echo "-it" || echo) $(INTEGRATION_IMAGE):$(VERSION)
+
+.PHONY: coverage_within_docker
+coverage_within_docker: bootstrap_redis_tls compile
+	./script/run_test_caches.sh &
+	go test -coverprofile=/coverage/coverage.out -cover -coverpkg=./src/... -race -tags=integration $(MODULE)/...
+
+.PHONY: docker_coverage
+docker_coverage:
+	docker build -f Dockerfile.integration . -t $(INTEGRATION_IMAGE):$(VERSION) && \
+	docker run --mount type=bind,source=$(PWD),target=/coverage $$(tty -s && echo "-it" || echo) $(INTEGRATION_IMAGE):$(VERSION) make coverage_within_docker
+	@echo
+	@echo "Explore code coverage: go tool cover --html=coverage.out"
 
 .PHONY: docker_image
 docker_image: docker_tests

--- a/script/run_test_caches.sh
+++ b/script/run_test_caches.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+trap "exit" INT TERM ERR
+trap "kill 0" EXIT
+
+redis-server --port 6381 --requirepass password123 &
+redis-server --port 6382 --requirepass password123 &
+
+redis-server --port 6392 --requirepass password123 &
+redis-server --port 6393 --requirepass password123 --slaveof 127.0.0.1 6392 --masterauth password123 &
+mkdir 26394 && cp test/integration/conf/sentinel.conf 26394/sentinel.conf && redis-server 26394/sentinel.conf --sentinel --port 26394 &
+mkdir 26395 && cp test/integration/conf/sentinel.conf 26395/sentinel.conf && redis-server 26395/sentinel.conf --sentinel --port 26395 &
+mkdir 26396 && cp test/integration/conf/sentinel.conf 26396/sentinel.conf && redis-server 26396/sentinel.conf --sentinel --port 26396 &
+redis-server --port 6397 --requirepass password123 &
+redis-server --port 6398 --requirepass password123 --slaveof 127.0.0.1 6397 --masterauth password123 &
+mkdir 26399 && cp test/integration/conf/sentinel-pre-second.conf 26399/sentinel.conf && redis-server 26399/sentinel.conf --sentinel --port 26399 &
+mkdir 26400 && cp test/integration/conf/sentinel-pre-second.conf 26400/sentinel.conf && redis-server 26400/sentinel.conf --sentinel --port 26400 &
+mkdir 26401 && cp test/integration/conf/sentinel-pre-second.conf 26401/sentinel.conf && redis-server 26401/sentinel.conf --sentinel --port 26401 &
+
+mkdir 6386 && cd 6386 && redis-server --port 6386 --cluster-enabled yes --requirepass password123 &
+mkdir 6387 && cd 6387 && redis-server --port 6387 --cluster-enabled yes --requirepass password123 &
+mkdir 6388 && cd 6388 && redis-server --port 6388 --cluster-enabled yes --requirepass password123 &
+mkdir 6389 && cd 6389 && redis-server --port 6389 --cluster-enabled yes --requirepass password123 &
+mkdir 6390 && cd 6390 && redis-server --port 6390 --cluster-enabled yes --requirepass password123 &
+mkdir 6391 && cd 6391 && redis-server --port 6391 --cluster-enabled yes --requirepass password123 &
+sleep 2
+echo "yes" | redis-cli --cluster create -a password123 127.0.0.1:6386 127.0.0.1:6387 127.0.0.1:6388 --cluster-replicas 0
+echo "yes" | redis-cli --cluster create -a password123 127.0.0.1:6389 127.0.0.1:6390 127.0.0.1:6391 --cluster-replicas 0
+redis-cli --cluster check -a password123 127.0.0.1:6386
+redis-cli --cluster check -a password123 127.0.0.1:6389
+
+wait


### PR DESCRIPTION
Running "make docker_coverage" would create coverage.out and
suggest running "go tool cover --html=coverage.out" to explore it.

It would show the coverage of all unit and integration tests for
code under ./src/...

Other changes:
- "make docker_tests" no longer runs all the non-integration unit tests twice
- factors out the cache startup commands needed for integration tests into
  a script instead of the Makefile