### PR TITLE
Add support for mTLS between envoy and the rate limiter

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: "1.18"
 
       - name: run pre-commits
         run: |

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: "1.18"
 
       - name: run pre-commits
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 AS build
+FROM golang:1.18 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,5 +1,5 @@
 # Running this docker image runs the integration tests.
-FROM golang:1.17
+FROM golang:1.18
 
 RUN apt-get update -y && apt-get install sudo stunnel4 redis memcached -y && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 - [Memcache](#memcache)
 - [Custom headers](#custom-headers)
 - [Tracing](#tracing)
+- [mTLS](#mtls)
 - [Contact](#contact)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -782,6 +783,7 @@ Ratelimit supports mTLS when Envoy sends requests to the service.
 The following environment variables control the mTLS feature:
 
 The following variables can be set to enable mTLS on the Ratelimit service.
+
 1. `GRPC_SERVER_USE_TLS` - Enables gprc connections to server over TLS
 1. `GRPC_SERVER_TLS_CERT` - Path to the file containing the server cert chain
 1. `GRPC_SERVER_TLS_KEY` - Path to the file containing the server private key
@@ -789,23 +791,24 @@ The following variables can be set to enable mTLS on the Ratelimit service.
 1. `GRPC_CLIENT_TLS_SAN` - (Optional) DNS Name to validate from the client cert during mTLS auth
 
 In the envoy config use, add the `transport_socket` section to the ratelimit service cluster config
+
 ```yaml
-    "name": "ratelimit"
-    "transport_socket":
-      "name": "envoy.transport_sockets.tls"
-      "typed_config":
-        "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"
-        "common_tls_context":
-          "tls_certificates":
-          - "certificate_chain":
-              "filename": "/opt/envoy/tls/ratelimit-client-cert.pem"
-            "private_key":
-              "filename": "/opt/envoy/tls/ratelimit-client-key.pem"
-          "validation_context":
-            "match_subject_alt_names":
-            - "exact": "ratelimit.server.dnsname"
-            "trusted_ca":
-              "filename": "/opt/envoy/tls/ratelimit-server-ca.pem"
+"name": "ratelimit"
+"transport_socket":
+  "name": "envoy.transport_sockets.tls"
+  "typed_config":
+    "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"
+    "common_tls_context":
+      "tls_certificates":
+        - "certificate_chain":
+            "filename": "/opt/envoy/tls/ratelimit-client-cert.pem"
+          "private_key":
+            "filename": "/opt/envoy/tls/ratelimit-client-key.pem"
+      "validation_context":
+        "match_subject_alt_names":
+          - "exact": "ratelimit.server.dnsname"
+        "trusted_ca":
+          "filename": "/opt/envoy/tls/ratelimit-server-ca.pem"
 ```
 
 # Contact

--- a/README.md
+++ b/README.md
@@ -764,9 +764,9 @@ docker run -d --name jaeger -p 16686:16686 -p 14250:14250 jaegertracing/all-in-o
 
 # Tracing
 
-Ratelimit supports exporting spans in OLTP format. See [OpenTelemetry](https://opentelemetry.io/) for more information.
+Ratelimit service supports exporting spans in OLTP format. See [OpenTelemetry](https://opentelemetry.io/) for more information.
 
-Theh following environment variables control the tracing feature:
+The following environment variables control the tracing feature:
 
 1. `TRACING_ENABLED` - Enables the tracing feature. Only "true" and "false"(default) are allowed in this field.
 1. `TRACING_EXPORTER_PROTOCOL` - Controls the protocol of exporter in tracing feature. Only "http"(default) and "grpc" are allowed in this field.
@@ -774,6 +774,39 @@ Theh following environment variables control the tracing feature:
 1. `TRACING_SERVICE_NAMESPACE` - Controls the service namespace appears in tracing span. The default value is empty.
 1. `TRACING_SERVICE_INSTANCE_ID` - Controls the service instance id appears in tracing span. It is recommended to put the pod name or container name in this field. The default value is a randomly generated version 4 uuid if unspecified.
 1. Other fields in [OTLP Exporter Documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md). These section needs to be correctly configured in order to enable the exporter to export span to the correct destination.
+
+# mTLS
+
+Ratelimit supports mTLS when Envoy sends requests to the service.
+
+The following environment variables control the mTLS feature:
+
+The following variables can be set to enable mTLS on the Ratelimit service.
+1. `GRPC_SERVER_USE_TLS` - Enables gprc connections to server over TLS
+1. `GRPC_SERVER_TLS_CERT` - Path to the file containing the server cert chain
+1. `GRPC_SERVER_TLS_KEY` - Path to the file containing the server private key
+1. `GRPC_CLIENT_TLS_CACERT` - Path to the file containing the client CA certificate.
+1. `GRPC_CLIENT_TLS_SAN` - (Optional) DNS Name to validate from the client cert during mTLS auth
+
+In the envoy config use, add the `transport_socket` section to the ratelimit service cluster config
+```yaml
+    "name": "ratelimit"
+    "transport_socket":
+      "name": "envoy.transport_sockets.tls"
+      "typed_config":
+        "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"
+        "common_tls_context":
+          "tls_certificates":
+          - "certificate_chain":
+              "filename": "/opt/envoy/tls/ratelimit-client-cert.pem"
+            "private_key":
+              "filename": "/opt/envoy/tls/ratelimit-client-key.pem"
+          "validation_context":
+            "match_subject_alt_names":
+            - "exact": "ratelimit.server.dnsname"
+            "trusted_ca":
+              "filename": "/opt/envoy/tls/ratelimit-server-ca.pem"
+```
 
 # Contact
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/ratelimit
 
-go 1.17
+go 1.18
 
 require (
 	github.com/alicebob/miniredis/v2 v2.11.4

--- a/go.sum
+++ b/go.sum
@@ -151,7 +151,6 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/mux v1.7.4-0.20191121170500-49c01487a141 h1:VQjjMh+uElTfioy6GnUrVrTMAiLTNF3xsrAlSwC+g8o=
 github.com/gorilla/mux v1.7.4-0.20191121170500-49c01487a141/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QGdLI4y34qQGjGWO0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
@@ -350,12 +349,9 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/client_cmd/main.go
+++ b/src/client_cmd/main.go
@@ -10,10 +10,11 @@ import (
 
 	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
-	"github.com/envoyproxy/ratelimit/src/utils"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"github.com/envoyproxy/ratelimit/src/utils"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 

--- a/src/client_cmd/main.go
+++ b/src/client_cmd/main.go
@@ -10,8 +10,10 @@ import (
 
 	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"github.com/envoyproxy/ratelimit/src/utils"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 
@@ -65,7 +67,11 @@ func main() {
 	flag.Var(
 		&descriptorsValue, "descriptors",
 		"descriptor list to query in <key>=<value>,<key>=<value>,... form")
-	oltpProtocol := flag.String("oltp_protocol", "", "protocol to use when exporting tracing span, accept http, grpc or empty (disable tracing) as value, please use OLTP environment variables to set endpoint (refer to README.MD)")
+	oltpProtocol := flag.String("oltp-protocol", "", "protocol to use when exporting tracing span, accept http, grpc or empty (disable tracing) as value, please use OLTP environment variables to set endpoint (refer to README.MD)")
+	grpcServerTlsCACert := flag.String("grpc-server-ca-file", "", "path to the server CA file for TLS connection")
+	grpcUseTLS := flag.Bool("grpc-use-tls", false, "Use TLS for connection to server")
+	grpcTlsCertFile := flag.String("grpc-cert-file", "", "path to the client cert file for TLS connection")
+	grpcTlsKeyFile := flag.String("grpc-key-file", "", "path to the client key for TLS connection")
 	flag.Parse()
 
 	flag.VisitAll(func(f *flag.Flag) {
@@ -80,12 +86,17 @@ func main() {
 			}
 		}()
 	}
-
-	conn, err := grpc.Dial(*dialString,
-		grpc.WithInsecure(),
+	dialOptions := []grpc.DialOption{
 		grpc.WithUnaryInterceptor(otelgrpc.UnaryClientInterceptor()),
 		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
-	)
+	}
+	if *grpcUseTLS {
+		tlsConfig := utils.TlsConfigFromFiles(*grpcTlsCertFile, *grpcTlsKeyFile, *grpcServerTlsCACert, utils.ServerCA)
+		dialOptions = append(dialOptions, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+	} else {
+		dialOptions = append(dialOptions, grpc.WithInsecure())
+	}
+	conn, err := grpc.Dial(*dialString, dialOptions...)
 	if err != nil {
 		fmt.Printf("error connecting: %s\n", err.Error())
 		os.Exit(1)

--- a/src/server/tls.go
+++ b/src/server/tls.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"crypto/x509"
+	"errors"
+
+	logger "github.com/sirupsen/logrus"
+)
+
+func verifyClient(clientCAPool *x509.CertPool, clientSAN string) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		for _, certs := range verifiedChains {
+			opts := x509.VerifyOptions{
+				Roots:         clientCAPool,
+				Intermediates: x509.NewCertPool(),
+				DNSName:       clientSAN,
+				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+			}
+			if len(certs) < 1 {
+				return errors.New("missing client cert")
+			}
+			// Get intermediates if any
+			for _, cert := range certs[1:] {
+				opts.Intermediates.AddCert(cert)
+			}
+			_, err := certs[0].Verify(opts)
+			if err != nil {
+				logger.Warnf("error validating client: %s", err.Error())
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -2,11 +2,9 @@ package settings
 
 import (
 	"crypto/tls"
-	"crypto/x509"
-	"fmt"
-	"os"
 	"time"
 
+	"github.com/envoyproxy/ratelimit/src/utils"
 	"github.com/kelseyhightower/envconfig"
 	"google.golang.org/grpc"
 )
@@ -18,18 +16,31 @@ type Settings struct {
 	// Server listen address config
 	Host      string `envconfig:"HOST" default:"0.0.0.0"`
 	Port      int    `envconfig:"PORT" default:"8080"`
-	GrpcHost  string `envconfig:"GRPC_HOST" default:"0.0.0.0"`
-	GrpcPort  int    `envconfig:"GRPC_PORT" default:"8081"`
 	DebugHost string `envconfig:"DEBUG_HOST" default:"0.0.0.0"`
 	DebugPort int    `envconfig:"DEBUG_PORT" default:"6070"`
 
 	// GRPC server settings
+	GrpcHost string `envconfig:"GRPC_HOST" default:"0.0.0.0"`
+	GrpcPort int    `envconfig:"GRPC_PORT" default:"8081"`
+	// GrpcServerTlsConfig configures grpc for the server
+	GrpcServerTlsConfig *tls.Config
 	// GrpcMaxConnectionAge is a duration for the maximum amount of time a connection may exist before it will be closed by sending a GoAway.
 	// A random jitter of +/-10% will be added to MaxConnectionAge to spread out connection storms.
 	GrpcMaxConnectionAge time.Duration `envconfig:"GRPC_MAX_CONNECTION_AGE" default:"24h" description:"Duration a connection may exist before it will be closed by sending a GoAway."`
 	// GrpcMaxConnectionAgeGrace is an additive period after MaxConnectionAge after which the connection will be forcibly closed.
 	GrpcMaxConnectionAgeGrace time.Duration `envconfig:"GRPC_MAX_CONNECTION_AGE_GRACE" default:"1h" description:"Period after MaxConnectionAge after which the connection will be forcibly closed."`
-
+	// GrpcServerUseTLS enables gprc connections to server over TLS
+	GrpcServerUseTLS bool `envconfig:"GRPC_SERVER_USE_TLS" default:"false"`
+	// Allow to set the server certificate and key for TLS connections.
+	// 	GrpcServerTlsCert is the path to the file containing the server cert chain
+	GrpcServerTlsCert string `envconfig:"GRPC_SERVER_TLS_CERT" default:""`
+	// 	GrpcServerTlsKey is the path to the file containing the server private key
+	GrpcServerTlsKey string `envconfig:"GRPC_SERVER_TLS_KEY" default:""`
+	// GrpcClientTlsCACert is the path to the file containing the client CA certificate.
+	// Use for validating client certificate
+	GrpcClientTlsCACert string `envconfig:"GRPC_CLIENT_TLS_CACERT" default:""`
+	// GrpcClientTlsSAN is the SAN to validate from the client cert during mTLS auth
+	GrpcClientTlsSAN string `envconfig:"GRPC_CLIENT_TLS_SAN" default:""`
 	// Logging settings
 	LogLevel  string `envconfig:"LOG_LEVEL" default:"WARN"`
 	LogFormat string `envconfig:"LOG_FORMAT" default:"text"`
@@ -129,54 +140,40 @@ func NewSettings() Settings {
 	if err := envconfig.Process("", &s); err != nil {
 		panic(err)
 	}
-
-	// Golang copy-by-value causes the RootCAs to no longer be nil
-	// which isn't the expected default behavior of continuing to use system roots
-	// so let's just initialize to what we want the correct value to be.
-	s.RedisTlsConfig = &tls.Config{}
-
-	// When we require to connect using TLS, we check if we need to connect using the provided key-pair.
-	if s.RedisTls || s.RedisPerSecondTls {
-		TlsConfigFromFiles(s.RedisTlsClientCert, s.RedisTlsClientKey, s.RedisTlsCACert)(&s)
-	}
-
+	// When we require TLS to connect to Redis, we check if we need to connect using the provided key-pair.
+	RedisTlsConfig(s.RedisTls || s.RedisPerSecondTls)(&s)
+	GrpcServerTlsConfig()(&s)
 	return s
+}
+
+func RedisTlsConfig(redisTls bool) Option {
+	return func(s *Settings) {
+		// Golang copy-by-value causes the RootCAs to no longer be nil
+		// which isn't the expected default behavior of continuing to use system roots
+		// so let's just initialize to what we want the correct value to be.
+		s.RedisTlsConfig = &tls.Config{}
+		if redisTls {
+			s.RedisTlsConfig = utils.TlsConfigFromFiles(s.RedisTlsClientCert, s.RedisTlsClientKey, s.RedisTlsCACert, utils.ServerCA)
+		}
+	}
+}
+
+func GrpcServerTlsConfig() Option {
+	return func(s *Settings) {
+		if s.GrpcServerUseTLS {
+			grpcServerTlsConfig := utils.TlsConfigFromFiles(s.GrpcServerTlsCert, s.GrpcServerTlsKey, s.GrpcClientTlsCACert, utils.ClientCA)
+			if s.GrpcClientTlsCACert != "" {
+				grpcServerTlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+			} else {
+				grpcServerTlsConfig.ClientAuth = tls.NoClientCert
+			}
+			s.GrpcServerTlsConfig = grpcServerTlsConfig
+		}
+	}
 }
 
 func GrpcUnaryInterceptor(i grpc.UnaryServerInterceptor) Option {
 	return func(s *Settings) {
 		s.GrpcUnaryInterceptor = i
 	}
-}
-
-// TlsConfigFromFiles sets the TLS config from the provided files.
-func TlsConfigFromFiles(cert, key, caCert string) Option {
-	return func(s *Settings) {
-		if s.RedisTlsConfig == nil {
-			s.RedisTlsConfig = new(tls.Config)
-		}
-		if cert != "" && key != "" {
-			clientCert, err := tls.LoadX509KeyPair(cert, key)
-			if err != nil {
-				panic(fmt.Errorf("failed lo load client TLS key pair: %w", err))
-			}
-			s.RedisTlsConfig.Certificates = append(s.RedisTlsConfig.Certificates, clientCert)
-		}
-
-		if caCert != "" {
-			certPool := x509.NewCertPool()
-			if !certPool.AppendCertsFromPEM(mustReadFile(caCert)) {
-				panic("failed to load the provided TLS CA certificate")
-			}
-			s.RedisTlsConfig.RootCAs = certPool
-		}
-	}
-}
-
-func mustReadFile(name string) []byte {
-	b, err := os.ReadFile(name)
-	if err != nil {
-		panic(fmt.Errorf("failed to read file: %s: %w", name, err))
-	}
-	return b
 }

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -4,9 +4,10 @@ import (
 	"crypto/tls"
 	"time"
 
-	"github.com/envoyproxy/ratelimit/src/utils"
 	"github.com/kelseyhightower/envconfig"
 	"google.golang.org/grpc"
+
+	"github.com/envoyproxy/ratelimit/src/utils"
 )
 
 type Settings struct {

--- a/src/utils/tls.go
+++ b/src/utils/tls.go
@@ -1,0 +1,52 @@
+package utils
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+type CAType int
+
+const (
+	ClientCA CAType = iota
+	ServerCA
+)
+
+// TlsConfigFromFiles sets the TLS config from the provided files.
+func TlsConfigFromFiles(certFile, keyFile, caCertFile string, caType CAType) *tls.Config {
+	config := &tls.Config{}
+	if certFile != "" && keyFile != "" {
+		tlsKeyPair, err := tls.LoadX509KeyPair(certFile, keyFile)
+		if err != nil {
+			panic(fmt.Errorf("failed lo load TLS key pair (%s,%s): %w", certFile, keyFile, err))
+		}
+		config.Certificates = append(config.Certificates, tlsKeyPair)
+	}
+	if caCertFile != "" {
+		// try to get the SystemCertPool first
+		certPool, _ := x509.SystemCertPool()
+		if certPool == nil {
+			certPool = x509.NewCertPool()
+		}
+		if !certPool.AppendCertsFromPEM(mustReadFile(caCertFile)) {
+			panic(fmt.Errorf("failed to load the provided TLS CA certificate: %s", caCertFile))
+		}
+		switch caType {
+		case ClientCA:
+			config.ClientCAs = certPool
+		case ServerCA:
+			config.RootCAs = certPool
+		}
+	}
+	return config
+}
+
+func mustReadFile(name string) []byte {
+	b, err := os.ReadFile(name)
+	if err != nil {
+		panic(fmt.Errorf("failed to read file: %s: %w", name, err))
+	}
+	return b
+}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -229,8 +229,14 @@ func TestMultiNodeMemcache(t *testing.T) {
 		t.Run("MemcacheMultipleNodes", testBasicConfig(makeSimpleMemcacheSettings(multiNodePorts, 0)))
 	})
 }
+
 func Test_mTLS(t *testing.T) {
-	s := defaultSettings()
+	s := makeSimpleRedisSettings(16381, 16382, false, 0)
+	s.RedisTlsConfig = &tls.Config{}
+	s.RedisAuth = "password123"
+	s.RedisTls = true
+	s.RedisPerSecondAuth = "password123"
+	s.RedisPerSecondTls = true
 	assert := assert.New(t)
 	serverCAFile, serverCertFile, serverCertKey, err := mTLSSetup(utils.ServerCA)
 	assert.NoError(err)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package integration_test
 
@@ -20,10 +19,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 
 	"github.com/envoyproxy/ratelimit/src/memcached"
 	"github.com/envoyproxy/ratelimit/src/service_cmd/runner"
 	"github.com/envoyproxy/ratelimit/src/settings"
+	"github.com/envoyproxy/ratelimit/src/utils"
 	"github.com/envoyproxy/ratelimit/test/common"
 )
 
@@ -228,6 +229,26 @@ func TestMultiNodeMemcache(t *testing.T) {
 		t.Run("MemcacheMultipleNodes", testBasicConfig(makeSimpleMemcacheSettings(multiNodePorts, 0)))
 	})
 }
+func Test_mTLS(t *testing.T) {
+	s := defaultSettings()
+	assert := assert.New(t)
+	serverCAFile, serverCertFile, serverCertKey, err := mTLSSetup(utils.ServerCA)
+	assert.NoError(err)
+	clientCAFile, clientCertFile, clientCertKey, err := mTLSSetup(utils.ClientCA)
+	assert.NoError(err)
+	s.GrpcServerUseTLS = true
+	s.GrpcServerTlsCert = serverCertFile
+	s.GrpcServerTlsKey = serverCertKey
+	s.GrpcClientTlsCACert = clientCAFile
+	s.GrpcClientTlsSAN = "localhost"
+	settings.GrpcServerTlsConfig()(&s)
+	runner := startTestRunner(t, s)
+	defer runner.Stop()
+	clientTlsConfig := utils.TlsConfigFromFiles(clientCertFile, clientCertKey, serverCAFile, utils.ServerCA)
+	conn, err := grpc.Dial(fmt.Sprintf("localhost:%v", s.GrpcPort), grpc.WithTransportCredentials(credentials.NewTLS(clientTlsConfig)))
+	assert.NoError(err)
+	defer conn.Close()
+}
 
 func testBasicConfigAuthTLS(perSecond bool, local_cache_size int) func(*testing.T) {
 	s := makeSimpleRedisSettings(16381, 16382, perSecond, local_cache_size)
@@ -245,11 +266,14 @@ func testBasicConfigAuthTLSWithClientCert(perSecond bool, local_cache_size int) 
 	// verifies the peer certificate against the defined CA certificate (CAfile)).
 	// See: Makefile#REDIS_VERIFY_PEER_STUNNEL.
 	s := makeSimpleRedisSettings(16361, 16382, perSecond, local_cache_size)
-	settings.TlsConfigFromFiles(filepath.Join(projectDir, "cert.pem"), filepath.Join(projectDir, "key.pem"), filepath.Join(projectDir, "cert.pem"))(&s)
-	s.RedisAuth = "password123"
+	s.RedisTlsClientCert = filepath.Join(projectDir, "cert.pem")
+	s.RedisTlsClientKey = filepath.Join(projectDir, "key.pem")
+	s.RedisTlsCACert = filepath.Join(projectDir, "cert.pem")
 	s.RedisTls = true
-	s.RedisPerSecondAuth = "password123"
 	s.RedisPerSecondTls = true
+	settings.RedisTlsConfig(s.RedisTls || s.RedisPerSecondTls)(&s)
+	s.RedisAuth = "password123"
+	s.RedisPerSecondAuth = "password123"
 
 	return testBasicBaseConfig(s)
 }

--- a/test/integration/mtls_test.go
+++ b/test/integration/mtls_test.go
@@ -1,0 +1,134 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/envoyproxy/ratelimit/src/utils"
+)
+
+func createCA() (caFileName string, ca *x509.Certificate, pk *rsa.PrivateKey, err error) {
+	ca = &x509.Certificate{
+		SerialNumber: big.NewInt(2022),
+		Subject: pkix.Name{
+			Organization: []string{"Acme CA"},
+			Country:      []string{"CA"},
+			Province:     []string{"BC"},
+			Locality:     []string{"Vancouver"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(1, 0, 0),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+	}
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	// create the CA
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+	cafileName, err := writeContentToTempFile(caPEM.Bytes(), "ca.pem")
+	return cafileName, ca, caPrivKey, err
+}
+
+func writeContentToTempFile(content []byte, filenameprefix string) (filename string, err error) {
+	f, err := os.CreateTemp("", filenameprefix)
+	if err != nil {
+		return "", err
+	}
+	f.Write(content)
+	err = f.Close()
+	return f.Name(), err
+}
+
+func signCert(caType utils.CAType, ca *x509.Certificate, caPK *rsa.PrivateKey) (certFile string, keyFile string, err error) {
+	keyUsage := x509.ExtKeyUsageServerAuth
+	name := "Server"
+	var sn int64 = 2021
+	if caType == utils.ClientCA {
+		keyUsage = x509.ExtKeyUsageClientAuth
+		name = "Client"
+		sn = 2020
+	}
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(sn),
+		Subject: pkix.Name{
+			Organization: []string{name},
+			Country:      []string{"CA"},
+			Province:     []string{"BC"},
+			Locality:     []string{"Vancouver"},
+		},
+		DNSNames:    []string{"localhost"},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(0, 5, 0),
+		ExtKeyUsage: []x509.ExtKeyUsage{keyUsage},
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", "", err
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPK)
+	if err != nil {
+		return "", "", err
+	}
+	certPEM := new(bytes.Buffer)
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+	certfileName, err := writeContentToTempFile(certPEM.Bytes(), fmt.Sprintf("%s-cert.pem", name))
+	if err != nil {
+		return "", "", err
+	}
+	certPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(certPrivKey),
+	})
+
+	pkFileName, err := writeContentToTempFile(certPrivKeyPEM.Bytes(), fmt.Sprintf("%s-key.pem", name))
+	if err != nil {
+		return "", "", err
+	}
+	return certfileName, pkFileName, nil
+}
+func mTLSSetup(caType utils.CAType) (caFile string, certFile string, keyFile string, err error) {
+	caFile, serverCA, serverCApk, err := createCA()
+	if err != nil {
+		return "", "", "", err
+	}
+	certFile, keyFile, err = signCert(caType, serverCA, serverCApk)
+	return caFile, certFile, keyFile, err
+
+}
+
+func Test_mTLSSetup(t *testing.T) {
+	_, _, _, err := mTLSSetup(utils.ServerCA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+}

--- a/test/integration/mtls_test.go
+++ b/test/integration/mtls_test.go
@@ -57,7 +57,10 @@ func writeContentToTempFile(content []byte, filenameprefix string) (filename str
 	if err != nil {
 		return "", err
 	}
-	f.Write(content)
+	_, err = f.Write(content)
+	if err != nil {
+		return "", err
+	}
 	err = f.Close()
 	return f.Name(), err
 }
@@ -115,6 +118,7 @@ func signCert(caType utils.CAType, ca *x509.Certificate, caPK *rsa.PrivateKey) (
 	}
 	return certfileName, pkFileName, nil
 }
+
 func mTLSSetup(caType utils.CAType) (caFile string, certFile string, keyFile string, err error) {
 	caFile, serverCA, serverCApk, err := createCA()
 	if err != nil {
@@ -122,7 +126,6 @@ func mTLSSetup(caType utils.CAType) (caFile string, certFile string, keyFile str
 	}
 	certFile, keyFile, err = signCert(caType, serverCA, serverCApk)
 	return caFile, certFile, keyFile, err
-
 }
 
 func Test_mTLSSetup(t *testing.T) {
@@ -130,5 +133,4 @@ func Test_mTLSSetup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 }


### PR DESCRIPTION
See the README.md/mTLS for the setup instructions

Refactors the TlsConfigFromFiles method into utils to allow reuse across
client, server and integration test packages

mTLS is optional and is turned off by default.

Requires the following block in the envoy cluster config for ratelimit service to enable envoy to talk to the ratelimit service using mTLS

```yaml
    "name": "ratelimit"
    "transport_socket":
      "name": "envoy.transport_sockets.tls"
      "typed_config":
        "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"
        "common_tls_context":
          "tls_certificates":
          - "certificate_chain":
              "filename": "/opt/envoy/tls/ratelimit-client-cert.pem"
            "private_key":
              "filename": "/opt/envoy/tls/ratelimit-client-key.pem"
          "validation_context":
            "match_subject_alt_names":
            - "exact": "ratelimit.server.dnsname"
            "trusted_ca":
              "filename": "/opt/envoy/tls/ratelimit-server-ca.pem"
```
 Tested for client cert verification.
A failure would look something like

```bash
{"@message":"error validating client: x509: certificate is valid for envoy.ratelimit.internal, not anything.ratelimit.internal","@timestamp":"2022-05-17T23:46:05.90283615Z","level":"warning"}
```

Addresses #335 