### PR TITLE
Add transport_api_version to http_filters config for ratelimit service

### DIFF
--- a/examples/envoy/proxy.yaml
+++ b/examples/envoy/proxy.yaml
@@ -59,6 +59,7 @@ static_resources:
                         grpc_service:
                           envoy_grpc:
                             cluster_name: ratelimit
+                         transport_api_version: V3
                   - name: envoy.filters.http.router
                     typed_config: {}
                 route_config:


### PR DESCRIPTION
I found envoy was crashing with SEGV without this, on current version