### PR TITLE
Add configurable GrpcMaxConnectionAge, GrpcMaxConnectionAgeGrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
       - [Example 5](#example-5)
   - [Loading Configuration](#loading-configuration)
   - [Log Format](#log-format)
+  - [GRPC Keepalive](#grpc-keepalive)
 - [Request Fields](#request-fields)
 - [GRPC Client](#grpc-client)
   - [Commandline flags](#commandline-flags)

--- a/README.md
+++ b/README.md
@@ -407,6 +407,12 @@ Output example:
 {"@message":"waiting for runtime update","@timestamp":"2020-09-10T17:22:44.926267808Z","level":"debug"}
 ```
 
+## GRPC Keepalive
+Client-side GRPC DNS re-resolution in scenarios with auto scaling enabled might not work as expected and the current workaround is to [configure connection keepalive](https://github.com/grpc/grpc/issues/12295#issuecomment-382794204) on server-side.
+The behavior can be fixed by configuring the following env variables for the ratelimit server:
+* `GRPC_MAX_CONNECTION_AGE`: a duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway. A random jitter of +/-10% will be added to MaxConnectionAge to spread out connection storms.
+* `GRPC_MAX_CONNECTION_AGE_GRACE`: an additive period after MaxConnectionAge after which the connection will be forcibly closed.
+
 # Request Fields
 
 For information on the fields of a Ratelimit gRPC request please read the information

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"expvar"
 	"fmt"
+	"google.golang.org/grpc/keepalive"
 	"io"
 	"net/http"
 	"net/http/pprof"
@@ -178,7 +179,13 @@ func newServer(s settings.Settings, name string, statsManager stats.Manager, loc
 	}
 
 	ret := new(server)
-	ret.grpcServer = grpc.NewServer(s.GrpcUnaryInterceptor)
+
+	keepaliveOpt := grpc.KeepaliveParams(keepalive.ServerParameters{
+		MaxConnectionAge: s.GrpcMaxConnectionAge,
+		MaxConnectionAgeGrace: s.GrpcMaxConnectionAgeGrace,
+	})
+
+	ret.grpcServer = grpc.NewServer(s.GrpcUnaryInterceptor, keepaliveOpt)
 
 	// setup listen addresses
 	ret.httpAddress = net.JoinHostPort(s.Host, strconv.Itoa(s.Port))

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -181,7 +181,7 @@ func newServer(s settings.Settings, name string, statsManager stats.Manager, loc
 	ret := new(server)
 
 	keepaliveOpt := grpc.KeepaliveParams(keepalive.ServerParameters{
-		MaxConnectionAge: s.GrpcMaxConnectionAge,
+		MaxConnectionAge:      s.GrpcMaxConnectionAge,
 		MaxConnectionAgeGrace: s.GrpcMaxConnectionAgeGrace,
 	})
 

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -21,7 +21,7 @@ type Settings struct {
 	// GRPC server settings
 	// GrpcMaxConnectionAge is a duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway.
 	// A random jitter of +/-10% will be added to MaxConnectionAge to spread out connection storms.
-	GrpcMaxConnectionAge      time.Duration `envconfig:"GRPC_MAX_CONNECTION_AGE" default:"24h" description:"Duration a connection may exist before it will be closed by sending a GoAway."`
+	GrpcMaxConnectionAge time.Duration `envconfig:"GRPC_MAX_CONNECTION_AGE" default:"24h" description:"Duration a connection may exist before it will be closed by sending a GoAway."`
 	// GrpcMaxConnectionAgeGrace is an additive period after MaxConnectionAge after which the connection will be forcibly closed.
 	GrpcMaxConnectionAgeGrace time.Duration `envconfig:"GRPC_MAX_CONNECTION_AGE_GRACE" default:"1h" description:"Period after MaxConnectionAge after which the connection will be forcibly closed."`
 

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -18,6 +18,13 @@ type Settings struct {
 	DebugHost string `envconfig:"DEBUG_HOST" default:"0.0.0.0"`
 	DebugPort int    `envconfig:"DEBUG_PORT" default:"6070"`
 
+	// GRPC server settings
+	// GrpcMaxConnectionAge is a duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway.
+	// A random jitter of +/-10% will be added to MaxConnectionAge to spread out connection storms.
+	GrpcMaxConnectionAge      time.Duration `envconfig:"GRPC_MAX_CONNECTION_AGE" default:"24h" description:"Duration a connection may exist before it will be closed by sending a GoAway."`
+	// GrpcMaxConnectionAgeGrace is an additive period after MaxConnectionAge after which the connection will be forcibly closed.
+	GrpcMaxConnectionAgeGrace time.Duration `envconfig:"GRPC_MAX_CONNECTION_AGE_GRACE" default:"1h" description:"Period after MaxConnectionAge after which the connection will be forcibly closed."`
+
 	// Logging settings
 	LogLevel  string `envconfig:"LOG_LEVEL" default:"WARN"`
 	LogFormat string `envconfig:"LOG_FORMAT" default:"text"`


### PR DESCRIPTION
Server-side configuration of MaxConnectionAge, MaxConnectionAgeGrace is needed to achieve better load balancing behavior in auto-scaled scenarios: https://github.com/grpc/grpc/issues/12295#issuecomment-382794204