### PR TITLE
fix wildcard support to cover nested descriptors

### DIFF
--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -305,6 +305,7 @@ func (this *rateLimitConfigImpl) GetLimit(
 	}
 
 	descriptorsMap := value.descriptors
+	prevDescriptor := &value.rateLimitDescriptor
 	for i, entry := range descriptor.Entries {
 		// First see if key_value is in the map. If that isn't in the map we look for just key
 		// to check for a default value.
@@ -312,8 +313,8 @@ func (this *rateLimitConfigImpl) GetLimit(
 		logger.Debugf("looking up key: %s", finalKey)
 		nextDescriptor := descriptorsMap[finalKey]
 
-		if nextDescriptor == nil && len(value.wildcardKeys) > 0 {
-			for _, wildcardKey := range value.wildcardKeys {
+		if nextDescriptor == nil && len(prevDescriptor.wildcardKeys) > 0 {
+			for _, wildcardKey := range prevDescriptor.wildcardKeys {
 				if strings.HasPrefix(finalKey, strings.TrimSuffix(wildcardKey, "*")) {
 					nextDescriptor = descriptorsMap[wildcardKey]
 					break
@@ -347,6 +348,7 @@ func (this *rateLimitConfigImpl) GetLimit(
 
 			break
 		}
+		prevDescriptor = nextDescriptor
 	}
 
 	return rateLimit

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -597,8 +597,14 @@ func TestWildcardConfig(t *testing.T) {
 		&pb_struct.RateLimitDescriptor{
 			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "wild", Value: "foo2"}},
 		})
+	wildcard3 := rlConfig.GetLimit(
+		nil, "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "nestedWild", Value: "val1"}, {Key: "wild", Value: "goo2"}},
+		})
 	assert.NotNil(wildcard1)
 	assert.Equal(wildcard1, wildcard2)
+	assert.NotNil(wildcard3)
 
 	// Doesn't match non-matching values
 	noMatch := rlConfig.GetLimit(

--- a/test/config/wildcard.yaml
+++ b/test/config/wildcard.yaml
@@ -20,3 +20,11 @@ descriptors:
     rate_limit:
       unit: minute
       requests_per_unit: 20
+  - key: nestedWild
+    value: val1
+    descriptors:
+      - key: wild
+        value: goo*
+        rate_limit:
+          unit: minute
+          requests_per_unit: 20


### PR DESCRIPTION
each descriptor level can have a wildcard property therefore GetLimit should inspect there and not only on the base level