### PR TITLE
Display all statsd metrics in prometheus

### DIFF
--- a/examples/prom-statsd-exporter/conf.yaml
+++ b/examples/prom-statsd-exporter/conf.yaml
@@ -85,10 +85,9 @@ mappings: # Requires statsd exporter >= v0.6.0 since it uses the "drop" action.
   - match: "ratelimit.service.config_load_error"
     name: "ratelimit_service_config_load_error"
     match_metric_type: counter
-  - match: "ratelimit.service.config_load_error"
-    name: "ratelimit_service_config_load_error"
-    match_metric_type: counter
-  - match: "."
-    match_type: "regex"
-    action: "drop"
-    name: "dropped"
+
+  # Enable below in production once you have the metrics you need
+  # - match: "."
+  #   match_type: "regex"
+  #   action: "drop"
+  #   name: "dropped"


### PR DESCRIPTION
Before, due to the "drop all" rule, statsd metrics that didn't match any rules were dropped in prom. I'm removing that so metrics not specified by a rule will be autogenerated. Should help in debugging the some of the metrics issues in #274 #275 #276
ex:
```
# HELP ratelimit_service_rate_limit_within_limit Metric autogenerated by statsd_exporter.
# TYPE ratelimit_service_rate_limit_within_limit counter
ratelimit_service_rate_limit_within_limit{domain="rl",key1="foo",key2="bar"} 12
# HELP ratelimit_service_response_time_seconds Metric autogenerated by statsd_exporter.
# TYPE ratelimit_service_response_time_seconds histogram
ratelimit_service_response_time_seconds_bucket{grpc_method="ShouldRateLimit",le="0.005"} 196
ratelimit_service_response_time_seconds_bucket{grpc_method="ShouldRateLimit",le="0.01"} 196
```