### PR TITLE
Upgrade to Golang v1.17 and Alpine 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14 AS build
+FROM golang:1.17 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org
@@ -10,6 +10,6 @@ COPY script script
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit -ldflags="-w -s" -v github.com/envoyproxy/ratelimit/src/service_cmd
 
-FROM alpine:3.11 AS final
+FROM alpine:3.15 AS final
 RUN apk --no-cache add ca-certificates
 COPY --from=build /go/bin/ratelimit /bin/ratelimit

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,5 +1,5 @@
 # Running this docker image runs the integration tests.
-FROM golang:1.14
+FROM golang:1.17
 
 RUN apt-get update -y && apt-get install sudo stunnel4 redis memcached -y && rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ redis-per-second.conf:
 bootstrap_redis_tls: redis.conf redis-per-second.conf
 	openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" \
+    -addext "subjectAltName = DNS:localhost" \
     -keyout key.pem  -out cert.pem
 	cat key.pem cert.pem > private.pem
 	sudo cp cert.pem /usr/local/share/ca-certificates/redis-stunnel.crt

--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,12 @@
 module github.com/envoyproxy/ratelimit
 
-go 1.14
+go 1.17
 
 require (
 	github.com/alicebob/miniredis/v2 v2.11.4
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
-	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/coocood/freecache v1.1.0
 	github.com/envoyproxy/go-control-plane v0.9.7
-	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/golang/mock v1.4.1
 	github.com/golang/protobuf v1.4.2
 	github.com/gorilla/mux v1.7.4-0.20191121170500-49c01487a141
@@ -18,12 +16,26 @@ require (
 	github.com/lyft/gostats v0.4.0
 	github.com/mediocregopher/radix/v3 v3.5.1
 	github.com/sirupsen/logrus v1.6.0
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
+	google.golang.org/grpc v1.27.0
+	gopkg.in/yaml.v2 v2.3.0
+)
+
+require (
+	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb // indirect
 	golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e // indirect
 	golang.org/x/text v0.3.3-0.20191122225017-cbf43d21aaeb // indirect
-	google.golang.org/grpc v1.27.0
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
-	gopkg.in/yaml.v2 v2.3.0
 )

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package integration_test


### PR DESCRIPTION
Signed-off-by: Vito Sabella <vito@axon.com>

Upgrade to Golang v1.17
Upgrade to Alpine 3.15 for base image
Fix test x509 certificate to include SubjectAlternativeName (for go v1.17 compatibility)

The reason is to fix the following CVEs identified by Twistlock (Prisma Cloud Container Security)
https://www.paloaltonetworks.com/prisma/cloud/container-security

**Before**
```
Vulnerabilities
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
|      CVE       | SEVERITY | CVSS | PACKAGE | VERSION |          STATUS          |  PUBLISHED  | DISCOVERED |                    DESCRIPTION                     | TRIGGERED FAILURE |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-38297 | critical | 9.80 | go      | 1.14.15 | fixed in 1.17.2, 1.16.9  | > 3 months  | < 1 hour   | Go before 1.16.9 and 1.17.x before 1.17.2 has a    | Yes               |
|                |          |      |         |         | > 3 months ago           |             |            | Buffer Overflow via large arguments in a function  |                   |
|                |          |      |         |         |                          |             |            | invocation from a WASM module, when GOARCH=wasm    |                   |
|                |          |      |         |         |                          |             |            | GOOS...                                            |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-44716 | high     | 7.50 | go      | 1.14.15 | fixed in 1.17.5, 1.16.12 | 23 days     | < 1 hour   | net/http in Go before 1.16.12 and 1.17.x before    | Yes               |
|                |          |      |         |         | 23 days ago              |             |            | 1.17.5 allows uncontrolled memory consumption      |                   |
|                |          |      |         |         |                          |             |            | in the header canonicalization cache via HTTP/2    |                   |
|                |          |      |         |         |                          |             |            | requests...                                        |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-41772 | high     | 7.50 | go      | 1.14.15 | fixed in 1.17.3, 1.16.10 | 77 days     | < 1 hour   | Go before 1.16.10 and 1.17.x before 1.17.3 allows  | Yes               |
|                |          |      |         |         | 77 days ago              |             |            | an archive/zip Reader.Open panic via a crafted     |                   |
|                |          |      |         |         |                          |             |            | ZIP archive containing an invalid name or an empty |                   |
|                |          |      |         |         |                          |             |            | fi...                                              |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-41771 | high     | 7.50 | go      | 1.14.15 | fixed in 1.17.3, 1.16.10 | 77 days     | < 1 hour   | ImportedSymbols in debug/macho (for Open or        | Yes               |
|                |          |      |         |         | 77 days ago              |             |            | OpenFat) in Go before 1.16.10 and 1.17.x before    |                   |
|                |          |      |         |         |                          |             |            | 1.17.3 Accesses a Memory Location After the End of |                   |
|                |          |      |         |         |                          |             |            | a Buffe...                                         |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-33198 | high     | 7.50 | go      | 1.14.15 | fixed in 1.16.5, 1.15.13 | > 5 months  | < 1 hour   | In Go before 1.15.13 and 1.16.x before 1.16.5,     | Yes               |
|                |          |      |         |         | > 5 months ago           |             |            | there can be a panic for a large exponent to the   |                   |
|                |          |      |         |         |                          |             |            | math/big.Rat SetString or UnmarshalText method.    |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-33196 | high     | 7.50 | go      | 1.14.15 | fixed in 1.16.5, 1.15.13 | > 5 months  | < 1 hour   | In archive/zip in Go before 1.15.13 and 1.16.x     | Yes               |
|                |          |      |         |         | > 5 months ago           |             |            | before 1.16.5, a crafted file count (in an         |                   |
|                |          |      |         |         |                          |             |            | archive\'s header) can cause a NewReader or        |                   |
|                |          |      |         |         |                          |             |            | OpenReader panic...                                |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-33194 | high     | 7.50 | go      | 1.14.15 |                          | > 8 months  | < 1 hour   | golang.org/x/net before                            | Yes               |
|                |          |      |         |         |                          |             |            | v0.0.0-20210520170846-37e1c6afe023 allows          |                   |
|                |          |      |         |         |                          |             |            | attackers to cause a denial of service (infinite   |                   |
|                |          |      |         |         |                          |             |            | loop) via crafted ParseFragment inp...             |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-29923 | high     | 7.50 | go      | 1.14.15 | fixed in 1.17            | > 5 months  | < 1 hour   | Go before 1.17 does not properly consider          | Yes               |
|                |          |      |         |         | > 5 months ago           |             |            | extraneous zero characters at the beginning of     |                   |
|                |          |      |         |         |                          |             |            | an IP address octet, which (in some situations)    |                   |
|                |          |      |         |         |                          |             |            | allows attack...                                   |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-27918 | high     | 7.50 | go      | 1.14.15 | fixed in 1.16.1, 1.15.9  | > 10 months | < 1 hour   | encoding/xml in Go before 1.15.9 and 1.16.x        | Yes               |
|                |          |      |         |         | > 10 months ago          |             |            | before 1.16.1 has an infinite loop if a custom     |                   |
|                |          |      |         |         |                          |             |            | TokenReader (for xml.NewTokenDecoder) returns EOF  |                   |
|                |          |      |         |         |                          |             |            | in the mi...                                       |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-33195 | high     | 7.30 | go      | 1.14.15 | fixed in 1.16.5, 1.15.13 | > 5 months  | < 1 hour   | Go before 1.15.13 and 1.16.x before 1.16.5 has     | Yes               |
|                |          |      |         |         | > 5 months ago           |             |            | functions for DNS lookups that do not validate     |                   |
|                |          |      |         |         |                          |             |            | replies from DNS servers, and thus a return value  |                   |
|                |          |      |         |         |                          |             |            | may co...                                          |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-34558 | medium   | 6.50 | go      | 1.14.15 |                          | > 6 months  | < 1 hour   | The crypto/tls package of Go through 1.16.5 does   | No                |
|                |          |      |         |         |                          |             |            | not properly assert that the type of public key    |                   |
|                |          |      |         |         |                          |             |            | in an X.509 certificate matches the expected type  |                   |
|                |          |      |         |         |                          |             |            | whe...                                             |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-36221 | medium   | 5.90 | go      | 1.14.15 | fixed in 1.16.7, 1.15.15 | > 5 months  | < 1 hour   | Go before 1.15.15 and 1.16.x before 1.16.7         | No                |
|                |          |      |         |         | > 5 months ago           |             |            | has a race condition that can lead to a            |                   |
|                |          |      |         |         |                          |             |            | net/http/httputil ReverseProxy panic upon an       |                   |
|                |          |      |         |         |                          |             |            | ErrAbortHandler abort.                             |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-31525 | medium   | 5.90 | go      | 1.14.15 | fixed in 1.16.4, 1.15.12 | > 8 months  | < 1 hour   | net/http in Go before 1.15.12 and 1.16.x before    | No                |
|                |          |      |         |         | > 8 months ago           |             |            | 1.16.4 allows remote attackers to cause a          |                   |
|                |          |      |         |         |                          |             |            | denial of service (panic) via a large header to    |                   |
|                |          |      |         |         |                          |             |            | ReadRequest ...                                    |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2020-29510 | medium   | 5.60 | go      | 1.14.15 |                          | > 1 years   | < 1 hour   | The encoding/xml package in Go versions 1.15 and   | No                |
|                |          |      |         |         |                          |             |            | earlier does not correctly preserve the semantics  |                   |
|                |          |      |         |         |                          |             |            | of directives during tokenization round-trips,     |                   |
|                |          |      |         |         |                          |             |            | whic...                                            |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+
| CVE-2021-33197 | medium   | 5.30 | go      | 1.14.15 | fixed in 1.16.5, 1.15.13 | > 5 months  | < 1 hour   | In Go before 1.15.13 and 1.16.x before 1.16.5,     | No                |
|                |          |      |         |         | > 5 months ago           |             |            | some configurations of ReverseProxy (from          |                   |
|                |          |      |         |         |                          |             |            | net/http/httputil) result in a situation where an  |                   |
|                |          |      |         |         |                          |             |            | attacker is...                                     |                   |
+----------------+----------+------+---------+---------+--------------------------+-------------+------------+----------------------------------------------------+-------------------+

```

**After**
```
Scan results for: image envoyproxy/ratelimit:18edf9fe sha256:d08ed5d0cc10500b09cf266c16a886080b95c6e1656b4fe21ad2cf1b665dfbd2

Vulnerabilities found for image envoyproxy/ratelimit:18edf9fe: total - 0, critical - 0, high - 0, medium - 0, low - 0
Vulnerability threshold check results: PASS
```