### PR TITLE
Idea: Support of regex functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ key.pem
 private.pem
 redis-per-second.conf
 redis.conf
+.DS_Store

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -241,6 +241,7 @@ func (this *rateLimitConfigImpl) Dump() string {
 func (this *rateLimitConfigImpl) GetLimit(
 	ctx context.Context, domain string, descriptor *pb_struct.RateLimitDescriptor) *RateLimit {
 
+	logger.Debugf("Descriptor %v", descriptor)
 	logger.Debugf("starting get limit lookup")
 	var rateLimit *RateLimit = nil
 	value := this.domains[domain]
@@ -264,13 +265,16 @@ func (this *rateLimitConfigImpl) GetLimit(
 	for i, entry := range descriptor.Entries {
 		// First see if key_value is in the map. If that isn't in the map we look for just key
 		// to check for a default value.
+		entry.Value = checkRegex(descriptorsMap, descriptor)
 		finalKey := entry.Key + "_" + entry.Value
 		logger.Debugf("looking up key: %s", finalKey)
 		nextDescriptor := descriptorsMap[finalKey]
+		logger.Debugf("nextDescriptor [not nil]: %v", nextDescriptor)
 		if nextDescriptor == nil {
 			finalKey = entry.Key
 			logger.Debugf("looking up key: %s", finalKey)
 			nextDescriptor = descriptorsMap[finalKey]
+			logger.Debugf("nextDescriptor: %v", nextDescriptor)
 		}
 
 		if nextDescriptor != nil && nextDescriptor.limit != nil {

--- a/src/config/config_impl_test.go
+++ b/src/config/config_impl_test.go
@@ -1,0 +1,148 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
+)
+
+func Test_extractKeys(t *testing.T) {
+	type args struct {
+		descriptorMap map[string]*rateLimitDescriptor
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "Split two descriptors",
+			args: args{
+				descriptorMap: map[string]*rateLimitDescriptor{
+					"PATH_/api/v1": {
+						descriptors: map[string]*rateLimitDescriptor{},
+						limit: &RateLimit{
+							FullKey: "someKey",
+						},
+					},
+					"PATH_^\\/api\\/[\\w\\/]+$": {
+						descriptors: map[string]*rateLimitDescriptor{},
+						limit: &RateLimit{
+							FullKey: "someRegex",
+						},
+					},
+				},
+			},
+			want: []string{"/api/v1", "^\\/api\\/[\\w\\/]+$"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractKeys(tt.args.descriptorMap); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractKeys() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_checkRegex(t *testing.T) {
+	type args struct {
+		descriptorMap map[string]*rateLimitDescriptor
+		descriptor    *pb_struct.RateLimitDescriptor
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantValue string
+	}{
+		{
+			name: "Regex match -> return regex expression to match descriptor in rate limiting",
+			args: args{
+				descriptorMap: map[string]*rateLimitDescriptor{
+					"PATH_/api/v1": {
+						descriptors: map[string]*rateLimitDescriptor{},
+						limit: &RateLimit{
+							FullKey: "someKey",
+						},
+					},
+					"PATH_^\\/api\\/[\\w\\/]+$": {
+						descriptors: map[string]*rateLimitDescriptor{},
+						limit: &RateLimit{
+							FullKey: "someRegex",
+						},
+					},
+				},
+				descriptor: &pb_struct.RateLimitDescriptor{
+					Entries: []*pb_struct.RateLimitDescriptor_Entry{{
+						Key:   "PATH",
+						Value: "/api/v1/",
+					},
+					},
+				},
+			},
+			wantValue: "^\\/api\\/[\\w\\/]+$",
+		},
+		{
+			name: "No match -> return original value",
+			args: args{
+				descriptorMap: map[string]*rateLimitDescriptor{
+					"PATH_/api/v1": {
+						descriptors: map[string]*rateLimitDescriptor{},
+						limit: &RateLimit{
+							FullKey: "someKey",
+						},
+					},
+					"PATH_^\\/api\\/[\\w\\/]+$": {
+						descriptors: map[string]*rateLimitDescriptor{},
+						limit: &RateLimit{
+							FullKey: "someRegex",
+						},
+					},
+				},
+				descriptor: &pb_struct.RateLimitDescriptor{
+					Entries: []*pb_struct.RateLimitDescriptor_Entry{{
+						Key:   "PATH",
+						Value: "/livez",
+					},
+					},
+				},
+			},
+			wantValue: "/livez",
+		},
+		{
+			name: "No Regex match but simple uri match -> return original value",
+			args: args{
+				descriptorMap: map[string]*rateLimitDescriptor{
+					"PATH_/someurl": {
+						descriptors: map[string]*rateLimitDescriptor{},
+						limit: &RateLimit{
+							FullKey: "someKey",
+						},
+					},
+					"PATH_^\\/api\\/[\\w\\/]+$": {
+						descriptors: map[string]*rateLimitDescriptor{},
+						limit: &RateLimit{
+							FullKey: "someRegex",
+						},
+					},
+				},
+				descriptor: &pb_struct.RateLimitDescriptor{
+					Entries: []*pb_struct.RateLimitDescriptor_Entry{{
+						Key:   "PATH",
+						Value: "/someurl",
+					},
+					},
+				},
+			},
+			wantValue: "/someurl",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotValue := checkRegex(tt.args.descriptorMap, tt.args.descriptor); gotValue != tt.wantValue {
+				t.Errorf("checkRegex() = %v, want %v", gotValue, tt.wantValue)
+			}
+		})
+	}
+}

--- a/src/config/regex.go
+++ b/src/config/regex.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"regexp"
+	"strings"
+
+	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
+	logger "github.com/sirupsen/logrus"
+)
+
+func extractKeys(descriptorMap map[string]*rateLimitDescriptor) []string {
+	var keys []string
+	for k := range descriptorMap {
+		split := strings.Split(k, "_")
+		keys = append(keys, split[len(split)-1])
+	}
+	return keys
+}
+
+func checkRegex(descriptorMap map[string]*rateLimitDescriptor, descriptor *pb_struct.RateLimitDescriptor) (value string) {
+	value = descriptor.Entries[0].Value
+	keys := extractKeys(descriptorMap)
+	for _, k := range keys {
+		validID, err := regexp.Compile(k)
+		if err != nil {
+			logger.Infof("%s is not a regex expression", k)
+		}
+		regexMatch := validID.MatchString(descriptor.Entries[0].Value)
+		logger.Debugf("Regex match %t", regexMatch)
+		if len(descriptor.Entries) == 1 && regexMatch {
+			value = k
+			logger.Debugf("Rewrite descriptor")
+		}
+	}
+	return
+}


### PR DESCRIPTION
To explain the workflow of the incoming request I wrote the following pseudo code: 

![image](https://user-images.githubusercontent.com/30232445/128477366-25168f78-3747-4b6f-955d-222979c511d5.png)

The main idea is that the incoming descriptor has only a single entry and if the entry is matching the regex expression, the request will be modified such that the value of the redis keys can be checked. I know that there has been a similar issue but the we couldn't find an appropriate solution based on with a specific descriptor. 