### PR TITLE
Configuration of custom ratelimiting headers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,2 @@
+* Matt Klein ([mattklein123](https://github.com/mattklein123)) (mklein@lyft.com)
+* Yuki Sawa ([ysawa0](https://github.com/ysawa0)) (yukisawa@gmail.com)

--- a/examples/prom-statsd-exporter/conf.yaml
+++ b/examples/prom-statsd-exporter/conf.yaml
@@ -85,10 +85,9 @@ mappings: # Requires statsd exporter >= v0.6.0 since it uses the "drop" action.
   - match: "ratelimit.service.config_load_error"
     name: "ratelimit_service_config_load_error"
     match_metric_type: counter
-  - match: "ratelimit.service.config_load_error"
-    name: "ratelimit_service_config_load_error"
-    match_metric_type: counter
-  - match: "."
-    match_type: "regex"
-    action: "drop"
-    name: "dropped"
+
+  # Enable below in production once you have the metrics you need
+  # - match: "."
+  #   match_type: "regex"
+  #   action: "drop"
+  #   name: "dropped"

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -172,16 +172,16 @@ func (this *service) shouldRateLimitWorker(
 	finalCode := pb.RateLimitResponse_OK
 
 	// Keep track of the descriptor which is closes to hit the ratelimit
-	var minQuotaRemaining uint32 = MaxUint32
+	var minLimitRemaining uint32 = MaxUint32
 	var minimumDescriptor *pb.RateLimitResponse_DescriptorStatus = nil
 
 	for i, descriptorStatus := range responseDescriptorStatuses {
 
 		// Keep track of the descriptor closest to reset if we have a CurrentLimit
 		if descriptorStatus.CurrentLimit != nil &&
-			descriptorStatus.LimitRemaining < minQuotaRemaining {
+			descriptorStatus.LimitRemaining < minLimitRemaining {
 			minimumDescriptor = descriptorStatus
-			minQuotaRemaining = descriptorStatus.LimitRemaining
+			minLimitRemaining = descriptorStatus.LimitRemaining
 		}
 
 		if isUnlimited[i] {
@@ -194,8 +194,9 @@ func (this *service) shouldRateLimitWorker(
 			if descriptorStatus.Code == pb.RateLimitResponse_OVER_LIMIT {
 				finalCode = descriptorStatus.Code
 
+				// We have hit the limit so it's definitely the closest
 				minimumDescriptor = descriptorStatus
-				minQuotaRemaining = 0
+				minLimitRemaining = 0
 			}
 		}
 	}

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -2,11 +2,16 @@ package ratelimit
 
 import (
 	"fmt"
-	"github.com/envoyproxy/ratelimit/src/stats"
 	"math"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/envoyproxy/ratelimit/src/settings"
+	"github.com/envoyproxy/ratelimit/src/stats"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	"github.com/envoyproxy/ratelimit/src/assert"
 	"github.com/envoyproxy/ratelimit/src/config"
@@ -22,15 +27,32 @@ type RateLimitServiceServer interface {
 	GetCurrentConfig() config.RateLimitConfig
 }
 
+type Clock interface {
+	Now() time.Time
+}
+
+// StdClock returns system time.
+type StdClock struct{}
+
+func (c StdClock) Now() time.Time { return time.Now() }
+
 type service struct {
-	runtime            loader.IFace
-	configLock         sync.RWMutex
-	configLoader       config.RateLimitConfigLoader
-	config             config.RateLimitConfig
-	runtimeUpdateEvent chan int
-	cache              limiter.RateLimitCache
-	stats              stats.ServiceStats
-	runtimeWatchRoot   bool
+	runtime                     loader.IFace
+	configLock                  sync.RWMutex
+	configLoader                config.RateLimitConfigLoader
+	config                      config.RateLimitConfig
+	runtimeUpdateEvent          chan int
+	cache                       limiter.RateLimitCache
+	stats                       stats.ServiceStats
+	runtimeWatchRoot            bool
+	customHeadersEnabled        bool
+	customHeaderLimitHeader     string
+	customHeaderLimitValue      string
+	customHeaderRemainingHeader string
+	customHeaderRemainingValue  string
+	customHeaderResetHeader     string
+	customHeaderResetValue      string
+	customHeaderClock           Clock
 }
 
 func (this *service) reloadConfig(statsManager stats.Manager) {
@@ -61,6 +83,20 @@ func (this *service) reloadConfig(statsManager stats.Manager) {
 	this.configLock.Lock()
 	this.config = newConfig
 	this.configLock.Unlock()
+
+	rlSettings := settings.NewSettings()
+
+	if len(rlSettings.HeaderRatelimitLimit) > 0 &&
+		len(rlSettings.HeaderRatelimitReset) > 0 &&
+		len(rlSettings.HeaderRatelimitRemaining) > 0 {
+		this.customHeadersEnabled = true
+
+		this.customHeaderLimitHeader = rlSettings.HeaderRatelimitLimit
+
+		this.customHeaderRemainingHeader = rlSettings.HeaderRatelimitRemaining
+
+		this.customHeaderResetHeader = rlSettings.HeaderRatelimitReset
+	}
 }
 
 type serviceError string
@@ -118,6 +154,8 @@ func (this *service) constructLimitsToCheck(request *pb.RateLimitRequest, ctx co
 	return limitsToCheck, isUnlimited
 }
 
+const MaxUint32 = uint32(1<<32 - 1)
+
 func (this *service) shouldRateLimitWorker(
 	ctx context.Context, request *pb.RateLimitRequest) *pb.RateLimitResponse {
 
@@ -132,7 +170,20 @@ func (this *service) shouldRateLimitWorker(
 	response := &pb.RateLimitResponse{}
 	response.Statuses = make([]*pb.RateLimitResponse_DescriptorStatus, len(request.Descriptors))
 	finalCode := pb.RateLimitResponse_OK
+
+	// Keep track of the descriptor which is closes to hit the ratelimit
+	var minQuotaRemaining uint32 = MaxUint32
+	var minimumDescriptor *pb.RateLimitResponse_DescriptorStatus = nil
+
 	for i, descriptorStatus := range responseDescriptorStatuses {
+
+		// Keep track of the descriptor closest to reset if we have a CurrentLimit
+		if descriptorStatus.CurrentLimit != nil &&
+			descriptorStatus.LimitRemaining < minQuotaRemaining {
+			minimumDescriptor = descriptorStatus
+			minQuotaRemaining = descriptorStatus.LimitRemaining
+		}
+
 		if isUnlimited[i] {
 			response.Statuses[i] = &pb.RateLimitResponse_DescriptorStatus{
 				Code:           pb.RateLimitResponse_OK,
@@ -142,12 +193,70 @@ func (this *service) shouldRateLimitWorker(
 			response.Statuses[i] = descriptorStatus
 			if descriptorStatus.Code == pb.RateLimitResponse_OVER_LIMIT {
 				finalCode = descriptorStatus.Code
+
+				minimumDescriptor = descriptorStatus
+				minQuotaRemaining = 0
 			}
+		}
+	}
+
+	// Add any Headers if requested
+	if this.customHeadersEnabled && minimumDescriptor != nil {
+
+		response.ResponseHeadersToAdd = []*core.HeaderValue{
+			this.rateLimitLimitHeader(minimumDescriptor),
+			this.rateLimitRemainingHeader(minimumDescriptor),
+			this.rateLimitResetHeader(minimumDescriptor, this.customHeaderClock.Now().Unix()),
 		}
 	}
 
 	response.OverallCode = finalCode
 	return response
+}
+
+func (this *service) rateLimitLimitHeader(descriptor *pb.RateLimitResponse_DescriptorStatus) *core.HeaderValue {
+
+	return &core.HeaderValue{
+		Key:   this.customHeaderLimitHeader,
+		Value: strconv.FormatUint(uint64(descriptor.CurrentLimit.RequestsPerUnit), 10),
+	}
+}
+
+func (this *service) rateLimitRemainingHeader(descriptor *pb.RateLimitResponse_DescriptorStatus) *core.HeaderValue {
+
+	return &core.HeaderValue{
+		Key:   this.customHeaderRemainingHeader,
+		Value: strconv.FormatUint(uint64(descriptor.LimitRemaining), 10),
+	}
+}
+
+func (this *service) rateLimitResetHeader(
+	descriptor *pb.RateLimitResponse_DescriptorStatus, now int64) *core.HeaderValue {
+
+	return &core.HeaderValue{
+		Key:   this.customHeaderResetHeader,
+		Value: strconv.FormatInt(calculateReset(descriptor, now), 10),
+	}
+}
+
+func calculateReset(descriptor *pb.RateLimitResponse_DescriptorStatus, now int64) int64 {
+	sec := unitInSeconds(descriptor.CurrentLimit.Unit)
+	return sec - now%sec
+}
+
+func unitInSeconds(unit pb.RateLimitResponse_RateLimit_Unit) int64 {
+	switch unit {
+	case pb.RateLimitResponse_RateLimit_SECOND:
+		return 1
+	case pb.RateLimitResponse_RateLimit_MINUTE:
+		return 60
+	case pb.RateLimitResponse_RateLimit_HOUR:
+		return 60 * 60
+	case pb.RateLimitResponse_RateLimit_DAY:
+		return 60 * 60 * 24
+	default:
+		panic("unknown rate limit unit")
+	}
 }
 
 func (this *service) ShouldRateLimit(
@@ -190,7 +299,7 @@ func (this *service) GetCurrentConfig() config.RateLimitConfig {
 }
 
 func NewService(runtime loader.IFace, cache limiter.RateLimitCache,
-	configLoader config.RateLimitConfigLoader, statsManager stats.Manager, runtimeWatchRoot bool) RateLimitServiceServer {
+	configLoader config.RateLimitConfigLoader, statsManager stats.Manager, runtimeWatchRoot bool, clock Clock) RateLimitServiceServer {
 
 	newService := &service{
 		runtime:            runtime,
@@ -201,6 +310,7 @@ func NewService(runtime loader.IFace, cache limiter.RateLimitCache,
 		cache:              cache,
 		stats:              statsManager.NewServiceStats(),
 		runtimeWatchRoot:   runtimeWatchRoot,
+		customHeaderClock:  clock,
 	}
 
 	runtime.AddUpdateCallback(newService.runtimeUpdateEvent)

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -1,14 +1,15 @@
 package runner
 
 import (
-	"github.com/envoyproxy/ratelimit/src/metrics"
-	"github.com/envoyproxy/ratelimit/src/stats"
 	"io"
 	"math/rand"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/envoyproxy/ratelimit/src/metrics"
+	"github.com/envoyproxy/ratelimit/src/stats"
 
 	gostats "github.com/lyft/gostats"
 
@@ -107,6 +108,7 @@ func (runner *Runner) Run() {
 		config.NewRateLimitConfigLoaderImpl(),
 		runner.statsManager,
 		s.RuntimeWatchRoot,
+		ratelimit.StdClock{},
 	)
 
 	srv.AddDebugHttpEndpoint(

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -34,6 +34,14 @@ type Settings struct {
 	RuntimeIgnoreDotFiles bool   `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
 	RuntimeWatchRoot      bool   `envconfig:"RUNTIME_WATCH_ROOT" default:"true"`
 
+	// Settings for optional returning of custom headers
+	// value: the current limit
+	HeaderRatelimitLimit string `envconfig:"LIMIT_LIMIT_HEADER" default:""`
+	// value: remaining count
+	HeaderRatelimitRemaining string `envconfig:"LIMIT_REMAINING_HEADER" default:""`
+	// value: remaining seconds
+	HeaderRatelimitReset string `envconfig:"LIMIT_RESET_HEADER" default:""`
+
 	// Settings for all cache types
 	ExpirationJitterMaxSeconds int64   `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
 	LocalCacheSizeInBytes      int     `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`

--- a/test/limiter/base_limiter_test.go
+++ b/test/limiter/base_limiter_test.go
@@ -1,9 +1,10 @@
 package limiter
 
 import (
-	mockstats "github.com/envoyproxy/ratelimit/test/mocks/stats"
 	"math/rand"
 	"testing"
+
+	mockstats "github.com/envoyproxy/ratelimit/test/mocks/stats"
 
 	"github.com/coocood/freecache"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"

--- a/test/service/ratelimit_test.go
+++ b/test/service/ratelimit_test.go
@@ -1,11 +1,15 @@
 package ratelimit_test
 
 import (
-	"github.com/envoyproxy/ratelimit/src/stats"
 	"math"
+	"os"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/envoyproxy/ratelimit/src/stats"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	"github.com/envoyproxy/ratelimit/src/config"
 	"github.com/envoyproxy/ratelimit/src/redis"
@@ -60,7 +64,14 @@ type rateLimitServiceTestSuite struct {
 	runtimeUpdateCallback chan<- int
 	statsManager          stats.Manager
 	statStore             gostats.Store
+	mockClock             ratelimit.Clock
 }
+
+type MockClock struct {
+	now int64
+}
+
+func (c MockClock) Now() time.Time { return time.Unix(c.now, 0) }
 
 func commonSetup(t *testing.T) rateLimitServiceTestSuite {
 	ret := rateLimitServiceTestSuite{}
@@ -87,7 +98,7 @@ func (this *rateLimitServiceTestSuite) setupBasicService() ratelimit.RateLimitSe
 	this.configLoader.EXPECT().Load(
 		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}},
 		gomock.Any()).Return(this.config)
-	return ratelimit.NewService(this.runtime, this.cache, this.configLoader, this.statsManager, true)
+	return ratelimit.NewService(this.runtime, this.cache, this.configLoader, this.statsManager, true, MockClock{now: int64(2222)})
 }
 
 func TestService(test *testing.T) {
@@ -176,6 +187,93 @@ func TestService(test *testing.T) {
 	t.assert.EqualValues(1, t.statStore.NewCounter("config_load_error").Value())
 }
 
+func TestServiceWithCustomHeaders(test *testing.T) {
+	os.Setenv("LIMIT_LIMIT_HEADER", "A-Ratelimit-Limit")
+	os.Setenv("LIMIT_REMAINING_HEADER", "A-Ratelimit-Remaining")
+	os.Setenv("LIMIT_RESET_HEADER", "A-Ratelimit-Reset")
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	// Config reload.
+	barrier := newBarrier()
+	t.configLoader.EXPECT().Load(
+		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}}, gomock.Any()).Do(
+		func([]config.RateLimitConfigToLoad, stats.Manager) { barrier.signal() }).Return(t.config)
+	t.runtimeUpdateCallback <- 1
+	barrier.wait()
+
+	// Make request
+	request := common.NewRateLimitRequest(
+		"different-domain", [][][2]string{{{"foo", "bar"}}, {{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false),
+		nil}
+	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[0]).Return(limits[0])
+	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[1]).Return(limits[1])
+	t.cache.EXPECT().DoLimit(nil, request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0},
+			{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0}})
+
+	response, err := service.ShouldRateLimit(nil, request)
+	common.AssertProtoEqual(
+		t.assert,
+		&pb.RateLimitResponse{
+			OverallCode: pb.RateLimitResponse_OVER_LIMIT,
+			Statuses: []*pb.RateLimitResponse_DescriptorStatus{
+				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0},
+				{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0},
+			},
+			ResponseHeadersToAdd: []*core.HeaderValue{
+				{Key: "A-Ratelimit-Limit", Value: "10"},
+				{Key: "A-Ratelimit-Remaining", Value: "0"},
+				{Key: "A-Ratelimit-Reset", Value: "58"},
+			},
+		},
+		response)
+	t.assert.Nil(err)
+
+	// Config load failure.
+	t.configLoader.EXPECT().Load(
+		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}}, gomock.Any()).Do(
+		func([]config.RateLimitConfigToLoad, stats.Manager) {
+			defer barrier.signal()
+			panic(config.RateLimitConfigError("load error"))
+		})
+	t.runtimeUpdateCallback <- 1
+	barrier.wait()
+
+	// Config should still be valid. Also make sure order does not affect results.
+	limits = []*config.RateLimit{
+		nil,
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false)}
+	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[0]).Return(limits[0])
+	t.config.EXPECT().GetLimit(nil, "different-domain", request.Descriptors[1]).Return(limits[1])
+	t.cache.EXPECT().DoLimit(nil, request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0},
+			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0}})
+	response, err = service.ShouldRateLimit(nil, request)
+	common.AssertProtoEqual(
+		t.assert,
+		&pb.RateLimitResponse{
+			OverallCode: pb.RateLimitResponse_OVER_LIMIT,
+			Statuses: []*pb.RateLimitResponse_DescriptorStatus{
+				{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0},
+				{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0},
+			},
+			ResponseHeadersToAdd: []*core.HeaderValue{
+				{Key: "A-Ratelimit-Limit", Value: "10"},
+				{Key: "A-Ratelimit-Remaining", Value: "0"},
+				{Key: "A-Ratelimit-Reset", Value: "58"},
+			},
+		},
+		response)
+	t.assert.Nil(err)
+
+	t.assert.EqualValues(2, t.statStore.NewCounter("config_load_success").Value())
+	t.assert.EqualValues(1, t.statStore.NewCounter("config_load_error").Value())
+}
+
 func TestEmptyDomain(test *testing.T) {
 	t := commonSetup(test)
 	defer t.controller.Finish()
@@ -233,7 +331,7 @@ func TestInitialLoadError(test *testing.T) {
 		func([]config.RateLimitConfigToLoad, stats.Manager) {
 			panic(config.RateLimitConfigError("load error"))
 		})
-	service := ratelimit.NewService(t.runtime, t.cache, t.configLoader, t.statsManager, true)
+	service := ratelimit.NewService(t.runtime, t.cache, t.configLoader, t.statsManager, true, ratelimit.StdClock{})
 
 	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
 	response, err := service.ShouldRateLimit(nil, request)

--- a/test/service/ratelimit_test.go
+++ b/test/service/ratelimit_test.go
@@ -191,6 +191,12 @@ func TestServiceWithCustomHeaders(test *testing.T) {
 	os.Setenv("LIMIT_LIMIT_HEADER", "A-Ratelimit-Limit")
 	os.Setenv("LIMIT_REMAINING_HEADER", "A-Ratelimit-Remaining")
 	os.Setenv("LIMIT_RESET_HEADER", "A-Ratelimit-Reset")
+	defer func() {
+		os.Unsetenv("LIMIT_LIMIT_HEADER")
+		os.Unsetenv("LIMIT_REMAINING_HEADER")
+		os.Unsetenv("LIMIT_RESET_HEADER")
+	}()
+
 	t := commonSetup(test)
 	defer t.controller.Finish()
 	service := t.setupBasicService()


### PR DESCRIPTION
In the case where different headers is needed.

The Limit header only provides the mandatory "Limit" value and not the optional quota policy strings