### PR TITLE
tracing: make sampling rate configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,7 +837,7 @@ The following environment variables control the tracing feature:
 1. `TRACING_SERVICE_NAMESPACE` - Controls the service namespace appears in tracing span. The default value is empty.
 1. `TRACING_SERVICE_INSTANCE_ID` - Controls the service instance id appears in tracing span. It is recommended to put the pod name or container name in this field. The default value is a randomly generated version 4 uuid if unspecified.
 1. Other fields in [OTLP Exporter Documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md). These section needs to be correctly configured in order to enable the exporter to export span to the correct destination.
-1. `TRACING_SAMPLING_RATE` - Controls the sampling rate, defaults to 1 which means always sample. For high volume services, adjusting the sampling rate is recommended.
+1. `TRACING_SAMPLING_RATE` - Controls the sampling rate, defaults to 1 which means always sample. Valid range: 0.0-1.0. For high volume services, adjusting the sampling rate is recommended.
 
 # mTLS
 

--- a/README.md
+++ b/README.md
@@ -837,6 +837,7 @@ The following environment variables control the tracing feature:
 1. `TRACING_SERVICE_NAMESPACE` - Controls the service namespace appears in tracing span. The default value is empty.
 1. `TRACING_SERVICE_INSTANCE_ID` - Controls the service instance id appears in tracing span. It is recommended to put the pod name or container name in this field. The default value is a randomly generated version 4 uuid if unspecified.
 1. Other fields in [OTLP Exporter Documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md). These section needs to be correctly configured in order to enable the exporter to export span to the correct destination.
+1. `TRACING_SAMPLING_RATE` - Controls the sampling rate, defaults to 1 which means always sample. For high volume services, adjusting the sampling rate is recommended.
 
 # mTLS
 

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -78,7 +78,7 @@ func createLimiter(srv server.Server, s settings.Settings, localCache *freecache
 func (runner *Runner) Run() {
 	s := runner.settings
 	if s.TracingEnabled {
-		tp := trace.InitProductionTraceProvider(s.TracingExporterProtocol, s.TracingServiceName, s.TracingServiceNamespace, s.TracingServiceInstanceId)
+		tp := trace.InitProductionTraceProvider(s.TracingExporterProtocol, s.TracingServiceName, s.TracingServiceNamespace, s.TracingServiceInstanceId, s.TracingSamplingRate)
 		defer func() {
 			if err := tp.Shutdown(context.Background()); err != nil {
 				logger.Printf("Error shutting down tracer provider: %v", err)

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -135,6 +135,8 @@ type Settings struct {
 	// can only be http or gRPC
 	TracingExporterProtocol string `envconfig:"TRACING_EXPORTER_PROTOCOL" default:"http"`
 	// detailed setting of exporter should refer to https://opentelemetry.io/docs/reference/specification/protocol/exporter/, e.g. OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_CERTIFICATE, OTEL_EXPORTER_OTLP_TIMEOUT
+	// TracingSamplingRate defaults to 1 which amounts to using the `AlwaysSample` sampler
+	TracingSamplingRate float64 `envconfig:"TRACING_SAMPLING_RATE" default:"1"`
 }
 
 type Option func(*Settings)


### PR DESCRIPTION
The `AlwaysSample()` sampler is not recommended when the volume of traces collected can be large.

This commit adds the ability to configure the sampling rate while respecting parent sampling decisions Details at: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#parentbased

Signed-off-by: Tim Bart <tim@pims.me>