### PR TITLE
Add wildcard support to descriptor values

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
       - [Example 6](#example-6)
       - [Example 7](#example-7)
       - [Example 8](#example-8)
+      - [Example 9](#example-9)
   - [Loading Configuration](#loading-configuration)
     - [File Based Configuration Loading](#file-based-configuration-loading)
     - [xDS Management Server Based Configuration Loading](#xds-management-server-based-configuration-loading)
@@ -569,6 +570,25 @@ The metrics keys will be the following:
 rather than the normal
 "key1"
 "key1_value1"
+
+#### Example 9
+
+Value supports wildcard matching to apply rate-limit for nested endpoints:
+
+```
+(key_1, value_1): 20 / sec
+(key_1, value_2): 20 / sec
+```
+
+```yaml
+domain: example9
+descriptors:
+  - key: key1
+    value: value*
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20
+```
 
 ## Loading Configuration
 

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -305,6 +305,15 @@ func (this *rateLimitConfigImpl) GetLimit(
 		finalKey := entry.Key + "_" + entry.Value
 		logger.Debugf("looking up key: %s", finalKey)
 		nextDescriptor := descriptorsMap[finalKey]
+
+		if nextDescriptor == nil {
+			for descriptorKey := range descriptorsMap {
+				if descriptorKey[len(descriptorKey)-1:] == "*" && strings.HasPrefix(finalKey, strings.TrimSuffix(descriptorKey, "*")) {
+					nextDescriptor = descriptorsMap[descriptorKey]
+				}
+			}
+		}
+
 		if nextDescriptor == nil {
 			finalKey = entry.Key
 			logger.Debugf("looking up key: %s", finalKey)

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -40,8 +40,9 @@ type YamlRoot struct {
 }
 
 type rateLimitDescriptor struct {
-	descriptors map[string]*rateLimitDescriptor
-	limit       *RateLimit
+	descriptors  map[string]*rateLimitDescriptor
+	limit        *RateLimit
+	wildcardKeys []string
 }
 
 type rateLimitDomain struct {
@@ -184,9 +185,14 @@ func (this *rateLimitDescriptor) loadDescriptors(config RateLimitConfigToLoad, p
 
 		logger.Debugf(
 			"loading descriptor: key=%s%s", newParentKey, rateLimitDebugString)
-		newDescriptor := &rateLimitDescriptor{map[string]*rateLimitDescriptor{}, rateLimit}
+		newDescriptor := &rateLimitDescriptor{map[string]*rateLimitDescriptor{}, rateLimit, nil}
 		newDescriptor.loadDescriptors(config, newParentKey+".", descriptorConfig.Descriptors, statsManager)
 		this.descriptors[finalKey] = newDescriptor
+
+		// Preload keys ending with "*" symbol.
+		if finalKey[len(finalKey)-1:] == "*" {
+			this.wildcardKeys = append(this.wildcardKeys, finalKey)
+		}
 	}
 }
 
@@ -256,7 +262,7 @@ func (this *rateLimitConfigImpl) loadConfig(config RateLimitConfigToLoad) {
 	}
 
 	logger.Debugf("loading domain: %s", root.Domain)
-	newDomain := &rateLimitDomain{rateLimitDescriptor{map[string]*rateLimitDescriptor{}, nil}}
+	newDomain := &rateLimitDomain{rateLimitDescriptor{map[string]*rateLimitDescriptor{}, nil, nil}}
 	newDomain.loadDescriptors(config, root.Domain+".", root.Descriptors, this.statsManager)
 	this.domains[root.Domain] = newDomain
 }
@@ -306,10 +312,11 @@ func (this *rateLimitConfigImpl) GetLimit(
 		logger.Debugf("looking up key: %s", finalKey)
 		nextDescriptor := descriptorsMap[finalKey]
 
-		if nextDescriptor == nil {
-			for descriptorKey := range descriptorsMap {
-				if descriptorKey[len(descriptorKey)-1:] == "*" && strings.HasPrefix(finalKey, strings.TrimSuffix(descriptorKey, "*")) {
-					nextDescriptor = descriptorsMap[descriptorKey]
+		if nextDescriptor == nil && len(value.wildcardKeys) > 0 {
+			for _, wildcardKey := range value.wildcardKeys {
+				if strings.HasPrefix(finalKey, strings.TrimSuffix(wildcardKey, "*")) {
+					nextDescriptor = descriptorsMap[wildcardKey]
+					break
 				}
 			}
 		}

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -564,3 +564,54 @@ func TestShadowModeConfig(t *testing.T) {
 	assert.EqualValues(1, stats.NewCounter("test-domain.key2_value2.near_limit").Value())
 	assert.EqualValues(0, stats.NewCounter("test-domain.key2_value2.shadow_mode").Value())
 }
+
+func TestWildcardConfig(t *testing.T) {
+	assert := assert.New(t)
+	stats := stats.NewStore(stats.NewNullSink(), false)
+	rlConfig := config.NewRateLimitConfigImpl(loadFile("wildcard.yaml"), mockstats.NewMockStatManager(stats))
+	rlConfig.Dump()
+
+	// Baseline to show wildcard works like no value
+	withoutVal1 := rlConfig.GetLimit(
+		nil, "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "noVal", Value: "foo1"}},
+		})
+	withoutVal2 := rlConfig.GetLimit(
+		nil, "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "noVal", Value: "foo2"}},
+		})
+	assert.Equal(withoutVal1, withoutVal2)
+
+	// Matches multiple wildcard values and results are equal
+	wildcard1 := rlConfig.GetLimit(
+		nil, "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "wild", Value: "foo1"}},
+		})
+	wildcard2 := rlConfig.GetLimit(
+		nil, "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "wild", Value: "foo2"}},
+		})
+	assert.NotNil(wildcard1)
+	assert.NotNil(wildcard2)
+	assert.Equal(wildcard1, wildcard2)
+
+	// Doesn't match non-matching values
+	noMatch := rlConfig.GetLimit(
+		nil, "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "wild", Value: "bar"}},
+		})
+	assert.Nil(noMatch)
+
+	// Non-wildcard values don't eager match
+	eager := rlConfig.GetLimit(
+		nil, "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "noWild", Value: "foo1"}},
+		})
+	assert.Nil(eager)
+}

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -568,7 +568,7 @@ func TestShadowModeConfig(t *testing.T) {
 func TestWildcardConfig(t *testing.T) {
 	assert := assert.New(t)
 	stats := stats.NewStore(stats.NewNullSink(), false)
-	rlConfig := config.NewRateLimitConfigImpl(loadFile("wildcard.yaml"), mockstats.NewMockStatManager(stats))
+	rlConfig := config.NewRateLimitConfigImpl(loadFile("wildcard.yaml"), mockstats.NewMockStatManager(stats), false)
 	rlConfig.Dump()
 
 	// Baseline to show wildcard works like no value
@@ -582,6 +582,7 @@ func TestWildcardConfig(t *testing.T) {
 		&pb_struct.RateLimitDescriptor{
 			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "noVal", Value: "foo2"}},
 		})
+	assert.NotNil(withoutVal1)
 	assert.Equal(withoutVal1, withoutVal2)
 
 	// Matches multiple wildcard values and results are equal
@@ -596,7 +597,6 @@ func TestWildcardConfig(t *testing.T) {
 			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "wild", Value: "foo2"}},
 		})
 	assert.NotNil(wildcard1)
-	assert.NotNil(wildcard2)
 	assert.Equal(wildcard1, wildcard2)
 
 	// Doesn't match non-matching values
@@ -614,4 +614,12 @@ func TestWildcardConfig(t *testing.T) {
 			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "noWild", Value: "foo1"}},
 		})
 	assert.Nil(eager)
+
+	// Wildcard in the middle of value is not supported.
+	midWildcard := rlConfig.GetLimit(
+		nil, "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "midWildcard", Value: "barab"}},
+		})
+	assert.Nil(midWildcard)
 }

--- a/test/config/wildcard.yaml
+++ b/test/config/wildcard.yaml
@@ -1,0 +1,17 @@
+# Basic configuration for testing.
+domain: test-domain
+descriptors:
+  - key: wild
+    value: foo*
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20
+  - key: noWild
+    value: foo
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20
+  - key: noVal
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20

--- a/test/config/wildcard.yaml
+++ b/test/config/wildcard.yaml
@@ -15,3 +15,8 @@ descriptors:
     rate_limit:
       unit: minute
       requests_per_unit: 20
+  - key: midWild
+    value: bar*b
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20


### PR DESCRIPTION
Fixes #317.

Add wildcard support to descriptor values to match endpoints under the value. This eliminates the need to explicitly list all endpoints to which rate limiter should be applied.

Example configuration:
```yaml
domain: test-domain
descriptors:
  - key: wild
    value: foo*
    rate_limit:
      unit: minute
      requests_per_unit: 20
```