### PR TITLE
Fixed otel typo in

### DIFF
--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -19,7 +19,7 @@ import (
 	"github.com/envoyproxy/ratelimit/src/utils"
 )
 
-var tracer = otel.Tracer("redis.fixedCacaheImpl")
+var tracer = otel.Tracer("redis.fixedCacheImpl")
 
 type fixedRateLimitCacheImpl struct {
 	client Client


### PR DESCRIPTION
Fixed a typo in the `otel.Tracer` name