### PR TITLE
Fix shadow mode metric is not collected when local cache hit

### DIFF
--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -61,14 +61,12 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 
 		// Check if key is over the limit in local cache.
 		if this.baseRateLimiter.IsOverLimitWithLocalCache(cacheKey.Key) {
-
 			if limits[i].ShadowMode {
 				logger.Debugf("Cache key %s would be rate limited but shadow mode is enabled on this rule", cacheKey.Key)
 			} else {
 				logger.Debugf("cache key is over the limit: %s", cacheKey.Key)
-				isOverLimitWithLocalCache[i] = true
 			}
-
+			isOverLimitWithLocalCache[i] = true
 			continue
 		}
 


### PR DESCRIPTION
## Description

This PR fixes https://github.com/envoyproxy/ratelimit/issues/423 issue where statistics were not collected correctly when hitting the local cache.

If the local cache is hit, the rate limit service does not perform the INCR command, but the GetResponseDescriptorStatus method does not handle it properly.

### Invalid metric
shadow mode stats are not collected for the actual number of requests.

![image](https://github.com/envoyproxy/ratelimit/assets/5635513/2642a9c5-d88f-4b6f-922c-9bf919294b42)


### Expected
shadow mode stat should be the same value as over limit .

![image](https://github.com/envoyproxy/ratelimit/assets/5635513/a8750a79-96d1-4be5-b14f-9a95852cf926)
