### PR TITLE
feat: add optional custom response header with next reset timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
   - [Health Checking for Redis Active Connection](#health-checking-for-redis-active-connection)
 - [Memcache](#memcache)
 - [Custom headers](#custom-headers)
+  - [Optional custom headers (mimicking Github API behavior)](#optional-custom-headers-mimicking-github-api-behavior)
 - [Tracing](#tracing)
 - [mTLS](#mtls)
 - [Contact](#contact)

--- a/README.md
+++ b/README.md
@@ -1003,6 +1003,15 @@ The following environment variables control the custom response feature:
 1. `LIMIT_REMAINING_HEADER` - The default value is "RateLimit-Remaining", setting the environment variable will specify an alternative header name
 1. `LIMIT_RESET_HEADER` - The default value is "RateLimit-Reset", setting the environment variable will specify an alternative header name
 
+## Optional custom headers (mimicking Github API behavior)
+
+Some services such as Github add another header containing the timestamp on which the rate-limit clears. This can be configured using the following options:
+
+1. `LIMIT_RESET_TIMESTAMP_HEADER_ENABLED` - Enables the additional timestamp response header
+1. `LIMIT_RESET_TIMESTAMP_HEADER` - THe default value is "X-RateLimit-Reset" and defines the time at which the current rate limit window resets in UTC epoch seconds
+
+# Tracing
+
 You may use the following commands to quickly setup a openTelemetry collector together with a Jaeger all-in-one binary for quickstart:
 
 ```bash
@@ -1011,8 +1020,6 @@ otelcol-contrib --config examples/otlp-collector/config.yaml
 
 docker run -d --name jaeger -p 16686:16686 -p 14250:14250 jaegertracing/all-in-one:1.33
 ```
-
-# Tracing
 
 Ratelimit service supports exporting spans in OLTP format. See [OpenTelemetry](https://opentelemetry.io/) for more information.
 

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -98,6 +98,10 @@ type Settings struct {
 	HeaderRatelimitRemaining string `envconfig:"LIMIT_REMAINING_HEADER" default:"RateLimit-Remaining"`
 	// value: remaining seconds
 	HeaderRatelimitReset string `envconfig:"LIMIT_RESET_HEADER" default:"RateLimit-Reset"`
+	// value: remaining seconds
+	RateLimitResponseHeaderResetTimestampEnabled bool `envconfig:"LIMIT_RESET_TIMESTAMP_HEADER_ENABLED" default:"false"`
+	// value: current rate limit window reset in UTC epoch seconds
+	HeaderRatelimitResetTimestamp string `envconfig:"LIMIT_RESET_TIMESTAMP_HEADER" default:"X-RateLimit-Reset"`
 
 	// Health-check settings
 	HealthyWithAtLeastOneConfigLoaded bool `envconfig:"HEALTHY_WITH_AT_LEAST_ONE_CONFIG_LOADED" default:"false"`


### PR DESCRIPTION
This adds an optional `X-Ratelimit-Reset` header, which contains a
timestamp on which the rate-limit window rolls over. It follows [Github API](https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28).
design, which we adopted internally.
Hope to get this upstream :) If there's anything missing, let me know!

Signed-off-by: Matthias Riegler <matthias.riegler@ankorstore.com>
