### PR TITLE
Configurable Redis TLS Config through settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,8 +542,6 @@ As well Ratelimit supports TLS connections and authentication. These can be conf
 1. `REDIS_AUTH` & `REDIS_PERSECOND_AUTH`: set to `"password"` to enable authentication to the redis host.
 1. `CACHE_KEY_PREFIX`: a string to prepend to all cache keys
 
-Ratelimit also provides the ability to specify TLS settings via `RedisTlsConfig` in the [settings](https://github.com/envoyproxy/ratelimit/blob/master/src/settings/settings.go).
-
 ## Redis type
 
 Ratelimit supports different types of redis deployments:

--- a/README.md
+++ b/README.md
@@ -542,6 +542,8 @@ As well Ratelimit supports TLS connections and authentication. These can be conf
 1. `REDIS_AUTH` & `REDIS_PERSECOND_AUTH`: set to `"password"` to enable authentication to the redis host.
 1. `CACHE_KEY_PREFIX`: a string to prepend to all cache keys
 
+Ratelimit also provides the ability to specify TLS settings via `RedisTlsConfig` in the [settings](https://github.com/envoyproxy/ratelimit/blob/master/src/settings/settings.go).
+
 ## Redis type
 
 Ratelimit supports different types of redis deployments:

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -15,11 +15,11 @@ func NewRateLimiterCacheImplFromSettings(s settings.Settings, localCache *freeca
 	var perSecondPool Client
 	if s.RedisPerSecond {
 		perSecondPool = NewClientImpl(srv.Scope().Scope("redis_per_second_pool"), s.RedisPerSecondTls, s.RedisPerSecondAuth, s.RedisPerSecondSocketType,
-			s.RedisPerSecondType, s.RedisPerSecondUrl, s.RedisPerSecondPoolSize, s.RedisPerSecondPipelineWindow, s.RedisPerSecondPipelineLimit)
+			s.RedisPerSecondType, s.RedisPerSecondUrl, s.RedisPerSecondPoolSize, s.RedisPerSecondPipelineWindow, s.RedisPerSecondPipelineLimit, s.RedisTlsConfig)
 	}
 	var otherPool Client
 	otherPool = NewClientImpl(srv.Scope().Scope("redis_pool"), s.RedisTls, s.RedisAuth, s.RedisSocketType, s.RedisType, s.RedisUrl, s.RedisPoolSize,
-		s.RedisPipelineWindow, s.RedisPipelineLimit)
+		s.RedisPipelineWindow, s.RedisPipelineLimit, s.RedisTlsConfig)
 
 	return NewFixedRateLimitCacheImpl(
 		otherPool,

--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -53,14 +53,18 @@ func checkError(err error) {
 }
 
 func NewClientImpl(scope stats.Scope, useTls bool, auth, redisSocketType, redisType, url string, poolSize int,
-	pipelineWindow time.Duration, pipelineLimit int) Client {
+	pipelineWindow time.Duration, pipelineLimit int, tlsConfig *tls.Config) Client {
 	logger.Warnf("connecting to redis on %s with pool size %d", url, poolSize)
 
 	df := func(network, addr string) (radix.Conn, error) {
 		var dialOpts []radix.DialOpt
 
 		if useTls {
-			dialOpts = append(dialOpts, radix.DialUseTLS(&tls.Config{}))
+			if tlsConfig != nil {
+				dialOpts = append(dialOpts, radix.DialUseTLS(tlsConfig))
+			} else {
+				dialOpts = append(dialOpts, radix.DialUseTLS(&tls.Config{}))
+			}
 		}
 
 		if auth != "" {

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"crypto/tls"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -48,6 +49,7 @@ type Settings struct {
 	RedisPoolSize   int    `envconfig:"REDIS_POOL_SIZE" default:"10"`
 	RedisAuth       string `envconfig:"REDIS_AUTH" default:""`
 	RedisTls        bool   `envconfig:"REDIS_TLS" default:"false"`
+	RedisTlsConfig   *tls.Config
 	// RedisPipelineWindow sets the duration after which internal pipelines will be flushed.
 	// If window is zero then implicit pipelining will be disabled. Radix use 150us for the
 	// default value, see https://github.com/mediocregopher/radix/blob/v3.5.1/pool.go#L278.

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -49,7 +49,8 @@ type Settings struct {
 	RedisPoolSize   int    `envconfig:"REDIS_POOL_SIZE" default:"10"`
 	RedisAuth       string `envconfig:"REDIS_AUTH" default:""`
 	RedisTls        bool   `envconfig:"REDIS_TLS" default:"false"`
-	RedisTlsConfig  *tls.Config
+	// TODO: Make this setting configurable out of the box instead of having to provide it through code.
+	RedisTlsConfig *tls.Config
 
 	// RedisPipelineWindow sets the duration after which internal pipelines will be flushed.
 	// If window is zero then implicit pipelining will be disabled. Radix use 150us for the

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -49,7 +49,8 @@ type Settings struct {
 	RedisPoolSize   int    `envconfig:"REDIS_POOL_SIZE" default:"10"`
 	RedisAuth       string `envconfig:"REDIS_AUTH" default:""`
 	RedisTls        bool   `envconfig:"REDIS_TLS" default:"false"`
-	RedisTlsConfig   *tls.Config
+	RedisTlsConfig  *tls.Config
+
 	// RedisPipelineWindow sets the duration after which internal pipelines will be flushed.
 	// If window is zero then implicit pipelining will be disabled. Radix use 150us for the
 	// default value, see https://github.com/mediocregopher/radix/blob/v3.5.1/pool.go#L278.

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -223,6 +223,7 @@ func TestMultiNodeMemcache(t *testing.T) {
 
 func testBasicConfigAuthTLS(perSecond bool, local_cache_size int) func(*testing.T) {
 	s := makeSimpleRedisSettings(16381, 16382, perSecond, local_cache_size)
+	s.RedisTlsConfig = nil
 	s.RedisAuth = "password123"
 	s.RedisTls = true
 	s.RedisPerSecondAuth = "password123"

--- a/test/redis/bench_test.go
+++ b/test/redis/bench_test.go
@@ -44,7 +44,7 @@ func BenchmarkParallelDoLimit(b *testing.B) {
 		return func(b *testing.B) {
 			statsStore := gostats.NewStore(gostats.NewNullSink(), false)
 			sm := stats.NewMockStatManager(statsStore)
-			client := redis.NewClientImpl(statsStore, false, "", "tcp", "single", "127.0.0.1:6379", poolSize, pipelineWindow, pipelineLimit)
+			client := redis.NewClientImpl(statsStore, false, "", "tcp", "single", "127.0.0.1:6379", poolSize, pipelineWindow, pipelineLimit, nil)
 			defer client.Close()
 
 			cache := redis.NewFixedRateLimitCacheImpl(client, nil, utils.NewTimeSourceImpl(), rand.New(utils.NewLockedSource(time.Now().Unix())), 10, nil, 0.8, "", sm)

--- a/test/redis/driver_impl_test.go
+++ b/test/redis/driver_impl_test.go
@@ -36,7 +36,7 @@ func testNewClientImpl(t *testing.T, pipelineWindow time.Duration, pipelineLimit
 		statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 		mkRedisClient := func(auth, addr string) redis.Client {
-			return redis.NewClientImpl(statsStore, false, auth, "tcp", "single", addr, 1, pipelineWindow, pipelineLimit)
+			return redis.NewClientImpl(statsStore, false, auth, "tcp", "single", addr, 1, pipelineWindow, pipelineLimit, nil)
 		}
 
 		t.Run("connection refused", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestDoCmd(t *testing.T) {
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	mkRedisClient := func(addr string) redis.Client {
-		return redis.NewClientImpl(statsStore, false, "", "tcp", "single", addr, 1, 0, 0)
+		return redis.NewClientImpl(statsStore, false, "", "tcp", "single", addr, 1, 0, 0, nil)
 	}
 
 	t.Run("SETGET ok", func(t *testing.T) {
@@ -148,7 +148,7 @@ func testPipeDo(t *testing.T, pipelineWindow time.Duration, pipelineLimit int) f
 		statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 		mkRedisClient := func(addr string) redis.Client {
-			return redis.NewClientImpl(statsStore, false, "", "tcp", "single", addr, 1, pipelineWindow, pipelineLimit)
+			return redis.NewClientImpl(statsStore, false, "", "tcp", "single", addr, 1, pipelineWindow, pipelineLimit, nil)
 		}
 
 		t.Run("SETGET ok", func(t *testing.T) {


### PR DESCRIPTION
At the moment, the redis tls config that it's using is a default and there is no way to change it. This makes it so that clients can specify their own TLS config if they choose to.