### PR TITLE
GRPC, HTTP, and Debug server listen addresses fully configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ $ curl 0:6070/
 /stats: print out stats
 ```
 
-You can specify the debug port with the `DEBUG_PORT` environment variable. It defaults to `6070`.
+You can specify the debug server address with the `DEBUG_HOST` and `DEBUG_PORT` environment variables. They currently default to `0.0.0.0` and `6070` respectively.
 
 # Local Cache
 

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -10,10 +10,13 @@ import (
 type Settings struct {
 	// runtime options
 	GrpcUnaryInterceptor grpc.ServerOption
-	// env config
-	Port      int `envconfig:"PORT" default:"8080"`
-	GrpcPort  int `envconfig:"GRPC_PORT" default:"8081"`
-	DebugPort int `envconfig:"DEBUG_PORT" default:"6070"`
+	// Server listen address config
+	Host      string `envconfig:"HOST" default:"0.0.0.0"`
+	Port      int    `envconfig:"PORT" default:"8080"`
+	GrpcHost  string `envconfig:"GRPC_HOST" default:"0.0.0.0"`
+	GrpcPort  int    `envconfig:"GRPC_PORT" default:"8081"`
+	DebugHost string `envconfig:"DEBUG_HOST" default:"0.0.0.0"`
+	DebugPort int    `envconfig:"DEBUG_PORT" default:"6070"`
 
 	// Logging settings
 	LogLevel  string `envconfig:"LOG_LEVEL" default:"WARN"`


### PR DESCRIPTION
- servers listen addresses are configurable via environment variable
- matches port configurability providing *HOST environment variables

Fixes #245