### PR TITLE
Bump docker base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 AS build
+FROM golang:1.20.5 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org
@@ -10,6 +10,6 @@ COPY script script
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit -ldflags="-w -s" -v github.com/envoyproxy/ratelimit/src/service_cmd
 
-FROM alpine:3.18 AS final
+FROM alpine:3.18.2 AS final
 RUN apk --no-cache add ca-certificates && apk --no-cache update
 COPY --from=build /go/bin/ratelimit /bin/ratelimit


### PR DESCRIPTION
During a recent CVE scan we found envoyproxy to use `alpine:3.18` as the final image

```
grype envoyproxy/ratelimit:59565c87
 ✔ Vulnerability DB        [no update available]
 ✔ Pulled image
 ✔ Loaded image
 ✔ Parsed image
 ✔ Cataloged packages      [57 packages]
 ✔ Scanning image...       [4 vulnerabilities]
   ├── 0 critical, 3 high, 1 medium, 0 low, 0 negligible
   └── 2 fixed
NAME        INSTALLED  FIXED-IN  TYPE  VULNERABILITY  SEVERITY
libcrypto3  3.1.0-r4   3.1.1-r0  apk   CVE-2023-2650  High
libssl3     3.1.0-r4   3.1.1-r0  apk   CVE-2023-2650  High
```

Since docker image tags are derived from the git commit sha, triggering a rebuild of the image as is (which implicitly would use alpine:3.18.2 and golang:1.20.5) would result in the image getting replaced with the same commit sha. Instead, we're explicitly setting the version numbers to ensure any version update is tied to a commit.