### PR TITLE
Fix bug and code optimization

### DIFF
--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -1,24 +1,24 @@
 package redis
 
 import (
-	"github.com/envoyproxy/ratelimit/src/stats"
 	"math/rand"
 
 	"github.com/coocood/freecache"
 	"github.com/envoyproxy/ratelimit/src/limiter"
 	"github.com/envoyproxy/ratelimit/src/server"
 	"github.com/envoyproxy/ratelimit/src/settings"
+	"github.com/envoyproxy/ratelimit/src/stats"
 	"github.com/envoyproxy/ratelimit/src/utils"
 )
 
 func NewRateLimiterCacheImplFromSettings(s settings.Settings, localCache *freecache.Cache, srv server.Server, timeSource utils.TimeSource, jitterRand *rand.Rand, expirationJitterMaxSeconds int64, statsManager stats.Manager) limiter.RateLimitCache {
 	var perSecondPool Client
 	if s.RedisPerSecond {
-		perSecondPool = NewClientImpl(srv.Scope().Scope("redis_per_second_pool"), s.RedisPerSecondTls, s.RedisPerSecondAuth,
+		perSecondPool = NewClientImpl(srv.Scope().Scope("redis_per_second_pool"), s.RedisPerSecondTls, s.RedisPerSecondAuth, s.RedisPerSecondSocketType,
 			s.RedisPerSecondType, s.RedisPerSecondUrl, s.RedisPerSecondPoolSize, s.RedisPerSecondPipelineWindow, s.RedisPerSecondPipelineLimit)
 	}
 	var otherPool Client
-	otherPool = NewClientImpl(srv.Scope().Scope("redis_pool"), s.RedisTls, s.RedisAuth, s.RedisType, s.RedisUrl, s.RedisPoolSize,
+	otherPool = NewClientImpl(srv.Scope().Scope("redis_pool"), s.RedisTls, s.RedisAuth, s.RedisSocketType, s.RedisType, s.RedisUrl, s.RedisPoolSize,
 		s.RedisPipelineWindow, s.RedisPipelineLimit)
 
 	return NewFixedRateLimitCacheImpl(

--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -52,7 +52,7 @@ func checkError(err error) {
 	}
 }
 
-func NewClientImpl(scope stats.Scope, useTls bool, auth string, redisType string, url string, poolSize int,
+func NewClientImpl(scope stats.Scope, useTls bool, auth, redisSocketType, redisType, url string, poolSize int,
 	pipelineWindow time.Duration, pipelineLimit int) Client {
 	logger.Warnf("connecting to redis on %s with pool size %d", url, poolSize)
 
@@ -92,7 +92,7 @@ func NewClientImpl(scope stats.Scope, useTls bool, auth string, redisType string
 	var err error
 	switch strings.ToLower(redisType) {
 	case "single":
-		client, err = poolFunc("tcp", url)
+		client, err = poolFunc(redisSocketType, url)
 	case "cluster":
 		urls := strings.Split(url, ",")
 		if implicitPipelining == false {

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"expvar"
 	"fmt"
-	"github.com/envoyproxy/ratelimit/src/stats"
 	"io"
 	"net/http"
 	"net/http/pprof"
@@ -12,6 +11,8 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+
+	"github.com/envoyproxy/ratelimit/src/stats"
 
 	"os"
 	"os/signal"
@@ -283,13 +284,13 @@ func newServer(s settings.Settings, name string, statsManager stats.Manager, loc
 func (server *server) Stop() {
 	server.grpcServer.GracefulStop()
 	server.listenerMu.Lock()
+	defer server.listenerMu.Unlock()
 	if server.debugListener.listener != nil {
 		server.debugListener.listener.Close()
 	}
 	if server.httpServer != nil {
 		server.httpServer.Close()
 	}
-	server.listenerMu.Unlock()
 }
 
 func (server *server) handleGracefulShutdown() {
@@ -300,15 +301,6 @@ func (server *server) handleGracefulShutdown() {
 		sig := <-sigs
 
 		logger.Infof("Ratelimit server received %v, shutting down gracefully", sig)
-		server.grpcServer.GracefulStop()
-		server.listenerMu.Lock()
-		if server.debugListener.listener != nil {
-			server.debugListener.listener.Close()
-		}
-		if server.httpServer != nil {
-			server.httpServer.Close()
-		}
-		server.listenerMu.Unlock()
-		os.Exit(0)
+		server.Stop()
 	}()
 }

--- a/test/redis/bench_test.go
+++ b/test/redis/bench_test.go
@@ -2,10 +2,11 @@ package redis_test
 
 import (
 	"context"
-	"github.com/envoyproxy/ratelimit/test/mocks/stats"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/envoyproxy/ratelimit/test/mocks/stats"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	"github.com/envoyproxy/ratelimit/src/config"
@@ -43,7 +44,7 @@ func BenchmarkParallelDoLimit(b *testing.B) {
 		return func(b *testing.B) {
 			statsStore := gostats.NewStore(gostats.NewNullSink(), false)
 			sm := stats.NewMockStatManager(statsStore)
-			client := redis.NewClientImpl(statsStore, false, "", "single", "127.0.0.1:6379", poolSize, pipelineWindow, pipelineLimit)
+			client := redis.NewClientImpl(statsStore, false, "", "tcp", "single", "127.0.0.1:6379", poolSize, pipelineWindow, pipelineLimit)
 			defer client.Close()
 
 			cache := redis.NewFixedRateLimitCacheImpl(client, nil, utils.NewTimeSourceImpl(), rand.New(utils.NewLockedSource(time.Now().Unix())), 10, nil, 0.8, "", sm)

--- a/test/redis/driver_impl_test.go
+++ b/test/redis/driver_impl_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/envoyproxy/ratelimit/src/redis"
-	"github.com/lyft/gostats"
+	stats "github.com/lyft/gostats"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +36,7 @@ func testNewClientImpl(t *testing.T, pipelineWindow time.Duration, pipelineLimit
 		statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 		mkRedisClient := func(auth, addr string) redis.Client {
-			return redis.NewClientImpl(statsStore, false, auth, "single", addr, 1, pipelineWindow, pipelineLimit)
+			return redis.NewClientImpl(statsStore, false, auth, "tcp", "single", addr, 1, pipelineWindow, pipelineLimit)
 		}
 
 		t.Run("connection refused", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestDoCmd(t *testing.T) {
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	mkRedisClient := func(addr string) redis.Client {
-		return redis.NewClientImpl(statsStore, false, "", "single", addr, 1, 0, 0)
+		return redis.NewClientImpl(statsStore, false, "", "tcp", "single", addr, 1, 0, 0)
 	}
 
 	t.Run("SETGET ok", func(t *testing.T) {
@@ -148,7 +148,7 @@ func testPipeDo(t *testing.T, pipelineWindow time.Duration, pipelineLimit int) f
 		statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 		mkRedisClient := func(addr string) redis.Client {
-			return redis.NewClientImpl(statsStore, false, "", "single", addr, 1, pipelineWindow, pipelineLimit)
+			return redis.NewClientImpl(statsStore, false, "", "tcp", "single", addr, 1, pipelineWindow, pipelineLimit)
 		}
 
 		t.Run("SETGET ok", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: devincd <505259926@qq.com>

If redis url is unix domain socket, will panic. The log is bellow:
```
WARN[0000] connecting to redis on /var/run/nutcracker/ratelimit.sock with pool size 10
panic: dial tcp: address /var/run/nutcracker/ratelimit.sock: missing port in address
```