### PR TITLE
Allow merge of configs referencing the same domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,9 @@ The former is the default behavior. To use the latter method, set the `RUNTIME_W
 
 For more information on how runtime works you can read its [README](https://github.com/lyft/goruntime).
 
+By default it is not possible to define multiple configuration files within `RUNTIME_SUBDIRECTORY` referencing the same domain.
+To enable this behavior set `MERGE_DOMAIN_CONFIG` to `true`.
+
 ## Log Format
 
 A centralized log collection system works better with logs in json format. JSON format avoids the need for custom parsing rules.
@@ -586,7 +589,7 @@ There is a global shadow-mode which can make it easier to introduce rate limitin
 
 The global shadow mode is configured with an environment variable
 
-Setting environment variable`SHADOW_MODE` to `true` will enable the feature.
+Setting environment variable `SHADOW_MODE` to `true` will enable the feature.
 
 ## Statistics
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -50,7 +50,8 @@ type RateLimitConfigLoader interface {
 	// Load a new configuration from a list of YAML files.
 	// @param configs supplies a list of full YAML files in string form.
 	// @param statsManager supplies the statsManager to initialize stats during runtime.
+	// @param mergeDomainConfigs defines whether multiple configurations referencing the same domain will be merged or rejected throwing an error.
 	// @return a new configuration.
 	// @throws RateLimitConfigError if the configuration could not be created.
-	Load(configs []RateLimitConfigToLoad, statsManager stats.Manager) RateLimitConfig
+	Load(configs []RateLimitConfigToLoad, statsManager stats.Manager, mergeDomainConfigs bool) RateLimitConfig
 }

--- a/src/config_check_cmd/main.go
+++ b/src/config_check_cmd/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/envoyproxy/ratelimit/src/config"
 )
 
-func loadConfigs(allConfigs []config.RateLimitConfigToLoad) {
+func loadConfigs(allConfigs []config.RateLimitConfigToLoad, mergeDomainConfigs bool) {
 	defer func() {
 		err := recover()
 		if err != nil {
@@ -23,13 +23,15 @@ func loadConfigs(allConfigs []config.RateLimitConfigToLoad) {
 			os.Exit(1)
 		}
 	}()
-	statsManager := stats.NewStatManager(gostats.NewStore(gostats.NewNullSink(), false), settings.NewSettings())
-	config.NewRateLimitConfigImpl(allConfigs, statsManager)
+	statsManager := stats.NewStatManager(gostats.NewStore(gostats.NewNullSink(), mergeDomainConfigs), settings.NewSettings())
+	config.NewRateLimitConfigImpl(allConfigs, statsManager, mergeDomainConfigs)
 }
 
 func main() {
 	configDirectory := flag.String(
 		"config_dir", "", "path to directory containing rate limit configs")
+	mergeDomainConfigs := flag.Bool(
+		"merge_domain_configs", false, "whether to merge configurations, referencing the same domain")
 	flag.Parse()
 	fmt.Printf("checking rate limit configs...\n")
 	fmt.Printf("loading config directory: %s\n", *configDirectory)
@@ -52,6 +54,6 @@ func main() {
 		allConfigs = append(allConfigs, config.RateLimitConfigToLoad{finalPath, string(bytes)})
 	}
 
-	loadConfigs(allConfigs)
+	loadConfigs(allConfigs, *mergeDomainConfigs)
 	fmt.Printf("all rate limit configs ok\n")
 }

--- a/src/config_check_cmd/main.go
+++ b/src/config_check_cmd/main.go
@@ -23,7 +23,7 @@ func loadConfigs(allConfigs []config.RateLimitConfigToLoad, mergeDomainConfigs b
 			os.Exit(1)
 		}
 	}()
-	statsManager := stats.NewStatManager(gostats.NewStore(gostats.NewNullSink(), mergeDomainConfigs), settings.NewSettings())
+	statsManager := stats.NewStatManager(gostats.NewStore(gostats.NewNullSink(), false), settings.NewSettings())
 	config.NewRateLimitConfigImpl(allConfigs, statsManager, mergeDomainConfigs)
 }
 

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -75,14 +75,11 @@ func (this *service) reloadConfig(statsManager stats.Manager) {
 		files = append(files, config.RateLimitConfigToLoad{key, snapshot.Get(key)})
 	}
 
-	this.configLock.Lock()
-	defer this.configLock.Unlock()
-
 	rlSettings := settings.NewSettings()
-
 	newConfig := this.configLoader.Load(files, statsManager, rlSettings.MergeDomainConfigurations)
 	this.stats.ConfigLoadSuccess.Inc()
 
+	this.configLock.Lock()
 	this.config = newConfig
 	this.globalShadowMode = rlSettings.GlobalShadowMode
 
@@ -95,6 +92,7 @@ func (this *service) reloadConfig(statsManager stats.Manager) {
 
 		this.customHeaderResetHeader = rlSettings.HeaderRatelimitReset
 	}
+	this.configLock.Unlock()
 }
 
 type serviceError string

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -124,6 +124,9 @@ type Settings struct {
 	// Should the ratelimiting be running in Global shadow-mode, ie. never report a ratelimit status, unless a rate was provided from envoy as an override
 	GlobalShadowMode bool `envconfig:"SHADOW_MODE" default:"false"`
 
+	// Allow merging of multiple yaml files referencing the same domain
+	MergeDomainConfigurations bool `envconfig:"MERGE_DOMAIN_CONFIG" default:"false"`
+
 	// OTLP trace settings
 	TracingEnabled           bool   `envconfig:"TRACING_ENABLED" default:"false"`
 	TracingServiceName       string `envconfig:"TRACING_SERVICE_NAME" default:"RateLimit"`

--- a/test/config/merge_domain_key1.yaml
+++ b/test/config/merge_domain_key1.yaml
@@ -1,0 +1,9 @@
+# Basic configuration which will be merged with `merge_domain2.yaml`
+domain: test-domain
+descriptors:
+  # Top level key/value which is not specified in `merge_domain2.yaml`
+  - key: key1
+    value: value1
+    rate_limit:
+      unit: minute
+      requests_per_unit: 10

--- a/test/config/merge_domain_key2.yaml
+++ b/test/config/merge_domain_key2.yaml
@@ -1,0 +1,9 @@
+# Basic configuration which will be merged with `merge_domain.yaml`
+domain: test-domain
+descriptors:
+  # Top level key/value which is not specified in `merge_domain.yaml`
+  - key: key2
+    value: value2
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20

--- a/test/mocks/config/config.go
+++ b/test/mocks/config/config.go
@@ -90,15 +90,15 @@ func (m *MockRateLimitConfigLoader) EXPECT() *MockRateLimitConfigLoaderMockRecor
 }
 
 // Load mocks base method
-func (m *MockRateLimitConfigLoader) Load(arg0 []config.RateLimitConfigToLoad, arg1 stats.Manager) config.RateLimitConfig {
+func (m *MockRateLimitConfigLoader) Load(arg0 []config.RateLimitConfigToLoad, arg1 stats.Manager, arg2 bool) config.RateLimitConfig {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Load", arg0, arg1)
+	ret := m.ctrl.Call(m, "Load", arg0, arg1, arg2)
 	ret0, _ := ret[0].(config.RateLimitConfig)
 	return ret0
 }
 
 // Load indicates an expected call of Load
-func (mr *MockRateLimitConfigLoaderMockRecorder) Load(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockRateLimitConfigLoaderMockRecorder) Load(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockRateLimitConfigLoader)(nil).Load), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockRateLimitConfigLoader)(nil).Load), arg0, arg1, arg2)
 }

--- a/test/service/ratelimit_test.go
+++ b/test/service/ratelimit_test.go
@@ -100,8 +100,8 @@ func (this *rateLimitServiceTestSuite) setupBasicService() ratelimit.RateLimitSe
 	this.snapshot.EXPECT().Keys().Return([]string{"foo", "config.basic_config"}).MinTimes(1)
 	this.snapshot.EXPECT().Get("config.basic_config").Return("fake_yaml").MinTimes(1)
 	this.configLoader.EXPECT().Load(
-		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}},
-		gomock.Any()).Return(this.config)
+		[]config.RateLimitConfigToLoad{{Name: "config.basic_config", FileBytes: "fake_yaml"}},
+		gomock.Any(), gomock.Any()).Return(this.config)
 
 	// reset exporter before using
 	testSpanExporter.Reset()
@@ -136,8 +136,8 @@ func TestService(test *testing.T) {
 	// Force a config reload.
 	barrier := newBarrier()
 	t.configLoader.EXPECT().Load(
-		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}}, gomock.Any()).Do(
-		func([]config.RateLimitConfigToLoad, stats.Manager) { barrier.signal() }).Return(t.config)
+		[]config.RateLimitConfigToLoad{{Name: "config.basic_config", FileBytes: "fake_yaml"}}, gomock.Any(), gomock.Any()).Do(
+		func([]config.RateLimitConfigToLoad, stats.Manager, bool) { barrier.signal() }).Return(t.config)
 	t.runtimeUpdateCallback <- 1
 	barrier.wait()
 
@@ -170,8 +170,8 @@ func TestService(test *testing.T) {
 
 	// Config load failure.
 	t.configLoader.EXPECT().Load(
-		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}}, gomock.Any()).Do(
-		func([]config.RateLimitConfigToLoad, stats.Manager) {
+		[]config.RateLimitConfigToLoad{{Name: "config.basic_config", FileBytes: "fake_yaml"}}, gomock.Any(), gomock.Any()).Do(
+		func([]config.RateLimitConfigToLoad, stats.Manager, bool) {
 			defer barrier.signal()
 			panic(config.RateLimitConfigError("load error"))
 		})
@@ -223,8 +223,8 @@ func TestServiceGlobalShadowMode(test *testing.T) {
 	// Force a config reload.
 	barrier := newBarrier()
 	t.configLoader.EXPECT().Load(
-		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}}, gomock.Any()).Do(
-		func([]config.RateLimitConfigToLoad, stats.Manager) { barrier.signal() }).Return(t.config)
+		[]config.RateLimitConfigToLoad{{Name: "config.basic_config", FileBytes: "fake_yaml"}}, gomock.Any(), gomock.Any()).Do(
+		func([]config.RateLimitConfigToLoad, stats.Manager, bool) { barrier.signal() }).Return(t.config)
 	t.runtimeUpdateCallback <- 1
 	barrier.wait()
 
@@ -357,8 +357,8 @@ func TestServiceWithCustomRatelimitHeaders(test *testing.T) {
 	// Config reload.
 	barrier := newBarrier()
 	t.configLoader.EXPECT().Load(
-		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}}, gomock.Any()).Do(
-		func([]config.RateLimitConfigToLoad, stats.Manager) { barrier.signal() }).Return(t.config)
+		[]config.RateLimitConfigToLoad{{Name: "config.basic_config", FileBytes: "fake_yaml"}}, gomock.Any(), gomock.Any()).Do(
+		func([]config.RateLimitConfigToLoad, stats.Manager, bool) { barrier.signal() }).Return(t.config)
 	t.runtimeUpdateCallback <- 1
 	barrier.wait()
 
@@ -409,8 +409,8 @@ func TestServiceWithDefaultRatelimitHeaders(test *testing.T) {
 	// Config reload.
 	barrier := newBarrier()
 	t.configLoader.EXPECT().Load(
-		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}}, gomock.Any()).Do(
-		func([]config.RateLimitConfigToLoad, stats.Manager) { barrier.signal() }).Return(t.config)
+		[]config.RateLimitConfigToLoad{{Name: "config.basic_config", FileBytes: "fake_yaml"}}, gomock.Any(), gomock.Any()).Do(
+		func([]config.RateLimitConfigToLoad, stats.Manager, bool) { barrier.signal() }).Return(t.config)
 	t.runtimeUpdateCallback <- 1
 	barrier.wait()
 
@@ -501,8 +501,8 @@ func TestInitialLoadError(test *testing.T) {
 	t.snapshot.EXPECT().Keys().Return([]string{"foo", "config.basic_config"}).MinTimes(1)
 	t.snapshot.EXPECT().Get("config.basic_config").Return("fake_yaml").MinTimes(1)
 	t.configLoader.EXPECT().Load(
-		[]config.RateLimitConfigToLoad{{"config.basic_config", "fake_yaml"}}, gomock.Any()).Do(
-		func([]config.RateLimitConfigToLoad, stats.Manager) {
+		[]config.RateLimitConfigToLoad{{Name: "config.basic_config", FileBytes: "fake_yaml"}}, gomock.Any(), gomock.Any()).Do(
+		func([]config.RateLimitConfigToLoad, stats.Manager, bool) {
 			panic(config.RateLimitConfigError("load error"))
 		})
 	service := ratelimit.NewService(t.runtime, t.cache, t.configLoader, t.statsManager, true, t.mockClock, false)


### PR DESCRIPTION
Add MERGE_DOMAIN_CONFIG variable defaulting to false and mapping to the former behavior.
Setting to true will allow multiple files containing non duplicate keys and referencing the same domain to be merged.

* Fixes #206
* Continues #209
