### PR TITLE
Add possibility to provide additional headers to grpc request in xds sotw provider

### DIFF
--- a/src/provider/xds_grpc_sotw_provider.go
+++ b/src/provider/xds_grpc_sotw_provider.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"google.golang.org/grpc/metadata"
+
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/golang/protobuf/ptypes/any"
@@ -39,7 +41,7 @@ type XdsGrpcSotwProvider struct {
 
 // NewXdsGrpcSotwProvider initializes xDS listener and returns the xDS provider.
 func NewXdsGrpcSotwProvider(settings settings.Settings, statsManager stats.Manager) RateLimitConfigProvider {
-	ctx := context.Background()
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.New(settings.ConfigGrpcXdsClientAdditionalHeaders))
 	p := &XdsGrpcSotwProvider{
 		settings:               settings,
 		statsManager:           statsManager,

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -68,6 +68,9 @@ type Settings struct {
 	// GrpcClientTlsSAN is the SAN to validate from the client cert during mTLS auth
 	ConfigGrpcXdsServerTlsSAN string `envconfig:"CONFIG_GRPC_XDS_SERVER_TLS_SAN" default:""`
 
+	// xDS grpc client configuration
+	ConfigGrpcXdsClientAdditionalHeaders map[string]string `envconfig:"CONFIG_GRPC_XDS_CLIENT_ADDITIONAL_HEADERS"`
+
 	// Stats-related settings
 	UseStatsd  bool              `envconfig:"USE_STATSD" default:"true"`
 	StatsdHost string            `envconfig:"STATSD_HOST" default:"localhost"`


### PR DESCRIPTION
Adding headers to GRPC requests can be used in multiple ways, one and most important is adding Authorization data to requests between ratelimit service and config provider.