### PR TITLE
Do not panic on debug /rlconfig if no config loaded

### DIFF
--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -117,8 +117,7 @@ func (runner *Runner) Run() {
 		"/rlconfig",
 		"print out the currently loaded configuration for debugging",
 		func(writer http.ResponseWriter, request *http.Request) {
-			current := service.GetCurrentConfig()
-			if current != nil {
+			if current := service.GetCurrentConfig(); current != nil {
 				io.WriteString(writer, current.Dump())
 			}
 		})


### PR DESCRIPTION
Previously http handler panics if config did not load as `config == nil`

Signed-off-by: James Fish <jfish@pinterest.com>