### PR TITLE
ci: improve release workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
 
 jobs:
   check:
@@ -14,6 +16,7 @@ jobs:
         run: make check_format
 
   build:
+    needs: [check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -25,14 +28,50 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: build and push docker image
-        run: |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          VERSION=master make docker_multiarch_push     # Push image tagged with "master"
-          make docker_multiarch_push                    # Push image tagged with git sha
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Restore Docker Cache Layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-ratelimit-buildx
+
+      - name: Prepare Images
+        id: images
         env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          IMAGE_NAME: envoyproxy/ratelimit
+        run: |
+          if [[ $GITHUB_REF =~ refs/tags/* ]]; then
+            tag=${GITHUB_REF#refs/tags/*}
+            images="$IMAGE_NAME:$tag,$IMAGE_NAME:latest"
+            echo "::set-output name=value::$images"
+          else
+            branch=${GITHUB_REF#refs/heads/*}
+            images="$IMAGE_NAME:$branch,$IMAGE_NAME:$branch-$(git rev-parse --short HEAD)"
+            echo "::set-output name=value::$images"
+          fi
+
+      - name: Docker Tests
+        run: make docker_tests
+
+      - name: Docker build & push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.images.outputs.value }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          platforms: linux/amd64,linux/arm64/v8
+
+      - name: Move Docker cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
   precommits:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
       - name: check format
         run: make check_format
   build:
+    needs: [check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -24,10 +25,40 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: build and push docker image
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Restore Docker Cache Layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-ratelimit-buildx
+
+      - name: Prepare Image tag
+        id: image_tag
         run: |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-          make docker_multiarch_push
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          TAG=${GITHUB_REF#refs/*/}
+          echo "::set-output name=value::$TAG"
+
+      - name: Docker Tests
+        run: make docker_tests
+
+      - name: Docker build & push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            envoyproxy/ratelimit:${{ steps.image_tag.outputs.value }}
+            envoyproxy/ratelimit:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          platforms: linux/amd64,linux/arm64/v8
+
+      - name: Move Docker cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
This PR aim to improve release workflow.
* Now, `check` phase must be passed to run `build` phase.
* Trigger workflow (no changes).
* The release workflow will push 2 images: `latest` and `image_tag` (e.g: `v1.8.1`).
* The main workflow now support build from a `tag` or `branches` trigger.
  * If the trigger is a `tag` push, this will build 2 images: `latest` and `image_tag`.
  * If the trigger is a `branches` push, this will build 2 images: `branch_name` (main) and `<branch_name>-<short_commit_hash>` (e.g: main-e63a469).