### PR TITLE
Fix incrementing cache keys when overall status is over limited

### DIFF
--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -53,32 +53,27 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 	results := make([]uint32, len(request.Descriptors))
 	var pipeline, perSecondPipeline Pipeline
 
-	for _, cacheKey := range cacheKeys {
-		if cacheKey.Key == "" {
-			continue
-		}
-
-		// Check if any of the descriptors are over limit in local cache.
-		if this.baseRateLimiter.IsOverLimitWithLocalCache(cacheKey.Key) {
-			hitsAddend = 0
-			break
-		}
-	}
-
-	// Now, actually setup the pipeline, skipping empty cache keys.
-	for i, cacheKey := range cacheKeys {
+	for j, cacheKey := range cacheKeys {
 		if cacheKey.Key == "" {
 			continue
 		}
 
 		// Check if key is over the limit in local cache.
 		if this.baseRateLimiter.IsOverLimitWithLocalCache(cacheKey.Key) {
-			if limits[i].ShadowMode {
+			hitsAddend = 0
+			if limits[j].ShadowMode {
 				logger.Debugf("Cache key %s would be rate limited but shadow mode is enabled on this rule", cacheKey.Key)
 			} else {
 				logger.Debugf("cache key is over the limit: %s", cacheKey.Key)
 			}
-			isOverLimitWithLocalCache[i] = true
+			isOverLimitWithLocalCache[j] = true
+			continue
+		}
+	}
+
+	// Now, actually setup the pipeline, skipping empty cache keys.
+	for i, cacheKey := range cacheKeys {
+		if cacheKey.Key == "" {
 			continue
 		}
 

--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -53,6 +53,18 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 	results := make([]uint32, len(request.Descriptors))
 	var pipeline, perSecondPipeline Pipeline
 
+	for _, cacheKey := range cacheKeys {
+		if cacheKey.Key == "" {
+			continue
+		}
+
+		// Check if any of the descriptors are over limit in local cache.
+		if this.baseRateLimiter.IsOverLimitWithLocalCache(cacheKey.Key) {
+			hitsAddend = 0
+			break
+		}
+	}
+
 	// Now, actually setup the pipeline, skipping empty cache keys.
 	for i, cacheKey := range cacheKeys {
 		if cacheKey.Key == "" {

--- a/test/redis/fixed_cache_impl_test.go
+++ b/test/redis/fixed_cache_impl_test.go
@@ -274,8 +274,8 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 		},
 		cache.DoLimit(context.Background(), request, limits))
 	assert.Equal(uint64(4), limits[0].Stats.TotalHits.Value())
-	assert.Equal(uint64(2), limits[0].Stats.OverLimit.Value())
-	assert.Equal(uint64(1), limits[0].Stats.OverLimitWithLocalCache.Value())
+	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimitWithLocalCache.Value())
 	assert.Equal(uint64(1), limits[0].Stats.NearLimit.Value())
 	assert.Equal(uint64(2), limits[0].Stats.WithinLimit.Value())
 
@@ -586,9 +586,9 @@ func TestOverLimitWithLocalCacheShadowRule(t *testing.T) {
 
 	// Even if you hit the local cache, other metrics should increase normally.
 	assert.Equal(uint64(4), limits[0].Stats.TotalHits.Value())
-	assert.Equal(uint64(2), limits[0].Stats.OverLimit.Value())
-	assert.Equal(uint64(1), limits[0].Stats.OverLimitWithLocalCache.Value())
-	assert.Equal(uint64(2), limits[0].Stats.ShadowMode.Value())
+	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimitWithLocalCache.Value())
+	assert.Equal(uint64(1), limits[0].Stats.ShadowMode.Value())
 	assert.Equal(uint64(1), limits[0].Stats.NearLimit.Value())
 	assert.Equal(uint64(2), limits[0].Stats.WithinLimit.Value())
 


### PR DESCRIPTION
## Description
This will add a fix to stop incrementing cache keys when the overall status is over-limited.

### Fixes
- https://github.com/envoyproxy/ratelimit/issues/427