### PR TITLE
Add switch to force config reload if files are deleted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ docker_multiarch_push: docker_multiarch_image
 
 .PHONY: integration_tests
 integration_tests:
-	docker-compose --project-dir $(PWD)  -f integration-test/docker-compose-integration-test.yml up --build  --exit-code-from tester
+	docker-compose --project-directory $(PWD)  -f integration-test/docker-compose-integration-test.yml up --build  --exit-code-from tester
 
 .PHONY: precommit_install
 precommit_install:

--- a/README.md
+++ b/README.md
@@ -512,6 +512,15 @@ There are two methods for triggering a configuration reload:
 2. Update the contents inside `RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/config/` directly.
 
 The former is the default behavior. To use the latter method, set the `RUNTIME_WATCH_ROOT` environment variable to `false`.
+Having `RUNTIME_WATCH_ROOT` set to `false` will listen for a [default set of filesystem operations](https://github.com/lyft/goruntime/blob/master/loader/directory_refresher.go#L10).
+
+As the default implementation will not force a configuration reload in case of deletion, `RUNTIME_WATCH_DELETION` was introduced.
+If set to `true` the following filesystem operations on configuration files inside `RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/config/` will force a reload of all config files:
+
+- Write
+- Create
+- Chmod
+- Remove
 
 For more information on how runtime works you can read its [README](https://github.com/lyft/goruntime).
 

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/gorilla/mux v1.7.4-0.20191121170500-49c01487a141
 	github.com/kavu/go_reuseport v1.2.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/lyft/goruntime v0.2.5
-	github.com/lyft/gostats v0.4.0
+	github.com/lyft/goruntime v0.3.0
+	github.com/lyft/gostats v0.4.1
 	github.com/mediocregopher/radix/v3 v3.8.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.7.1
@@ -40,7 +40,7 @@ require (
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
-	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/envoyproxy/go-control-plane v0.10.1 h1:cgDRLG7bs59Zd+apAWuzLQL95obVYA
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
-github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -151,7 +151,6 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/mux v1.7.4-0.20191121170500-49c01487a141 h1:VQjjMh+uElTfioy6GnUrVrTMAiLTNF3xsrAlSwC+g8o=
 github.com/gorilla/mux v1.7.4-0.20191121170500-49c01487a141/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QGdLI4y34qQGjGWO0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
@@ -172,10 +171,10 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lyft/goruntime v0.2.5 h1:yRmwOXl3Zns3+Z03fDMWt5+p609rfhIErh7HYCayODg=
-github.com/lyft/goruntime v0.2.5/go.mod h1:8rUh5gwIPQtyIkIXHbLN1j45HOb8cMgDhrw5GA7DF4g=
-github.com/lyft/gostats v0.4.0 h1:PbRWmwidTPk6Y80S6itBWDa+XVt1hGvqFM88TBJYdOo=
-github.com/lyft/gostats v0.4.0/go.mod h1:Tpx2xRzz4t+T2Tx0xdVgIoBdR2UMVz+dKnE3X01XSd8=
+github.com/lyft/goruntime v0.3.0 h1:VLBYR4s3XazkUT8lLtq9CJrt58YmLQQumrK3ktenEkI=
+github.com/lyft/goruntime v0.3.0/go.mod h1:BW1gngSpMJR9P9w23BPUPdhdbUWhpirl98TQhOWWMF4=
+github.com/lyft/gostats v0.4.1 h1:oR6p4HRCGxt0nUntmZIWmYMgyothBi3eZH2A71vRjsc=
+github.com/lyft/gostats v0.4.1/go.mod h1:Tpx2xRzz4t+T2Tx0xdVgIoBdR2UMVz+dKnE3X01XSd8=
 github.com/mediocregopher/radix/v3 v3.8.1 h1:rOkHflVuulFKlwsLY01/M2cM2tWCjDoETcMqKbAWu1M=
 github.com/mediocregopher/radix/v3 v3.8.1/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -329,6 +328,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -350,12 +350,9 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -241,21 +241,31 @@ func newServer(s settings.Settings, name string, statsManager stats.Manager, loc
 	} else {
 		loaderOpts = append(loaderOpts, loader.AllowDotFiles)
 	}
-
+	var err error
 	if s.RuntimeWatchRoot {
-		ret.runtime = loader.New(
+		ret.runtime, err = loader.New2(
 			s.RuntimePath,
 			s.RuntimeSubdirectory,
 			ret.store.ScopeWithTags("runtime", s.ExtraTags),
 			&loader.SymlinkRefresher{RuntimePath: s.RuntimePath},
 			loaderOpts...)
 	} else {
-		ret.runtime = loader.New(
+		directoryRefresher := &loader.DirectoryRefresher{}
+		if s.RuntimeWatchDeletion {
+			// Adding loader.Remove to the default set of goruntime's FileSystemOps.
+			directoryRefresher.WatchFileSystemOps(loader.Remove, loader.Write, loader.Create, loader.Chmod)
+		}
+
+		ret.runtime, err = loader.New2(
 			filepath.Join(s.RuntimePath, s.RuntimeSubdirectory),
 			"config",
 			ret.store.ScopeWithTags("runtime", s.ExtraTags),
-			&loader.DirectoryRefresher{},
+			directoryRefresher,
 			loaderOpts...)
+	}
+
+	if err != nil {
+		panic(err)
 	}
 
 	// setup http router

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -57,6 +57,7 @@ type Settings struct {
 	RuntimeSubdirectory   string `envconfig:"RUNTIME_SUBDIRECTORY"`
 	RuntimeIgnoreDotFiles bool   `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
 	RuntimeWatchRoot      bool   `envconfig:"RUNTIME_WATCH_ROOT" default:"true"`
+	RuntimeWatchDeletion  bool   `envconfig:"RUNTIME_WATCH_DELETION" default:"false"`
 
 	// Settings for all cache types
 	ExpirationJitterMaxSeconds int64   `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -177,7 +177,8 @@ func TestBasicReloadConfig(t *testing.T) {
 		{Port: 6383},
 	}, func() {
 		t.Run("BasicWithoutWatchRoot", testBasicConfigWithoutWatchRoot(false, 0))
-		t.Run("ReloadWithoutWatchRoot", testBasicConfigReload(false, 0, false))
+		t.Run("ReloadWithoutWatchRoot", testBasicConfigReload(false, 0, false, false))
+		t.Run("ReloadWithoutWatchRootAndWithDeletion", testBasicConfigReload(false, 0, false, true))
 	})
 }
 
@@ -378,9 +379,10 @@ func testBasicConfigWithoutWatchRootWithRedisSentinel(perSecond bool, local_cach
 	return testBasicBaseConfig(s)
 }
 
-func testBasicConfigReload(perSecond bool, local_cache_size int, runtimeWatchRoot bool) func(*testing.T) {
+func testBasicConfigReload(perSecond bool, local_cache_size int, runtimeWatchRoot bool, runtimeWatchDeletion bool) func(*testing.T) {
 	s := makeSimpleRedisSettings(6383, 6380, perSecond, local_cache_size)
 	s.RuntimeWatchRoot = runtimeWatchRoot
+	s.RuntimeWatchDeletion = runtimeWatchDeletion
 	return testConfigReload(s)
 }
 
@@ -696,7 +698,7 @@ func testConfigReload(s settings.Settings) func(*testing.T) {
 		assert.NoError(err)
 
 		runner.GetStatsStore().Flush()
-		loadCount1 := runner.GetStatsStore().NewCounter("ratelimit.service.config_load_success").Value()
+		loadCountBefore := runner.GetStatsStore().NewCounter("ratelimit.service.config_load_success").Value()
 
 		// Copy a new file to config folder to test config reload functionality
 		in, err := os.Open("runtime/current/ratelimit/reload.yaml")
@@ -718,26 +720,10 @@ func testConfigReload(s settings.Settings) func(*testing.T) {
 			panic(err)
 		}
 
-		// Need to wait for config reload to take place and new descriptors to be loaded.
-		// Shouldn't take more than 5 seconds but wait 120 at most just to be safe.
-		wait := 120
-		reloaded := false
-		loadCount2 := uint64(0)
-
-		for i := 0; i < wait; i++ {
-			time.Sleep(1 * time.Second)
-			runner.GetStatsStore().Flush()
-			loadCount2 = runner.GetStatsStore().NewCounter("ratelimit.service.config_load_success").Value()
-
-			// Check that successful loads count has increased before continuing.
-			if loadCount2 > loadCount1 {
-				reloaded = true
-				break
-			}
-		}
+		loadCountAfter, reloaded := waitForConfigReload(runner, loadCountBefore)
 
 		assert.True(reloaded)
-		assert.Greater(loadCount2, loadCount1)
+		assert.Greater(loadCountAfter, loadCountBefore)
 
 		response, err = c.ShouldRateLimit(
 			context.Background(),
@@ -759,5 +745,34 @@ func testConfigReload(s settings.Settings) func(*testing.T) {
 		if err != nil {
 			panic(err)
 		}
+
+		if s.RuntimeWatchDeletion {
+			loadCountBefore = loadCountAfter
+			// If RuntimeWatchDeletion is specified, removal of config files must trigger a reload
+			loadCountAfter, reloaded = waitForConfigReload(runner, loadCountBefore)
+			assert.True(reloaded)
+			assert.Greater(loadCountAfter, loadCountBefore)
+		}
 	}
+}
+
+func waitForConfigReload(runner *runner.Runner, loadCountBefore uint64) (uint64, bool) {
+	// Need to wait for config reload to take place and new descriptors to be loaded.
+	// Shouldn't take more than 5 seconds but wait 120 at most just to be safe.
+	wait := 120
+	reloaded := false
+	loadCountAfter := uint64(0)
+
+	for i := 0; i < wait; i++ {
+		time.Sleep(1 * time.Second)
+		runner.GetStatsStore().Flush()
+		loadCountAfter = runner.GetStatsStore().NewCounter("ratelimit.service.config_load_success").Value()
+
+		// Check that successful loads count has increased before continuing.
+		if loadCountAfter > loadCountBefore {
+			reloaded = true
+			break
+		}
+	}
+	return loadCountAfter, reloaded
 }


### PR DESCRIPTION
Motivation: Allow to trigger a configuration reload if any file within the config directory is deleted
Usecase: Having multiple Kubernetes Configmaps, containing ratelimit configurations. On resource deletion the corresponding configuration should be removed from the active ratelimit configuration as well. 

I'm not sure whether the switch introduced in this PR (RUNTIME_WATCH_DELETION) is the most suitable option here. I could imagine following configuration options:

- Pass a comma separated string "Read,Write,Delete..." 
- Pass a numeric representation (similar to unix file permissions) 1=Read, 2=Write, 4=Delete, 8=Chmod - might be a bit too obscure but easy to parse
- Pass each operation as separate boolean variable - might be too verbose

@mattklein123 do you have an opinion on which way to go? Or should we stick with the 'minimal' setup of this PR?