### PR TITLE
fix typed_config in example file for envoy.filters.http.router

### DIFF
--- a/examples/envoy/mock.yaml
+++ b/examples/envoy/mock.yaml
@@ -26,7 +26,8 @@ static_resources:
                               inline_string: "Hello World"
                 http_filters:
                   - name: envoy.filters.http.router
-                    typed_config: {}
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 admin:
   access_log_path: "/dev/null"
   address:

--- a/examples/envoy/proxy.yaml
+++ b/examples/envoy/proxy.yaml
@@ -62,7 +62,8 @@ static_resources:
                             cluster_name: ratelimit
                         transport_api_version: V3
                   - name: envoy.filters.http.router
-                    typed_config: {}
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                 route_config:
                   name: route
                   virtual_hosts:


### PR DESCRIPTION
Based on the Issue https://github.com/envoyproxy/ratelimit/issues/339 that I've opened, I think the envoy.filters.http.router http_filter was missing the typed_config for it , failing to startup during the compose up of the example of this project, this PR includes the type information so the envoy can start

Closes https://github.com/envoyproxy/ratelimit/issues/339