### PR TITLE
Fix flaky test TestServiceLegacy

### DIFF
--- a/test/service/ratelimit_legacy_test.go
+++ b/test/service/ratelimit_legacy_test.go
@@ -121,7 +121,7 @@ func TestServiceLegacy(test *testing.T) {
 	t.configLoader.EXPECT().Load(
 		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}}, gomock.Any()).Do(
 		func([]config.RateLimitConfigToLoad, stats.Scope) {
-			barrier.signal()
+			defer barrier.signal()
 			panic(config.RateLimitConfigError("load error"))
 		})
 	t.runtimeUpdateCallback <- 1


### PR DESCRIPTION
User deferred barrier.signal() so panic definitely occurs before
we continue on in test.

Config reload uses recover() and increments config load counter, tests
were failing to see config load error counter increment.

Fixes: #256