### PR TITLE
Add transport_api_version: V3 in example conf

### DIFF
--- a/examples/envoy/proxy.yaml
+++ b/examples/envoy/proxy.yaml
@@ -59,6 +59,7 @@ static_resources:
                         grpc_service:
                           envoy_grpc:
                             cluster_name: ratelimit
+                        transport_api_version: V3
                   - name: envoy.filters.http.router
                     typed_config: {}
                 route_config:


### PR DESCRIPTION
The docker-compose-example.yml crashes while sending a cURL request. After adding `transport_api_version: V3` in the `http_filters` spec for the `rate_limit_service` it started working.