### PR TITLE
Allow to set key-pair for the Redis TLS connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ key.pem
 private.pem
 redis-per-second.conf
 redis.conf
+redis-verify-peer.conf
+
+# Directories created by "test_with_redis" make target.
+63*
+26*

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ GIT_REF = $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse
 VERSION ?= $(GIT_REF)
 SHELL := /bin/bash
 BUILDX_PLATFORMS := linux/amd64,linux/arm64/v8
+# Root dir returns absolute path of current directory. It has a trailing "/".
+PROJECT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+export PROJECT_DIR
 
 .PHONY: bootstrap
 bootstrap: ;
@@ -26,15 +29,26 @@ pid = /var/run/stunnel-2.pid
 accept = 127.0.0.1:16382
 connect = 127.0.0.1:6382
 endef
+define REDIS_VERIFY_PEER_STUNNEL
+cert = private.pem
+pid = /var/run/stunnel-3.pid
+[redis]
+CAfile = cert.pem
+accept = 127.0.0.1:16361
+connect = 127.0.0.1:6361
+endef
 export REDIS_STUNNEL
 export REDIS_PER_SECOND_STUNNEL
+export REDIS_VERIFY_PEER_STUNNEL
 redis.conf:
 	echo "$$REDIS_STUNNEL" >> $@
 redis-per-second.conf:
 	echo "$$REDIS_PER_SECOND_STUNNEL" >> $@
+redis-verify-peer.conf:
+	echo "$$REDIS_VERIFY_PEER_STUNNEL" >> $@
 
 .PHONY: bootstrap_redis_tls
-bootstrap_redis_tls: redis.conf redis-per-second.conf
+bootstrap_redis_tls: redis.conf redis-per-second.conf redis-verify-peer.conf
 	openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 \
     -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=localhost" \
     -addext "subjectAltName = DNS:localhost" \
@@ -45,6 +59,7 @@ bootstrap_redis_tls: redis.conf redis-per-second.conf
 	sudo update-ca-certificates
 	sudo stunnel redis.conf
 	sudo stunnel redis-per-second.conf
+	sudo stunnel redis-verify-peer.conf
 .PHONY: docs_format
 docs_format:
 	script/docs_check_format
@@ -77,6 +92,7 @@ tests: compile
 tests_with_redis: bootstrap_redis_tls tests_unit
 	redis-server --port 6381 --requirepass password123 &
 	redis-server --port 6382 --requirepass password123 &
+	redis-server --port 6361 --requirepass password123 &
 
 	redis-server --port 6392 --requirepass password123 &
 	redis-server --port 6393 --requirepass password123 --slaveof 127.0.0.1 6392 --masterauth password123 &

--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@ Ratelimit uses Redis as its caching layer. Ratelimit supports two operation mode
 As well Ratelimit supports TLS connections and authentication. These can be configured using the following environment variables:
 
 1. `REDIS_TLS` & `REDIS_PERSECOND_TLS`: set to `"true"` to enable a TLS connection for the specific connection type.
+1. `REDIS_TLS_CLIENT_CERT`, `REDIS_TLS_CLIENT_KEY`, and `REDIS_TLS_CACERT` to provides files to specify a TLS connection configuration to Redis server that requires client certificate verification. (This is effective when `REDIS_TLS` or `REDIS_PERSECOND_TLS` is set to to `"true"`).
 1. `REDIS_AUTH` & `REDIS_PERSECOND_AUTH`: set to `"password"` to enable authentication to the redis host.
 1. `CACHE_KEY_PREFIX`: a string to prepend to all cache keys
 

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -140,8 +140,11 @@ func GrpcUnaryInterceptor(i grpc.UnaryServerInterceptor) Option {
 }
 
 // TlsConfigFromFiles sets the TLS config from the provided files.
-func TlsConfigFromFiles(cert, key, cacert string) Option {
+func TlsConfigFromFiles(cert, key, caCert string) Option {
 	return func(s *Settings) {
+		if s.RedisTlsConfig == nil {
+			s.RedisTlsConfig = new(tls.Config)
+		}
 		if cert != "" && key != "" {
 			clientCert, err := tls.LoadX509KeyPair(cert, key)
 			if err != nil {
@@ -150,12 +153,12 @@ func TlsConfigFromFiles(cert, key, cacert string) Option {
 			s.RedisTlsConfig.Certificates = append(s.RedisTlsConfig.Certificates, clientCert)
 		}
 
-		if cacert != "" {
-			certpool := x509.NewCertPool()
-			if !certpool.AppendCertsFromPEM(mustReadFile(cacert)) {
+		if caCert != "" {
+			certPool := x509.NewCertPool()
+			if !certPool.AppendCertsFromPEM(mustReadFile(caCert)) {
 				panic("failed to load the provided TLS CA certificate")
 			}
-			s.RedisTlsConfig.RootCAs = certpool
+			s.RedisTlsConfig.RootCAs = certPool
 		}
 	}
 }

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -2,6 +2,9 @@ package settings
 
 import (
 	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -67,6 +70,10 @@ type Settings struct {
 	RedisTls        bool   `envconfig:"REDIS_TLS" default:"false"`
 	// TODO: Make this setting configurable out of the box instead of having to provide it through code.
 	RedisTlsConfig *tls.Config
+	// Allow to set the client certificate and key for TLS connections.
+	RedisTlsClientCert string `envconfig:"REDIS_TLS_CLIENT_CERT" default:""`
+	RedisTlsClientKey  string `envconfig:"REDIS_TLS_CLIENT_KEY" default:""`
+	RedisTlsCACert     string `envconfig:"REDIS_TLS_CACERT" default:""`
 
 	// RedisPipelineWindow sets the duration after which internal pipelines will be flushed.
 	// If window is zero then implicit pipelining will be disabled. Radix use 150us for the
@@ -109,15 +116,18 @@ type Option func(*Settings)
 
 func NewSettings() Settings {
 	var s Settings
-	err := envconfig.Process("", &s)
+	if err := envconfig.Process("", &s); err != nil {
+		panic(err)
+	}
 
 	// Golang copy-by-value causes the RootCAs to no longer be nil
 	// which isn't the expected default behavior of continuing to use system roots
 	// so let's just initialize to what we want the correct value to be.
 	s.RedisTlsConfig = &tls.Config{}
 
-	if err != nil {
-		panic(err)
+	// When we require to connect using TLS, we check if we need to connect using a provided key-pair.
+	if s.RedisTls {
+		TlsConfigFromFiles(s.RedisTlsClientCert, s.RedisTlsClientKey, s.RedisTlsCACert)(&s)
 	}
 
 	return s
@@ -127,4 +137,33 @@ func GrpcUnaryInterceptor(i grpc.UnaryServerInterceptor) Option {
 	return func(s *Settings) {
 		s.GrpcUnaryInterceptor = grpc.UnaryInterceptor(i)
 	}
+}
+
+// TlsConfigFromFiles sets the TLS config from the provided files.
+func TlsConfigFromFiles(cert, key, cacert string) Option {
+	return func(s *Settings) {
+		if cert != "" && key != "" {
+			clientCert, err := tls.LoadX509KeyPair(cert, key)
+			if err != nil {
+				panic(fmt.Errorf("failed lo load client TLS key pair: %w", err))
+			}
+			s.RedisTlsConfig.Certificates = append(s.RedisTlsConfig.Certificates, clientCert)
+		}
+
+		if cacert != "" {
+			certpool := x509.NewCertPool()
+			if !certpool.AppendCertsFromPEM(mustReadFile(cacert)) {
+				panic("failed to load the provided TLS CA certificate")
+			}
+			s.RedisTlsConfig.RootCAs = certpool
+		}
+	}
+}
+
+func mustReadFile(name string) []byte {
+	b, err := os.ReadFile(name)
+	if err != nil {
+		panic(fmt.Errorf("failed to read file: %s: %w", name, err))
+	}
+	return b
 }

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -125,8 +125,8 @@ func NewSettings() Settings {
 	// so let's just initialize to what we want the correct value to be.
 	s.RedisTlsConfig = &tls.Config{}
 
-	// When we require to connect using TLS, we check if we need to connect using a provided key-pair.
-	if s.RedisTls {
+	// When we require to connect using TLS, we check if we need to connect using the provided key-pair.
+	if s.RedisTls || s.RedisPerSecondTls {
 		TlsConfigFromFiles(s.RedisTlsClientCert, s.RedisTlsClientKey, s.RedisTlsCACert)(&s)
 	}
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 	"time"

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -242,7 +242,7 @@ func testBasicConfigAuthTLS(perSecond bool, local_cache_size int) func(*testing.
 
 func testBasicConfigAuthTLSWithClientCert(perSecond bool, local_cache_size int) func(*testing.T) {
 	// "16361" is the port of the redis server running behind stunnel with verify level 2 (the level 2
-	// verifies the peer certificate against the defined CA certificate (CAfile).
+	// verifies the peer certificate against the defined CA certificate (CAfile)).
 	// See: Makefile#REDIS_VERIFY_PEER_STUNNEL.
 	s := makeSimpleRedisSettings(16361, 16382, perSecond, local_cache_size)
 	settings.TlsConfigFromFiles(filepath.Join(projectDir, "cert.pem"), filepath.Join(projectDir, "key.pem"), filepath.Join(projectDir, "cert.pem"))(&s)


### PR DESCRIPTION
This allows setting key-pair for connecting to the Redis server which enables client certificate verification.

Test: Added a new stunnel setup (REDIS_VERIFY_PEER_STUNNEL) which sets "verify 2", hence requiring the client certificate to be sent by the client. `make tests_with_redis`.
Risk: Low, since the existing use-cases still work.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>