### PR TITLE
Print requested domain with descriptors in debug log

### DIFF
--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -124,7 +124,7 @@ func (this *service) constructLimitsToCheck(request *pb.RateLimitRequest, ctx co
 					fmt.Sprintf("(%s=%s)", descriptorEntry.Key, descriptorEntry.Value),
 				)
 			}
-			logger.Debugf("got descriptor: %s", strings.Join(descriptorEntryStrings, ","))
+			logger.Debugf("got descriptor: %s %s", request.Domain, strings.Join(descriptorEntryStrings, ","))
 		}
 		limitsToCheck[i] = snappedConfig.GetLimit(ctx, request.Domain, descriptor)
 		if logger.IsLevelEnabled(logger.DebugLevel) {


### PR DESCRIPTION
If only the descriptor is printed in the log, it is not possible to know which domain the request is for.
Print domain in the log to make analysis easier.

```go
limitsToCheck[i] = snappedConfig.GetLimit(ctx, request.Domain, descriptor)
```