### PR TITLE
Clarify memcache client constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ With memcache mode increments will happen asynchronously, so it's technically po
 a client to exceed quota briefly if multiple requests happen at exactly the same time.
 
 Note that Memcache has a max key length of 250 characters, so operations referencing very long
-descriptors will fail.
+descriptors will fail. Descriptors sent to Memcache should not contain whitespaces or control characters. 
 
 # Contact
 


### PR DESCRIPTION
Clarifying constraints of go memcache client, eg that whitespaces and control characters are not allowed in descriptors sent to Memcache.  Reference: https://pkg.go.dev/github.com/bradfitz/gomemcache/memcache#pkg-variables (ErrMalformedKey) 

Signed-off-by: Kateryna Nezdolii <nezdolik@spotify.com>