### PR TITLE
Allow override of runtime app directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Support for [v2 rls proto](https://github.com/envoyproxy/data-plane-api/blob/mas
   ```
 - To run the server locally using some sensible default settings you can do this (this will setup the server to read the configuration files from the path you specify):
   ```bash
-  USE_STATSD=false LOG_LEVEL=debug REDIS_SOCKET_TYPE=tcp REDIS_URL=localhost:6379 RUNTIME_ROOT=/home/user/src/runtime/data RUNTIME_SUBDIRECTORY=ratelimit
+  USE_STATSD=false LOG_LEVEL=debug REDIS_SOCKET_TYPE=tcp REDIS_URL=localhost:6379 RUNTIME_ROOT=/home/user/src/runtime/data RUNTIME_SUBDIRECTORY=ratelimit RUNTIME_APPDIRECTORY=config
   ```
 
 ## Docker-compose setup
@@ -593,19 +593,20 @@ package with the following environment variables:
 ```
 RUNTIME_ROOT default:"/srv/runtime_data/current"
 RUNTIME_SUBDIRECTORY
+RUNTIME_APPDIRECTORY default:"config"
 RUNTIME_IGNOREDOTFILES default:"false"
 ```
 
-**Configuration files are loaded from RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/config/\*.yaml**
+**Configuration files are loaded from RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/RUNTIME_APPDIRECTORY/\*.yaml**
 
 There are two methods for triggering a configuration reload:
 
 1. Symlink RUNTIME_ROOT to a different directory.
-2. Update the contents inside `RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/config/` directly.
+2. Update the contents inside `RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/RUNTIME_APPDIRECTORY/` directly.
 
 The former is the default behavior. To use the latter method, set the `RUNTIME_WATCH_ROOT` environment variable to `false`.
 
-The following filesystem operations on configuration files inside `RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/config/` will force a reload of all config files:
+The following filesystem operations on configuration files inside `RUNTIME_ROOT/RUNTIME_SUBDIRECTORY/RUNTIME_APPDIRECTORY/` will force a reload of all config files:
 
 - Write
 - Create

--- a/src/provider/file_provider.go
+++ b/src/provider/file_provider.go
@@ -55,7 +55,7 @@ func (p *FileProvider) sendEvent() {
 	files := []config.RateLimitConfigToLoad{}
 	snapshot := p.runtime.Snapshot()
 	for _, key := range snapshot.Keys() {
-		if p.runtimeWatchRoot && !strings.HasPrefix(key, "config.") {
+		if p.runtimeWatchRoot && !strings.HasPrefix(key, p.settings.RuntimeAppDirectory+".") {
 			continue
 		}
 
@@ -91,7 +91,7 @@ func (p *FileProvider) setupRuntime() {
 
 		p.runtime, err = loader.New2(
 			filepath.Join(p.settings.RuntimePath, p.settings.RuntimeSubdirectory),
-			"config",
+			p.settings.RuntimeAppDirectory,
 			p.rootStore.ScopeWithTags("runtime", p.settings.ExtraTags),
 			directoryRefresher,
 			loaderOpts...)

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -77,6 +77,7 @@ type Settings struct {
 	// Settings for rate limit configuration
 	RuntimePath           string `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`
 	RuntimeSubdirectory   string `envconfig:"RUNTIME_SUBDIRECTORY"`
+	RuntimeAppDirectory   string `envconfig:"RUNTIME_APPDIRECTORY" default:"config"`
 	RuntimeIgnoreDotFiles bool   `envconfig:"RUNTIME_IGNOREDOTFILES" default:"false"`
 	RuntimeWatchRoot      bool   `envconfig:"RUNTIME_WATCH_ROOT" default:"true"`
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -48,6 +48,7 @@ func defaultSettings() settings.Settings {
 	// Set some convenient defaults for all integration tests.
 	s.RuntimePath = "runtime/current"
 	s.RuntimeSubdirectory = "ratelimit"
+	s.RuntimeAppDirectory = "config"
 	s.RedisPerSecondSocketType = "tcp"
 	s.RedisSocketType = "tcp"
 	s.DebugPort = 8084


### PR DESCRIPTION
Allow override of runtime app directory due to our configuration delivery system has a hard-coded directory that isn't 'config'

Signed-off-by: Peter Leng [yleng@pinterest.com](mailto:yleng@pinterest.com)