### PR TITLE
Fix memcached shards being inconsistent when looking up hosts by SRV

### DIFF
--- a/src/srv/srv_test.go
+++ b/src/srv/srv_test.go
@@ -1,0 +1,18 @@
+package srv
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mockAddrsLookup(service, proto, name string) (cname string, addrs []*net.SRV, err error) {
+	return "ignored", []*net.SRV{{"z", 1, 0, 0}, {"z", 0, 0, 0}, {"a", 9001, 0, 0}}, nil
+}
+
+func TestLookupServerStringsFromSrvReturnsServersSorted(t *testing.T) {
+	targets, err := lookupServerStringsFromSrv("_something._tcp.example.org.", mockAddrsLookup)
+	assert.Nil(t, err)
+	assert.Equal(t, targets, []string{"a:9001", "z:0", "z:1"})
+}


### PR DESCRIPTION
SRV records return hosts in an arbitrary order, but the memcached
library in use relies on the order of the hosts for sharding (i.e.
the i-th host passed to the client will host shard i). If multiple
ratelimitinstances looked up the same set of memcached hosts via
SRV they could recieve them in different orders and begin sharding
descriptor keys to separate hosts, leading to non-global rate
limiting (as the sum of hits would be split accross hosts, meaning
each ratelimit instance would have an incomplete total of hits).

This fixes the issue by sorting the hosts returned by the SRV
lexicographically. Both weight and priority are ignored; weight
was not previously handled and priority is not possible to handle
(as the memcached library cannot take a priority into account when
determining shards).