### PR TITLE
Add support to RateLimit-Policy response header

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,7 @@ The following environment variables control the custom response feature:
 1. `LIMIT_LIMIT_HEADER` - The default value is "RateLimit-Limit", setting the environment variable will specify an alternative header name
 1. `LIMIT_REMAINING_HEADER` - The default value is "RateLimit-Remaining", setting the environment variable will specify an alternative header name
 1. `LIMIT_RESET_HEADER` - The default value is "RateLimit-Reset", setting the environment variable will specify an alternative header name
+1. `LIMIT_RESET_POLICY` - The default value is "RateLimit-Policy", setting the environment variable will specify an alternative header name
 
 You may use the following commands to quickly setup a openTelemetry collector together with a Jaeger all-in-one binary for quickstart:
 

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -73,6 +73,8 @@ type Settings struct {
 	HeaderRatelimitRemaining string `envconfig:"LIMIT_REMAINING_HEADER" default:"RateLimit-Remaining"`
 	// value: remaining seconds
 	HeaderRatelimitReset string `envconfig:"LIMIT_RESET_HEADER" default:"RateLimit-Reset"`
+	// value: rate limit policy summary
+	HeaderRatelimitPolicy string `envconfig:"LIMIT_POLICY_HEADER" default:"RateLimit-Policy"`
 
 	// Redis settings
 	RedisSocketType string `envconfig:"REDIS_SOCKET_TYPE" default:"unix"`

--- a/test/service/ratelimit_test.go
+++ b/test/service/ratelimit_test.go
@@ -343,11 +343,13 @@ func TestServiceWithCustomRatelimitHeaders(test *testing.T) {
 	os.Setenv("LIMIT_LIMIT_HEADER", "A-Ratelimit-Limit")
 	os.Setenv("LIMIT_REMAINING_HEADER", "A-Ratelimit-Remaining")
 	os.Setenv("LIMIT_RESET_HEADER", "A-Ratelimit-Reset")
+	os.Setenv("LIMIT_POLICY_HEADER", "A-Ratelimit-Policy")
 	defer func() {
 		os.Unsetenv("LIMIT_RESPONSE_HEADERS_ENABLED")
 		os.Unsetenv("LIMIT_LIMIT_HEADER")
 		os.Unsetenv("LIMIT_REMAINING_HEADER")
 		os.Unsetenv("LIMIT_RESET_HEADER")
+		os.Unsetenv("LIMIT_POLICY_HEADER")
 	}()
 
 	t := commonSetup(test)
@@ -390,6 +392,7 @@ func TestServiceWithCustomRatelimitHeaders(test *testing.T) {
 				{Key: "A-Ratelimit-Limit", Value: "10"},
 				{Key: "A-Ratelimit-Remaining", Value: "0"},
 				{Key: "A-Ratelimit-Reset", Value: "58"},
+				{Key: "A-Ratelimit-Policy", Value: "10;60"},
 			},
 		},
 		response)
@@ -442,6 +445,7 @@ func TestServiceWithDefaultRatelimitHeaders(test *testing.T) {
 				{Key: "RateLimit-Limit", Value: "10"},
 				{Key: "RateLimit-Remaining", Value: "0"},
 				{Key: "RateLimit-Reset", Value: "58"},
+				{Key: "RateLimit-Policy", Value: "10;60"},
 			},
 		},
 		response)


### PR DESCRIPTION
The ratelimit server now support the following custom headers:

- RateLimit-Limit
- RateLimit-Remaining
- RateLimit-Reset 
 
Adding new spec header: RateLimit-Policy

https://greenbytes.de/tech/webdav/draft-ietf-httpapi-ratelimit-headers-latest.html\#rfc.section.3.2
Signed-off-by: Amiram Wingarten <amiram.wingarten@sap.com>