### PR TITLE
Add support for Redis AUTH with username and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,8 @@ As well Ratelimit supports TLS connections and authentication. These can be conf
 
 1. `REDIS_TLS` & `REDIS_PERSECOND_TLS`: set to `"true"` to enable a TLS connection for the specific connection type.
 1. `REDIS_TLS_CLIENT_CERT`, `REDIS_TLS_CLIENT_KEY`, and `REDIS_TLS_CACERT` to provides files to specify a TLS connection configuration to Redis server that requires client certificate verification. (This is effective when `REDIS_TLS` or `REDIS_PERSECOND_TLS` is set to to `"true"`).
-1. `REDIS_AUTH` & `REDIS_PERSECOND_AUTH`: set to `"password"` to enable authentication to the redis host.
+1. `REDIS_AUTH` & `REDIS_PERSECOND_AUTH`: set to `"password"` to enable password-only authentication to the redis host.
+1. `REDIS_AUTH` & `REDIS_PERSECOND_AUTH`: set to `"username:password"` to enable username-password authentication to the redis host.
 1. `CACHE_KEY_PREFIX`: a string to prepend to all cache keys
 
 ## Redis type

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/envoyproxy/ratelimit
 go 1.18
 
 require (
-	github.com/alicebob/miniredis/v2 v2.11.4
+	github.com/alicebob/miniredis/v2 v2.23.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/coocood/freecache v1.1.0
 	github.com/envoyproxy/go-control-plane v0.10.1
@@ -36,7 +36,7 @@ require (
 )
 
 require (
-	github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 // indirect
+	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
@@ -45,7 +45,7 @@ require (
 	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
-	github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb // indirect
+	github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.31.0
 	go.opentelemetry.io/otel v1.7.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.6.3

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,12 @@ github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6 h1:45bxf7AZMwWcqkLzDAQugVEwedisr5nRJ1r+7LYnv0U=
 github.com/alicebob/gopher-json v0.0.0-20180125190556-5a6b3ba71ee6/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
+github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZpUGpz5+4FfNmIU+FmZg2P3Xaj2v2bfNWmk=
+github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis/v2 v2.11.4 h1:GsuyeunTx7EllZBU3/6Ji3dhMQZDpC9rLf1luJ+6M5M=
 github.com/alicebob/miniredis/v2 v2.11.4/go.mod h1:VL3UDEfAH59bSa7MuHMuFToxkqyHh69s/WUbYlOAuyg=
+github.com/alicebob/miniredis/v2 v2.23.0 h1:+lwAJYjvvdIVg6doFHuotFjueJ/7KY10xo/vm3X3Scw=
+github.com/alicebob/miniredis/v2 v2.23.0/go.mod h1:XNqvJdQJv5mSuVMc0ynneafpnL/zv52acZ6kqeS0t88=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b h1:L/QXpzIa3pOvUGt1D1lA5KjYhPBAN/3iWdP7xeFS9F0=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
@@ -202,6 +206,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb h1:ZkM6LRnq40pR1Ox0hTHlnpkcOTuFIDQpZ1IN8rKKhX0=
 github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
+github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9 h1:k/gmLsJDWwWqbLCur2yWnJzwQEKRcAHXo6seXGuSwWw=
+github.com/yuin/gopher-lua v0.0.0-20210529063254-f4c35e4016d9/go.mod h1:E1AXubJBdNmFERAOucpDIxNzeGfLzg0mYh+UfMWdChA=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -77,9 +77,14 @@ func NewClientImpl(scope stats.Scope, useTls bool, auth, redisSocketType, redisT
 		}
 
 		if auth != "" {
-			logger.Warnf("enabling authentication to redis on %s", maskedUrl)
-
-			dialOpts = append(dialOpts, radix.DialAuthPass(auth))
+			user, pass, found := strings.Cut(auth, ":")
+			if found {
+				logger.Warnf("enabling authentication to redis on %s with user %s", maskedUrl, user)
+				dialOpts = append(dialOpts, radix.DialAuthUser(user, pass))
+			} else {
+				logger.Warnf("enabling authentication to redis on %s without user", maskedUrl)
+				dialOpts = append(dialOpts, radix.DialAuthPass(auth))
+			}
 		}
 
 		return radix.Dial(network, addr, dialOpts...)

--- a/test/redis/driver_impl_test.go
+++ b/test/redis/driver_impl_test.go
@@ -1,6 +1,7 @@
 package redis_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -76,6 +77,32 @@ func testNewClientImpl(t *testing.T, pipelineWindow time.Duration, pipelineLimit
 			redisSrv.RequireAuth(redisAuth)
 
 			assert.NotPanics(t, func() {
+				mkRedisClient(redisAuth, redisSrv.Addr())
+			})
+		})
+
+		t.Run("auth user pass", func(t *testing.T) {
+			redisSrv := mustNewRedisServer()
+			defer redisSrv.Close()
+
+			user, pass := "test-user", "test-pass"
+			redisSrv.RequireUserAuth(user, pass)
+
+			redisAuth := fmt.Sprintf("%s:%s", user, pass)
+			assert.NotPanics(t, func() {
+				mkRedisClient(redisAuth, redisSrv.Addr())
+			})
+		})
+
+		t.Run("auth user pass fail", func(t *testing.T) {
+			redisSrv := mustNewRedisServer()
+			defer redisSrv.Close()
+
+			user, pass := "test-user", "test-pass"
+			redisSrv.RequireUserAuth(user, pass)
+
+			redisAuth := fmt.Sprintf("%s:invalid-password", user)
+			assert.PanicsWithError(t, "WRONGPASS invalid username-password pair", func() {
 				mkRedisClient(redisAuth, redisSrv.Addr())
 			})
 		})


### PR DESCRIPTION
The current code only supports Redis AUTH with the username `default`.
Add support for Redis AUTH with username and password.

Based on this PR for the upstream library:
https://github.com/mediocregopher/radix/pull/195/files

---

I have tested configuring the ratelimit service with environment variables `REDIS_AUTH=user:pass` and `REDIS_PERSECOND_AUTH=user:pass` to connect to a password-protected AWS Elasticache Redis server.