### PR TITLE
Set logger level before tracing initialization

### DIFF
--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -76,16 +76,6 @@ func createLimiter(srv server.Server, s settings.Settings, localCache *freecache
 
 func (runner *Runner) Run() {
 	s := runner.settings
-	if s.TracingEnabled {
-		tp := trace.InitProductionTraceProvider(s.TracingExporterProtocol, s.TracingServiceName, s.TracingServiceNamespace, s.TracingServiceInstanceId, s.TracingSamplingRate)
-		defer func() {
-			if err := tp.Shutdown(context.Background()); err != nil {
-				logger.Printf("Error shutting down tracer provider: %v", err)
-			}
-		}()
-	} else {
-		logger.Infof("Tracing disabled")
-	}
 
 	logLevel, err := logger.ParseLevel(s.LogLevel)
 	if err != nil {
@@ -101,6 +91,17 @@ func (runner *Runner) Run() {
 				logger.FieldKeyMsg:  "@message",
 			},
 		})
+	}
+
+	if s.TracingEnabled {
+		tp := trace.InitProductionTraceProvider(s.TracingExporterProtocol, s.TracingServiceName, s.TracingServiceNamespace, s.TracingServiceInstanceId, s.TracingSamplingRate)
+		defer func() {
+			if err := tp.Shutdown(context.Background()); err != nil {
+				logger.Printf("Error shutting down tracer provider: %v", err)
+			}
+		}()
+	} else {
+		logger.Infof("Tracing disabled")
 	}
 
 	var localCache *freecache.Cache


### PR DESCRIPTION
An issue: if JSON log format is used `InitProductionTraceProvider` prints the `time="2023-06-05T15:29:34Z" level=info msg="TracerProvider initialized with following parameters: ...` line in the default (text) format. 
Fix: set log level before initializing OTEL.