### PR TITLE
TLS config pointer is never nil which regresses TLS Support

### DIFF
--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -71,11 +71,7 @@ func NewClientImpl(scope stats.Scope, useTls bool, auth, redisSocketType, redisT
 		var dialOpts []radix.DialOpt
 
 		if useTls {
-			if tlsConfig != nil {
-				dialOpts = append(dialOpts, radix.DialUseTLS(tlsConfig))
-			} else {
-				dialOpts = append(dialOpts, radix.DialUseTLS(&tls.Config{}))
-			}
+			dialOpts = append(dialOpts, radix.DialUseTLS(tlsConfig))
 		}
 
 		if auth != "" {

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -109,6 +109,7 @@ type Option func(*Settings)
 
 func NewSettings() Settings {
 	var s Settings
+	s.RedisTlsConfig = &tls.Config{}
 
 	err := envconfig.Process("", &s)
 	if err != nil {

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -109,9 +109,13 @@ type Option func(*Settings)
 
 func NewSettings() Settings {
 	var s Settings
+	err := envconfig.Process("", &s)
+
+	// Golang copy-by-value causes the RootCAs to no longer be nil
+	// which isn't the expected default behavior of continuing to use system roots
+	// so let's just initialize to what we want the correct value to be.
 	s.RedisTlsConfig = &tls.Config{}
 
-	err := envconfig.Process("", &s)
 	if err != nil {
 		panic(err)
 	}

--- a/src/settings/settings_test.go
+++ b/src/settings/settings_test.go
@@ -1,8 +1,9 @@
 package settings
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSettingsTlsConfigUnmodified(t *testing.T) {

--- a/src/settings/settings_test.go
+++ b/src/settings/settings_test.go
@@ -1,0 +1,12 @@
+package settings
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSettingsTlsConfigUnmodified(t *testing.T) {
+	settings := NewSettings()
+	assert.NotNil(t, settings.RedisTlsConfig)
+	assert.Nil(t, settings.RedisTlsConfig.RootCAs)
+}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration_test

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -3,6 +3,7 @@
 package integration_test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"math/rand"
@@ -223,7 +224,7 @@ func TestMultiNodeMemcache(t *testing.T) {
 
 func testBasicConfigAuthTLS(perSecond bool, local_cache_size int) func(*testing.T) {
 	s := makeSimpleRedisSettings(16381, 16382, perSecond, local_cache_size)
-	s.RedisTlsConfig = nil
+	s.RedisTlsConfig = &tls.Config{}
 	s.RedisAuth = "password123"
 	s.RedisTls = true
 	s.RedisPerSecondAuth = "password123"


### PR DESCRIPTION
Fixes regression in #289  as tlsConfigPointer is never nil
Fixes issue #303 which allows the default tlsConfig for Redis Client