### PR TITLE
Support for "Memory" backend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ descriptors:
       requests_per_unit: 100
 ```
 
-For an unlimited descriptor, the request will not be sent to the underlying cache (Redis/Memcached), but will be quickly returned locally by the ratelimit instance.
+For an unlimited descriptor, the request will not be sent to the underlying cache (Redis/Memcached/Memory), but will be quickly returned locally by the ratelimit instance.
 This can be useful for collecting statistics, or if one wants to define a descriptor that has no limit but the client wants to distinguish between such descriptor and one that does not exist.
 
 The return value for unlimited descriptors will be an OK status code with the LimitRemaining field set to MaxUint32 value.

--- a/src/limiter/base_limiter.go
+++ b/src/limiter/base_limiter.go
@@ -43,7 +43,7 @@ func NewRateLimitInfo(limit *config.RateLimit, limitBeforeIncrease uint32, limit
 // Generates cache keys for given rate limit request. Each cache key is represented by a concatenation of
 // domain, descriptor and current timestamp.
 func (this *BaseRateLimiter) GenerateCacheKeys(request *pb.RateLimitRequest,
-	limits []*config.RateLimit, hitsAddend uint32) []CacheKey {
+	limits []*config.RateLimit, hitsAddend uint32) ([]CacheKey, int64) {
 	assert.Assert(len(request.Descriptors) == len(limits))
 	cacheKeys := make([]CacheKey, len(request.Descriptors))
 	now := this.timeSource.UnixNow()
@@ -56,7 +56,7 @@ func (this *BaseRateLimiter) GenerateCacheKeys(request *pb.RateLimitRequest,
 			limits[i].Stats.TotalHits.Add(uint64(hitsAddend))
 		}
 	}
-	return cacheKeys
+	return cacheKeys, now
 }
 
 // Returns `true` in case local cache is enabled and contains value for provided cache key, `false` otherwise.

--- a/src/memcached/cache_impl.go
+++ b/src/memcached/cache_impl.go
@@ -66,7 +66,7 @@ func (this *rateLimitMemcacheImpl) DoLimit(
 	hitsAddend := utils.Max(1, request.HitsAddend)
 
 	// First build a list of all cache keys that we are actually going to hit.
-	cacheKeys := this.baseRateLimiter.GenerateCacheKeys(request, limits, hitsAddend)
+	cacheKeys, _ := this.baseRateLimiter.GenerateCacheKeys(request, limits, hitsAddend)
 
 	isOverLimitWithLocalCache := make([]bool, len(request.Descriptors))
 

--- a/src/memory/cache_impl.go
+++ b/src/memory/cache_impl.go
@@ -1,0 +1,88 @@
+package memory
+
+import (
+	"github.com/coocood/freecache"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/src/limiter"
+	"github.com/envoyproxy/ratelimit/src/settings"
+	"github.com/envoyproxy/ratelimit/src/stats"
+	"github.com/envoyproxy/ratelimit/src/utils"
+	gostats "github.com/lyft/gostats"
+	"golang.org/x/net/context"
+	"math/rand"
+	"sync"
+)
+
+type keyCounters struct {
+	dividerCounters    map[int64]map[string]uint32 // divider to (key to counter)
+	dividerKeySegments map[int64]int64             // divider to keySegment
+	segmentLock        sync.Mutex
+}
+
+type memoryCacheImpl struct {
+	baseRateLimiter *limiter.BaseRateLimiter
+	counters        keyCounters
+}
+
+func (this *keyCounters) update(unit pb.RateLimitResponse_RateLimit_Unit, now int64, keyName string, hitsAddend uint32) (uint32, uint32) {
+	divider := utils.UnitToDivider(unit)
+	keySegment := (now / divider) * divider
+
+	this.segmentLock.Lock()
+	currentKeySegment := this.dividerKeySegments[divider]
+	if currentKeySegment == 0 {
+		this.dividerKeySegments[divider] = keySegment
+	} else if currentKeySegment != keySegment {
+		this.dividerKeySegments[divider] = keySegment
+		this.dividerCounters[divider] = make(map[string]uint32)
+	}
+
+	counters := this.dividerCounters[keySegment]
+	if counters == nil {
+		counters = make(map[string]uint32)
+		this.dividerCounters[keySegment] = counters
+	}
+	limitBeforeIncrease := counters[keyName]
+	limitAfterIncrease := limitBeforeIncrease + hitsAddend
+	counters[keyName] = limitAfterIncrease
+	this.segmentLock.Unlock()
+
+	return limitBeforeIncrease, limitAfterIncrease
+}
+
+func (this *memoryCacheImpl) DoLimit(
+	ctx context.Context,
+	request *pb.RateLimitRequest,
+	limits []*config.RateLimit) []*pb.RateLimitResponse_DescriptorStatus {
+
+	result := make([]*pb.RateLimitResponse_DescriptorStatus, len(limits))
+	hitsAddend := utils.Max(1, request.HitsAddend)
+	cacheKeys, now := this.baseRateLimiter.GenerateCacheKeys(request, limits, hitsAddend)
+
+	for idx, limit := range limits {
+		keyName := cacheKeys[idx].Key
+		var limitBeforeIncrease, limitAfterIncrease uint32
+		if limit != nil {
+			limitBeforeIncrease, limitAfterIncrease = this.counters.update(limit.Limit.Unit, now, keyName, hitsAddend)
+		} else {
+			limitBeforeIncrease, limitAfterIncrease = 0, 1
+		}
+
+		limitInfo := limiter.NewRateLimitInfo(limit, limitBeforeIncrease, limitAfterIncrease, 0, 0)
+		result[idx] = this.baseRateLimiter.GetResponseDescriptorStatus(keyName,
+			limitInfo, false, request.HitsAddend)
+	}
+
+	return result
+}
+
+func (this *memoryCacheImpl) Flush() {}
+
+func NewRateLimiterCacheImplFromSettings(s settings.Settings, timeSource utils.TimeSource, jitterRand *rand.Rand,
+	localCache *freecache.Cache, scope gostats.Scope, statsManager stats.Manager) limiter.RateLimitCache {
+	return &memoryCacheImpl{
+		baseRateLimiter: limiter.NewBaseRateLimit(timeSource, jitterRand, s.ExpirationJitterMaxSeconds, localCache, s.NearLimitRatio, s.CacheKeyPrefix, statsManager),
+		counters:        keyCounters{segmentLock: sync.Mutex{}, dividerCounters: make(map[int64]map[string]uint32), dividerKeySegments: make(map[int64]int64)},
+	}
+}

--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -41,7 +41,7 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 	hitsAddend := utils.Max(1, request.HitsAddend)
 
 	// First build a list of all cache keys that we are actually going to hit.
-	cacheKeys := this.baseRateLimiter.GenerateCacheKeys(request, limits, hitsAddend)
+	cacheKeys, _ := this.baseRateLimiter.GenerateCacheKeys(request, limits, hitsAddend)
 
 	isOverLimitWithLocalCache := make([]bool, len(request.Descriptors))
 	results := make([]uint32, len(request.Descriptors))

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"github.com/envoyproxy/ratelimit/src/memory"
 	"io"
 	"math/rand"
 	"net/http"
@@ -61,6 +62,14 @@ func createLimiter(srv server.Server, s settings.Settings, localCache *freecache
 		)
 	case "memcache":
 		return memcached.NewRateLimitCacheImplFromSettings(
+			s,
+			utils.NewTimeSourceImpl(),
+			rand.New(utils.NewLockedSource(time.Now().Unix())),
+			localCache,
+			srv.Scope(),
+			statsManager)
+	case "memory":
+		return memory.NewRateLimiterCacheImplFromSettings(
 			s,
 			utils.NewTimeSourceImpl(),
 			rand.New(utils.NewLockedSource(time.Now().Unix())),

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -172,6 +172,12 @@ func TestBasicReloadConfig(t *testing.T) {
 	})
 }
 
+func makeSimpleMemorySettings() settings.Settings {
+	s := defaultSettings()
+	s.BackendType = "memory"
+	return s
+}
+
 func makeSimpleMemcacheSettings(memcachePorts []int, localCacheSize int) settings.Settings {
 	s := defaultSettings()
 	var memcacheHostAndPort []string
@@ -195,6 +201,13 @@ func TestBasicConfigMemcache(t *testing.T) {
 		cacheSettings.CacheKeyPrefix = "prefix:"
 		t.Run("MemcacheWithPrefix", testBasicConfig(cacheSettings))
 	})
+}
+
+func TestBasicConfigMemory(t *testing.T) {
+	t.Run("Memory", testBasicConfig(makeSimpleMemorySettings()))
+	cacheSettings := makeSimpleMemorySettings()
+	cacheSettings.CacheKeyPrefix = "prefix:"
+	t.Run("MemoryWithPrefix", testBasicConfig(cacheSettings))
 }
 
 func TestConfigMemcacheWithMaxIdleConns(t *testing.T) {

--- a/test/limiter/base_limiter_test.go
+++ b/test/limiter/base_limiter_test.go
@@ -31,7 +31,7 @@ func TestGenerateCacheKeys(t *testing.T) {
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false)}
 	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
-	cacheKeys := baseRateLimit.GenerateCacheKeys(request, limits, 1)
+	cacheKeys, _ := baseRateLimit.GenerateCacheKeys(request, limits, 1)
 	assert.Equal(1, len(cacheKeys))
 	assert.Equal("domain_key_value_1234", cacheKeys[0].Key)
 	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
@@ -50,7 +50,7 @@ func TestGenerateCacheKeysPrefix(t *testing.T) {
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false)}
 	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
-	cacheKeys := baseRateLimit.GenerateCacheKeys(request, limits, 1)
+	cacheKeys, _ := baseRateLimit.GenerateCacheKeys(request, limits, 1)
 	assert.Equal(1, len(cacheKeys))
 	assert.Equal("prefix:domain_key_value_1234", cacheKeys[0].Key)
 	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())

--- a/test/memory/cache_impl_test.go
+++ b/test/memory/cache_impl_test.go
@@ -1,0 +1,136 @@
+package redis_test
+
+import (
+	"github.com/envoyproxy/ratelimit/src/memory"
+	"github.com/envoyproxy/ratelimit/src/settings"
+	"math/rand"
+	"testing"
+
+	"github.com/envoyproxy/ratelimit/test/mocks/stats"
+
+	"github.com/mediocregopher/radix/v3"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	gostats "github.com/lyft/gostats"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/utils"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/ratelimit/test/common"
+	mock_utils "github.com/envoyproxy/ratelimit/test/mocks/utils"
+)
+
+func pipeAppend(pipeline redis.Pipeline, rcv interface{}, cmd, key string, args ...interface{}) redis.Pipeline {
+	return append(pipeline, radix.FlatCmd(rcv, cmd, key, args...))
+}
+
+func TestMemory(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	settings := settings.Settings{ExpirationJitterMaxSeconds: 0, NearLimitRatio: 0.8, CacheKeyPrefix: ""}
+	cache := memory.NewRateLimiterCacheImplFromSettings(settings, timeSource, rand.New(rand.NewSource(1)), nil, nil, sm)
+
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false)}
+
+	assert.Equal(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 9, DurationUntilReset: utils.CalculateReset(&limits[0].Limit.Unit, timeSource)}},
+		cache.DoLimit(nil, request, limits))
+	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
+	assert.Equal(uint64(1), limits[0].Stats.WithinLimit.Value())
+
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+
+	request = common.NewRateLimitRequest(
+		"domain",
+		[][][2]string{
+			{{"key2", "value2"}},
+			{{"key2", "value2"}, {"subkey2", "subvalue2"}},
+		}, 11)
+	limits = []*config.RateLimit{
+		nil,
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key2_value2_subkey2_subvalue2"), false, false),
+	}
+
+	assert.Equal(
+		[]*pb.RateLimitResponse_DescriptorStatus{
+			{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0},
+			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0, DurationUntilReset: utils.CalculateReset(&limits[1].Limit.Unit, timeSource)},
+		},
+		cache.DoLimit(nil, request, limits))
+	assert.Equal(uint64(11), limits[1].Stats.TotalHits.Value())
+	assert.Equal(uint64(1), limits[1].Stats.OverLimit.Value())
+	assert.Equal(uint64(2), limits[1].Stats.NearLimit.Value())
+	assert.Equal(uint64(0), limits[1].Stats.WithinLimit.Value())
+
+	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(5)
+
+	request = common.NewRateLimitRequest(
+		"domain",
+		[][][2]string{
+			{{"key3", "value3"}},
+			{{"key3", "value3"}, {"subkey3", "subvalue3"}},
+		}, 11)
+	limits = []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_HOUR, sm.NewStats("key3_value3"), false, false),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_DAY, sm.NewStats("key3_value3_subkey3_subvalue3"), false, false),
+	}
+	assert.Equal(
+		[]*pb.RateLimitResponse_DescriptorStatus{
+			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0, DurationUntilReset: utils.CalculateReset(&limits[0].Limit.Unit, timeSource)},
+			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0, DurationUntilReset: utils.CalculateReset(&limits[1].Limit.Unit, timeSource)},
+		},
+		cache.DoLimit(nil, request, limits))
+	assert.Equal(uint64(11), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(2), limits[0].Stats.NearLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.WithinLimit.Value())
+	assert.Equal(uint64(11), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(2), limits[0].Stats.NearLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.WithinLimit.Value())
+}
+
+func TestNearLimit(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	settings := settings.Settings{ExpirationJitterMaxSeconds: 0, NearLimitRatio: 0.8, CacheKeyPrefix: ""}
+	cache := memory.NewRateLimiterCacheImplFromSettings(settings, timeSource, rand.New(rand.NewSource(1)), nil, nil, sm)
+
+	// Test Near Limit Stats. Under Near Limit Ratio
+	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(3)
+
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key4", "value4"}}}, 11)
+
+	limits := []*config.RateLimit{
+		config.NewRateLimit(15, pb.RateLimitResponse_RateLimit_HOUR, sm.NewStats("key4_value4"), false, false),
+	}
+
+	assert.Equal(
+		[]*pb.RateLimitResponse_DescriptorStatus{
+			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 4, DurationUntilReset: utils.CalculateReset(&limits[0].Limit.Unit, timeSource)},
+		},
+		cache.DoLimit(nil, request, limits))
+	assert.Equal(uint64(11), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
+	assert.Equal(uint64(11), limits[0].Stats.WithinLimit.Value())
+}


### PR DESCRIPTION
This is the implementation of pure memory-based backend. It is useful in situations where we do not want to have a (heavier) memcached/redis backend, but still want to use global rate limiting functionality.