### PR TITLE
Produce multi-arch Docker image for x86/arm64

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,11 +18,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: build and push docker image
         run: |
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          VERSION=master make docker_push     # Push image tagged with "master"
-          make docker_push                    # Push image tagged with git sha
+          VERSION=master make docker_multiarch_push     # Push image tagged with "master"
+          make docker_multiarch_push                    # Push image tagged with git sha
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,10 +17,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: build and push docker image
         run: |
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          make docker_push
+          make docker_multiarch_push
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ MODULE = github.com/envoyproxy/ratelimit
 GIT_REF = $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short=8 --verify HEAD)
 VERSION ?= $(GIT_REF)
 SHELL := /bin/bash
+BUILDX_PLATFORMS := linux/amd64,linux/arm64/v8
 
 .PHONY: bootstrap
 bootstrap: ;
@@ -114,6 +115,14 @@ docker_image: docker_tests
 .PHONY: docker_push
 docker_push: docker_image
 	docker push $(IMAGE):$(VERSION)
+
+.PHONY: docker_multiarch_image
+docker_multiarch_image: docker_tests
+	docker buildx build -t $(IMAGE):$(VERSION) --platform $(BUILDX_PLATFORMS) .
+
+.PHONY: docker_multiarch_push
+docker_multiarch_push: docker_multiarch_image
+	docker buildx build -t $(IMAGE):$(VERSION) --platform $(BUILDX_PLATFORMS) --push .
 
 .PHONY: integration_tests
 integration_tests:


### PR DESCRIPTION
Produce builds for arm64 in addition to x86_64 on merge to main or upon release.

Actions tested successfully in my GitHub account, publishing to [my personal Docker Hub account](https://hub.docker.com/repository/docker/otterley/ratelimit/tags).