### PR TITLE
 Add flag to skip hostname verification for Redis TLS connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ As well Ratelimit supports TLS connections and authentication. These can be conf
 
 1. `REDIS_TLS` & `REDIS_PERSECOND_TLS`: set to `"true"` to enable a TLS connection for the specific connection type.
 1. `REDIS_TLS_CLIENT_CERT`, `REDIS_TLS_CLIENT_KEY`, and `REDIS_TLS_CACERT` to provides files to specify a TLS connection configuration to Redis server that requires client certificate verification. (This is effective when `REDIS_TLS` or `REDIS_PERSECOND_TLS` is set to to `"true"`).
+1. `REDIS_TLS_SKIP_HOSTNAME_VERIFICATION` set to `"true"` will skip hostname verification in environments where the certificate has an invalid hostname, such as GCP Memorystore.
 1. `REDIS_AUTH` & `REDIS_PERSECOND_AUTH`: set to `"password"` to enable password-only authentication to the redis host.
 1. `REDIS_AUTH` & `REDIS_PERSECOND_AUTH`: set to `"username:password"` to enable username-password authentication to the redis host.
 1. `CACHE_KEY_PREFIX`: a string to prepend to all cache keys

--- a/src/client_cmd/main.go
+++ b/src/client_cmd/main.go
@@ -92,7 +92,7 @@ func main() {
 		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor()),
 	}
 	if *grpcUseTLS {
-		tlsConfig := utils.TlsConfigFromFiles(*grpcTlsCertFile, *grpcTlsKeyFile, *grpcServerTlsCACert, utils.ServerCA)
+		tlsConfig := utils.TlsConfigFromFiles(*grpcTlsCertFile, *grpcTlsKeyFile, *grpcServerTlsCACert, utils.ServerCA, false)
 		dialOptions = append(dialOptions, grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
 	} else {
 		dialOptions = append(dialOptions, grpc.WithInsecure())

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -111,9 +111,10 @@ type Settings struct {
 	// TODO: Make this setting configurable out of the box instead of having to provide it through code.
 	RedisTlsConfig *tls.Config
 	// Allow to set the client certificate and key for TLS connections.
-	RedisTlsClientCert string `envconfig:"REDIS_TLS_CLIENT_CERT" default:""`
-	RedisTlsClientKey  string `envconfig:"REDIS_TLS_CLIENT_KEY" default:""`
-	RedisTlsCACert     string `envconfig:"REDIS_TLS_CACERT" default:""`
+	RedisTlsClientCert               string `envconfig:"REDIS_TLS_CLIENT_CERT" default:""`
+	RedisTlsClientKey                string `envconfig:"REDIS_TLS_CLIENT_KEY" default:""`
+	RedisTlsCACert                   string `envconfig:"REDIS_TLS_CACERT" default:""`
+	RedisTlsSkipHostnameVerification bool   `envconfig:"REDIS_TLS_SKIP_HOSTNAME_VERIFICATION" default:"false"`
 
 	// RedisPipelineWindow sets the duration after which internal pipelines will be flushed.
 	// If window is zero then implicit pipelining will be disabled. Radix use 150us for the
@@ -187,7 +188,7 @@ func RedisTlsConfig(redisTls bool) Option {
 		// so let's just initialize to what we want the correct value to be.
 		s.RedisTlsConfig = &tls.Config{}
 		if redisTls {
-			s.RedisTlsConfig = utils.TlsConfigFromFiles(s.RedisTlsClientCert, s.RedisTlsClientKey, s.RedisTlsCACert, utils.ServerCA)
+			s.RedisTlsConfig = utils.TlsConfigFromFiles(s.RedisTlsClientCert, s.RedisTlsClientKey, s.RedisTlsCACert, utils.ServerCA, s.RedisTlsSkipHostnameVerification)
 		}
 	}
 }
@@ -195,7 +196,7 @@ func RedisTlsConfig(redisTls bool) Option {
 func GrpcServerTlsConfig() Option {
 	return func(s *Settings) {
 		if s.GrpcServerUseTLS {
-			grpcServerTlsConfig := utils.TlsConfigFromFiles(s.GrpcServerTlsCert, s.GrpcServerTlsKey, s.GrpcClientTlsCACert, utils.ClientCA)
+			grpcServerTlsConfig := utils.TlsConfigFromFiles(s.GrpcServerTlsCert, s.GrpcServerTlsKey, s.GrpcClientTlsCACert, utils.ClientCA, false)
 			if s.GrpcClientTlsCACert != "" {
 				grpcServerTlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			} else {
@@ -209,7 +210,7 @@ func GrpcServerTlsConfig() Option {
 func ConfigGrpcXdsServerTlsConfig() Option {
 	return func(s *Settings) {
 		if s.ConfigGrpcXdsServerUseTls {
-			configGrpcXdsServerTlsConfig := utils.TlsConfigFromFiles(s.ConfigGrpcXdsClientTlsCert, s.ConfigGrpcXdsClientTlsKey, s.ConfigGrpcXdsServerTlsCACert, utils.ServerCA)
+			configGrpcXdsServerTlsConfig := utils.TlsConfigFromFiles(s.ConfigGrpcXdsClientTlsCert, s.ConfigGrpcXdsClientTlsKey, s.ConfigGrpcXdsServerTlsCACert, utils.ServerCA, false)
 			if s.ConfigGrpcXdsServerTlsCACert != "" {
 				configGrpcXdsServerTlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			} else {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -261,6 +261,7 @@ func Test_mTLS(t *testing.T) {
 	s.RedisTlsConfig = &tls.Config{}
 	s.RedisAuth = "password123"
 	s.RedisTls = true
+	s.RedisTlsSkipHostnameVerification = false
 	s.RedisPerSecondAuth = "password123"
 	s.RedisPerSecondTls = true
 	assert := assert.New(t)
@@ -276,7 +277,7 @@ func Test_mTLS(t *testing.T) {
 	settings.GrpcServerTlsConfig()(&s)
 	runner := startTestRunner(t, s)
 	defer runner.Stop()
-	clientTlsConfig := utils.TlsConfigFromFiles(clientCertFile, clientCertKey, serverCAFile, utils.ServerCA)
+	clientTlsConfig := utils.TlsConfigFromFiles(clientCertFile, clientCertKey, serverCAFile, utils.ServerCA, false)
 	conn, err := grpc.Dial(fmt.Sprintf("localhost:%v", s.GrpcPort), grpc.WithTransportCredentials(credentials.NewTLS(clientTlsConfig)))
 	assert.NoError(err)
 	defer conn.Close()


### PR DESCRIPTION
In some scenarios one may not have full control over the certificate being served from the redis server, for example GCP Memorystore which sets the CN to an IP address.