### PR TITLE
Fail healthcheck when no config files loaded

### DIFF
--- a/src/server/health.go
+++ b/src/server/health.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"sync/atomic"
 	"syscall"
 
@@ -12,24 +13,30 @@ import (
 )
 
 type HealthChecker struct {
-	grpc *health.Server
-	ok   uint32
-	name string
+	sync.Mutex
+	grpc     *health.Server
+	ok       uint32
+	name     string
+	stopping bool
 }
 
+// NewHealthChecker creates health checker in NOT_SERVING mode and awaits Pass() after successful config load
 func NewHealthChecker(grpcHealthServer *health.Server, name string) *HealthChecker {
 	ret := &HealthChecker{}
-	ret.ok = 1
+	ret.ok = 0
 	ret.name = name
 
 	ret.grpc = grpcHealthServer
-	ret.grpc.SetServingStatus(ret.name, healthpb.HealthCheckResponse_SERVING)
+	ret.grpc.SetServingStatus(ret.name, healthpb.HealthCheckResponse_NOT_SERVING)
 
 	sigterm := make(chan os.Signal, 1)
 	signal.Notify(sigterm, syscall.SIGTERM)
 
 	go func() {
 		<-sigterm
+		ret.Lock()
+		defer ret.Unlock()
+		ret.stopping = true
 		atomic.StoreUint32(&ret.ok, 0)
 		ret.grpc.SetServingStatus(ret.name, healthpb.HealthCheckResponse_NOT_SERVING)
 	}()
@@ -47,8 +54,21 @@ func (hc *HealthChecker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (hc *HealthChecker) Fail() {
+	hc.Lock()
+	defer hc.Unlock()
 	atomic.StoreUint32(&hc.ok, 0)
 	hc.grpc.SetServingStatus(hc.name, healthpb.HealthCheckResponse_NOT_SERVING)
+}
+
+func (hc *HealthChecker) Pass() {
+	hc.Lock()
+	defer hc.Unlock()
+	if hc.stopping {
+		return
+	}
+
+	atomic.StoreUint32(&hc.ok, 1)
+	hc.grpc.SetServingStatus(hc.name, healthpb.HealthCheckResponse_SERVING)
 }
 
 func (hc *HealthChecker) Server() *health.Server {

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -40,6 +40,11 @@ type Server interface {
 	Runtime() loader.IFace
 
 	/**
+	 * Returns the health checker for the server.
+	 */
+	HealthChecker() *HealthChecker
+
+	/**
 	 *  Stops serving the grpc port (for integration testing).
 	 */
 	Stop()

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -169,6 +169,10 @@ func (server *server) Runtime() loader.IFace {
 	return server.runtime
 }
 
+func (server *server) HealthChecker() *HealthChecker {
+	return server.health
+}
+
 func NewServer(s settings.Settings, name string, statsManager stats.Manager, localCache *freecache.Cache, opts ...settings.Option) Server {
 	return newServer(s, name, statsManager, localCache, opts...)
 }

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -108,6 +108,7 @@ func (runner *Runner) Run() {
 		createLimiter(srv, s, localCache, runner.statsManager),
 		config.NewRateLimitConfigLoaderImpl(),
 		runner.statsManager,
+		srv.HealthChecker(),
 		s.RuntimeWatchRoot,
 		utils.NewTimeSourceImpl(),
 		s.GlobalShadowMode,

--- a/test/server/health_test.go
+++ b/test/server/health_test.go
@@ -25,6 +25,17 @@ func TestHealthCheck(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://1.2.3.4/healthcheck", nil)
 	hc.ServeHTTP(recorder, r)
 
+	if 500 != recorder.Code {
+		t.Errorf("expected code 500 actual %d", recorder.Code)
+	}
+
+	hc.Pass()
+
+	recorder = httptest.NewRecorder()
+
+	r, _ = http.NewRequest("GET", "http://1.2.3.4/healthcheck", nil)
+	hc.ServeHTTP(recorder, r)
+
 	if 200 != recorder.Code {
 		t.Errorf("expected code 200 actual %d", recorder.Code)
 	}
@@ -57,6 +68,13 @@ func TestGrpcHealthCheck(t *testing.T) {
 	}
 
 	res, _ := grpcHealthServer.Check(context.Background(), req)
+	if healthpb.HealthCheckResponse_NOT_SERVING != res.Status {
+		t.Errorf("expected status NOT_SERVING actual %v", res.Status)
+	}
+
+	hc.Pass()
+
+	res, _ = grpcHealthServer.Check(context.Background(), req)
 	if healthpb.HealthCheckResponse_SERVING != res.Status {
 		t.Errorf("expected status SERVING actual %v", res.Status)
 	}


### PR DESCRIPTION
To improve ready handling of the healthcheck, await a config to be loaded before
passing the health check or if there are no config files to load. Once a config
file is loaded pass the healthcheck.

Add a Pass() method to the HealthChecker and start it in a failed state until
a config file is successfully loaded.

Signed-off-by: James Fish <jfish@pinterest.com>