### PR TITLE
feat: add http provider for rate limit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
       - [Example 6](#example-6)
       - [Example 7](#example-7)
   - [Loading Configuration](#loading-configuration)
+    - [From local files](#from-local-files)
+    - [From http provider](#from-http-provider)
   - [Log Format](#log-format)
   - [GRPC Keepalive](#grpc-keepalive)
 - [Request Fields](#request-fields)
@@ -492,6 +494,8 @@ descriptors:
 
 ## Loading Configuration
 
+### From local files
+
 The Ratelimit service uses a library written by Lyft called [goruntime](https://github.com/lyft/goruntime) to do configuration loading. Goruntime monitors
 a designated path, and watches for symlink swaps to files in the directory tree to reload configuration files.
 
@@ -524,6 +528,20 @@ For more information on how runtime works you can read its [README](https://gith
 
 By default it is not possible to define multiple configuration files within `RUNTIME_SUBDIRECTORY` referencing the same domain.
 To enable this behavior set `MERGE_DOMAIN_CONFIG` to `true`.
+
+### From http provider
+
+The Ratelimit service allows to load configuration from a http server. The endpoint can be configured via the settings package with the following environment variables:
+
+```
+HTTP_PROVIDER_ENABLED default:"false"
+HTTP_PROVIDER_ENDPOINT
+HTTP_PROVIDER_SUBPATH default:""
+HTTP_PROVIDER_POLL_INTERVAL default:"10"
+HTTP_PROVIDER_POLL_TIMEOUT default:"10"
+```
+
+Configuration will be reloaded intervally according to the value of `HTTP_POLL_INTERVAL` (second). `HTTP_PROVIDER_SUBPATH` is an array which allows you to have multiple endpoints for different config files.
 
 ## Log Format
 

--- a/src/httpprovider/httpprovider.go
+++ b/src/httpprovider/httpprovider.go
@@ -1,0 +1,91 @@
+package httpprovider
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	logger "github.com/sirupsen/logrus"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+)
+
+type HttpProvider struct {
+	Endpoint     string
+	Subpath      []string
+	PollInterval time.Duration
+	PollTimeout  time.Duration
+	ConfigChan   chan []config.RateLimitConfigToLoad
+	httpClient   *http.Client
+	StopChan     chan bool
+}
+
+func NewHttpProvider(endpoint string, subpath []string, pollInterval time.Duration, pollTimeout time.Duration) *HttpProvider {
+	return &HttpProvider{
+		Endpoint:     endpoint,
+		Subpath:      subpath,
+		PollInterval: pollInterval,
+		ConfigChan:   make(chan []config.RateLimitConfigToLoad),
+		httpClient: &http.Client{
+			Timeout: pollTimeout,
+		},
+		StopChan: make(chan bool),
+	}
+}
+
+func (p *HttpProvider) Provide() error {
+	for {
+		select {
+		case <-p.StopChan:
+			return nil
+		default:
+			configs, err := p.fetchConfigurationData()
+			if err != nil {
+				logger.Errorf("Failed to fetch the configuration: %+v", err)
+				time.Sleep(p.PollInterval)
+				continue
+			}
+			p.ConfigChan <- configs
+			time.Sleep(p.PollInterval)
+		}
+	}
+}
+
+func (p *HttpProvider) Stop() {
+	p.StopChan <- true
+}
+
+// fetchConfigurationData fetches the configuration data from the configured endpoint.
+func (p *HttpProvider) fetchConfigurationData() ([]config.RateLimitConfigToLoad, error) {
+	configs := []config.RateLimitConfigToLoad{}
+
+	urls := []string{}
+	if len(p.Subpath) == 0 {
+		urls = append(urls, p.Endpoint)
+	} else {
+		for _, path := range p.Subpath {
+			urls = append(urls, fmt.Sprintf("%s/%s", p.Endpoint, path))
+		}
+	}
+
+	for _, url := range urls {
+		res, err := p.httpClient.Get(url)
+		if err != nil {
+			return nil, err
+		}
+
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("received non-ok response code: %d from the endpoint: %s", res.StatusCode, url)
+		}
+
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return nil, err
+		}
+		configs = append(configs, config.RateLimitConfigToLoad{url, string(body)})
+	}
+	return configs, nil
+}

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -5,6 +5,8 @@ import (
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 
+	"github.com/envoyproxy/ratelimit/src/httpprovider"
+
 	"github.com/lyft/goruntime/loader"
 	stats "github.com/lyft/gostats"
 	"google.golang.org/grpc"
@@ -38,6 +40,11 @@ type Server interface {
 	 * Returns the runtime configuration for the server.
 	 */
 	Runtime() loader.IFace
+
+	/**
+	 * Returns the configuration http provider for the server.
+	 */
+	HttpProvider() *httpprovider.HttpProvider
 
 	/**
 	 *  Stops serving the grpc port (for integration testing).

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -116,11 +116,20 @@ func (runner *Runner) Run() {
 	runner.srv = srv
 	runner.mu.Unlock()
 
+	var httpProviderChan chan []config.RateLimitConfigToLoad
+	if s.HttpProviderEnabled {
+		httpProviderChan = srv.HttpProvider().ConfigChan
+	} else {
+		httpProviderChan = make(chan []config.RateLimitConfigToLoad)
+	}
+
 	service := ratelimit.NewService(
 		srv.Runtime(),
 		createLimiter(srv, s, localCache, runner.statsManager),
 		config.NewRateLimitConfigLoaderImpl(),
 		runner.statsManager,
+		httpProviderChan,
+		s.HttpProviderEnabled,
 		s.RuntimeWatchRoot,
 		utils.NewTimeSourceImpl(),
 		s.GlobalShadowMode,

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -58,6 +58,13 @@ type Settings struct {
 	RuntimeIgnoreDotFiles bool   `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
 	RuntimeWatchRoot      bool   `envconfig:"RUNTIME_WATCH_ROOT" default:"true"`
 
+	// Settings for configuraiton http provider
+	HttpProviderEnabled      bool     `envconfig:"HTTP_PROVIDER_ENABLED" default:"false"`
+	HttpProviderEndpoint     string   `envconfig:"HTTP_PROVIDER_ENDPOINT"`
+	HttpProviderSubpath      []string `envconfig:"HTTP_PROVIDER_SUBPATH" default:""`
+	HttpProviderPollInterval int      `envconfig:"HTTP_PROVIDER_POLL_INTERVAL" default:"10"`
+	HttpProviderPollTimeout  int      `envconfig:"HTTP_PROVIDER_POLL_TIMEOUT" default:"10"`
+
 	// Settings for all cache types
 	ExpirationJitterMaxSeconds int64   `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
 	LocalCacheSizeInBytes      int     `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`

--- a/test/httpprovider/config.yaml
+++ b/test/httpprovider/config.yaml
@@ -1,0 +1,9 @@
+domain: test-domain
+descriptors:
+  - key: key1
+    value: value1
+    descriptors:
+      - key: subkey1
+        rate_limit:
+          unit: second
+          requests_per_unit: 5

--- a/test/httpprovider/example.yaml
+++ b/test/httpprovider/example.yaml
@@ -1,0 +1,81 @@
+---
+domain: rl
+descriptors:
+  - key: category
+    value: account
+    rate_limit:
+      replaces:
+        - name: bkthomps
+        - name: fake_name
+      unit: minute
+      requests_per_unit: 4
+  - key: source_cluster
+    value: proxy
+    descriptors:
+      - key: destination_cluster
+        value: bkthomps
+        rate_limit:
+          replaces:
+            - name: bkthomps
+          unit: minute
+          requests_per_unit: 2
+      - key: destination_cluster
+        value: mock
+        rate_limit:
+          unit: minute
+          requests_per_unit: 1
+      - key: destination_cluster
+        value: override
+        rate_limit:
+          replaces:
+            - name: banned_limit
+          unit: minute
+          requests_per_unit: 2
+      - key: destination_cluster
+        value: fake
+        rate_limit:
+          name: fake_name
+          unit: minute
+          requests_per_unit: 2
+  - key: foo
+    rate_limit:
+      unit: minute
+      requests_per_unit: 2
+    descriptors:
+      - key: bar
+        rate_limit:
+          unit: minute
+          requests_per_unit: 3
+      - key: bar
+        value: bkthomps
+        rate_limit:
+          name: bkthomps
+          unit: minute
+          requests_per_unit: 1
+      - key: bar
+        value: banned
+        rate_limit:
+          name: banned_limit
+          unit: minute
+          requests_per_unit: 0
+      - key: baz
+        rate_limit:
+          unit: second
+          requests_per_unit: 1
+      - key: baz
+        value: not-so-shady
+        rate_limit:
+          unit: minute
+          requests_per_unit: 3
+      - key: baz
+        value: shady
+        rate_limit:
+          unit: minute
+          requests_per_unit: 3
+        shadow_mode: true
+      - key: bay
+        rate_limit:
+          unlimited: true
+  - key: qux
+    rate_limit:
+      unlimited: true

--- a/test/httpprovider/httpprovider_test.go
+++ b/test/httpprovider/httpprovider_test.go
@@ -1,0 +1,68 @@
+package httpprovider_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/ratelimit/src/httpprovider"
+)
+
+func TestProvideWithOneEndpoint(t *testing.T) {
+	assert := assert.New(t)
+
+	testConfig, _ := os.ReadFile("config.yaml")
+	handler := func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		rw.Write(testConfig)
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	provider := httpprovider.NewHttpProvider(server.URL, []string{}, 2*time.Second, 2*time.Second)
+
+	go provider.Provide()
+	configs := <-provider.ConfigChan
+
+	assert.Equal(len(configs), 1)
+	assert.Equal(configs[0].Name, server.URL)
+	assert.Equal(configs[0].FileBytes, string(testConfig))
+
+	provider.Stop()
+}
+
+func TestProvideWithMultipleEndpoints(t *testing.T) {
+	assert := assert.New(t)
+
+	testConfig, _ := os.ReadFile("config.yaml")
+	testExampleConfig, _ := os.ReadFile("example.yaml")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/config", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		rw.Write(testConfig)
+	})
+	mux.HandleFunc("/example", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+		rw.Write(testExampleConfig)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	provider := httpprovider.NewHttpProvider(server.URL, []string{"config", "example"}, 1*time.Second, 1*time.Second)
+
+	go provider.Provide()
+	configs := <-provider.ConfigChan
+
+	assert.Equal(len(configs), 2)
+	assert.Equal(configs[0].Name, server.URL+"/config")
+	assert.Equal(configs[1].Name, server.URL+"/example")
+	assert.Equal(configs[0].FileBytes, string(testConfig))
+	assert.Equal(configs[1].FileBytes, string(testExampleConfig))
+
+	provider.Stop()
+}

--- a/test/service/ratelimit_test.go
+++ b/test/service/ratelimit_test.go
@@ -106,7 +106,7 @@ func (this *rateLimitServiceTestSuite) setupBasicService() ratelimit.RateLimitSe
 	// reset exporter before using
 	testSpanExporter.Reset()
 
-	return ratelimit.NewService(this.runtime, this.cache, this.configLoader, this.statsManager, true, MockClock{now: int64(2222)}, false)
+	return ratelimit.NewService(this.runtime, this.cache, this.configLoader, this.statsManager, make(chan []config.RateLimitConfigToLoad), false, true, MockClock{now: int64(2222)}, false)
 }
 
 // once a ratelimit service is initiated, the package always fetches a default tracer from otel runtime and it can't be change until a new round of test is run. It is necessary to keep a package level exporter in this test package in order to correctly run the tests.
@@ -505,7 +505,7 @@ func TestInitialLoadError(test *testing.T) {
 		func([]config.RateLimitConfigToLoad, stats.Manager, bool) {
 			panic(config.RateLimitConfigError("load error"))
 		})
-	service := ratelimit.NewService(t.runtime, t.cache, t.configLoader, t.statsManager, true, t.mockClock, false)
+	service := ratelimit.NewService(t.runtime, t.cache, t.configLoader, t.statsManager, make(chan []config.RateLimitConfigToLoad), false, true, t.mockClock, false)
 
 	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
 	response, err := service.ShouldRateLimit(context.Background(), request)


### PR DESCRIPTION
We want to have a method to load the rate limit config dynamically. This PR adds a simple http provider for feeding rate limit config to the Ratelimit service intervally.
Related github issue: https://github.com/envoyproxy/ratelimit/issues/201