### PR TITLE
Updates Golang minor version to resolve CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5 AS build
+FROM golang:1.20.7 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org


### PR DESCRIPTION
Updates Golang build version to 1.20.7 to resolve [CVE-2023-39533](https://nvd.nist.gov/vuln/detail/CVE-2023-39533)

[This is my first contribution to this project. Please let me know if I missed anything.]

cc: @envoyproxy/ratelimit-maintainers