### PR TITLE
Add env var to configure max idle connections per memcache node

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ To configure a Memcache instance use the following environment variables instead
 1. `MEMCACHE_HOST_PORT=`: a comma separated list of hostname:port pairs for memcache nodes.
 1. `BACKEND_TYPE=memcache`
 1. `CACHE_KEY_PREFIX`: a string to prepend to all cache keys
+1. `MEMCACHE_MAX_IDLE_CONNS=2`: the maximum number of idle TCP connections per memcache node, `2` is the default of the underlying library
 
 With memcache mode increments will happen asynchronously, so it's technically possible for
 a client to exceed quota briefly if multiple requests happen at exactly the same time.

--- a/src/memcached/cache_impl.go
+++ b/src/memcached/cache_impl.go
@@ -188,8 +188,10 @@ func NewRateLimitCacheImpl(client Client, timeSource utils.TimeSource, jitterRan
 
 func NewRateLimitCacheImplFromSettings(s settings.Settings, timeSource utils.TimeSource, jitterRand *rand.Rand,
 	localCache *freecache.Cache, scope stats.Scope) limiter.RateLimitCache {
+	var client = memcache.New(s.MemcacheHostPort...)
+	client.MaxIdleConns = s.MemcacheMaxIdleConns
 	return NewRateLimitCacheImpl(
-		CollectStats(memcache.New(s.MemcacheHostPort...), scope.Scope("memcache")),
+		CollectStats(client, scope.Scope("memcache")),
 		timeSource,
 		jitterRand,
 		s.ExpirationJitterMaxSeconds,

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -68,6 +68,12 @@ type Settings struct {
 
 	// Memcache settings
 	MemcacheHostPort []string `envconfig:"MEMCACHE_HOST_PORT" default:""`
+	// MemcacheMaxIdleConns sets the maximum number of idle TCP connections per memcached node.
+	// The default is 2 as that is the default of the underlying library. This is the maximum
+	// number of connections to memcache kept idle in pool, if a connection is needed but none
+	// are idle a new connection is opened, used and closed and can be left in a time-wait state
+	// which can result in high CPU usage.
+	MemcacheMaxIdleConns int `envconfig:"MEMCACHE_MAX_IDLE_CONNS" default:"2"`
 }
 
 type Option func(*Settings)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -209,6 +209,21 @@ func TestBasicConfigMemcache(t *testing.T) {
 	})
 }
 
+func TestConfigMemcacheWithMaxIdleConns(t *testing.T) {
+	singleNodePort := []int{6394}
+	assert := assert.New(t)
+	common.WithMultiMemcache(t, []common.MemcacheConfig{
+		{Port: 6394},
+	}, func() {
+		withDefaultMaxIdleConns := makeSimpleMemcacheSettings(singleNodePort, 0)
+		assert.Equal(2, withDefaultMaxIdleConns.MemcacheMaxIdleConns)
+		t.Run("MemcacheWithDefaultMaxIdleConns", testBasicConfig(withDefaultMaxIdleConns))
+		withSpecifiedMaxIdleConns := makeSimpleMemcacheSettings(singleNodePort, 0)
+		withSpecifiedMaxIdleConns.MemcacheMaxIdleConns = 100
+		t.Run("MemcacheWithSpecifiedMaxIdleConns", testBasicConfig(withSpecifiedMaxIdleConns))
+	})
+}
+
 func TestMultiNodeMemcache(t *testing.T) {
 	multiNodePorts := []int{6494, 6495}
 	common.WithMultiMemcache(t, []common.MemcacheConfig{


### PR DESCRIPTION
The underlying memcache client library allows this to be configured,
and currently defaults to a value of 2, see:

https://github.com/bradfitz/gomemcache/blob/master/memcache/memcache.go#L72
https://github.com/bradfitz/gomemcache/blob/master/memcache/memcache.go#L145
https://github.com/bradfitz/gomemcache/blob/master/memcache/memcache.go#L239

This allows this value to be configured by a new environmet variable:

MEMCACHE_MAX_IDLE_CONNS

which defaults to -1 meaning the default from the library will apply
(which is the current behaviour).

Signed-off-by: Peter Marsh <pete.d.marsh@gmail.com>