### PR TITLE
Bump to golang 1.21.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21.0"
 
       - name: run pre-commits
         run: |

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.20"
+          go-version: "1.21.0"
 
       - name: run pre-commits
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We welcome contributions from the community. Here are some guidelines.
 # Submitting a PR
 
 - Fork the repo.
-- Before commiting any code, install the pre-commits by:
+- Before committing any code, install the pre-commits by:
 
 ```bash
 make precommit_install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.8 AS build
+FROM golang:1.21.0 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,5 +1,5 @@
 # Running this docker image runs the integration tests.
-FROM golang:1.20
+FROM golang:1.21.0
 
 RUN apt-get update -y && apt-get install sudo stunnel4 redis memcached -y && rm -rf /var/lib/apt/lists/*
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   # minimal container that builds the ratelimit service binary and exits.
   ratelimit-build:
-    image: golang:1.20-alpine
+    image: golang:1.21.0-alpine
     working_dir: /go/src/github.com/envoyproxy/ratelimit
     command: go build -o /usr/local/bin/ratelimit ./src/service_cmd/main.go
     volumes:
@@ -28,7 +28,7 @@ services:
       - binary:/usr/local/bin/
 
   ratelimit-client-build:
-    image: golang:1.20-alpine
+    image: golang:1.21.0-alpine
     working_dir: /go/src/github.com/envoyproxy/ratelimit
     command: go build -o /usr/local/bin/ratelimit_client ./src/client_cmd/main.go
     volumes:

--- a/examples/xds-sotw-config-server/go.mod
+++ b/examples/xds-sotw-config-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/ratelimit/examples/xds-sotw-config-server
 
-go 1.20
+go 1.21.0
 
 require (
 	github.com/envoyproxy/go-control-plane v0.10.3-0.20230127155013-72157d335c8f

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/ratelimit
 
-go 1.20
+go 1.21.0
 
 require (
 	github.com/alicebob/miniredis/v2 v2.23.0


### PR DESCRIPTION
g1.21.0 - https://go.dev/dl/ 

g1.20 has some vulnerabilities which are fixed in the  g1.21.0. 