### PR TITLE
Hook up /debug/pprof/trace

### DIFF
--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -254,6 +254,14 @@ func newServer(s settings.Settings, name string, store stats.Store, localCache *
 			})
 		})
 
+	// setup trace endpoint
+	ret.AddDebugHttpEndpoint(
+		"/debug/pprof/trace",
+		"trace endpoint",
+		func(writer http.ResponseWriter, request *http.Request) {
+			pprof.Trace(writer, request)
+		})
+
 	// setup debug root
 	ret.debugListener.debugMux.HandleFunc(
 		"/",


### PR DESCRIPTION
The title says it all really, this hooks up the trace endpount for pprof.

Signed-off-by: Peter Marsh <pete.d.marsh@gmail.com>