### PR TITLE
Use _imaps._tcp.gmail.com in srv tests

### DIFF
--- a/test/srv/srv_test.go
+++ b/test/srv/srv_test.go
@@ -49,12 +49,11 @@ func TestServerStringsFromSevWhenSrvIsWellFormedButNotLookupable(t *testing.T) {
 }
 
 func TestServerStrings(t *testing.T) {
-	// it seems reasonable to think _xmpp-server._tcp.gmail.com will be available for a long time!
 	srvResolver := srv.DnsSrvResolver{}
-	servers, err := srvResolver.ServerStringsFromSrv("_xmpp-server._tcp.gmail.com.")
+	servers, err := srvResolver.ServerStringsFromSrv("_imaps._tcp.gmail.com.")
+	assert.Nil(t, err)
 	assert.True(t, len(servers) > 0)
 	for _, s := range servers {
-		assert.Regexp(t, `^.*xmpp-server.*google.com.:\d+$`, s)
+		assert.Regexp(t, `^.*imap.*gmail.com.:\d+$`, s)
 	}
-	assert.Nil(t, err)
 }


### PR DESCRIPTION
* Seeing tests failures in CI with the current SRV entry `_xmpp-server._tcp.gmail.com.`
https://github.com/envoyproxy/ratelimit/actions/runs/3466737811/jobs/5802374477#step:3:257

* What is odd is I also tried `_xmpp-server._tcp.google.com.` which is used in the upstream `net.LookupSRV` tests
https://cs.opensource.google/go/go/+/master:src/net/lookup_test.go;l=47;drc=2b59307ac21135ab8db58e08fb98211fbedbb10d?q=LookupSRV&ss=go%2Fgo but that failed as well

Signed-off-by: Arko Dasgupta <arko@tetrate.io>