### PR TITLE
Add lefthand-side wildcard support to descriptor values

### DIFF
--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -315,13 +315,13 @@ func (this *rateLimitConfigImpl) GetLimit(
 
 		if nextDescriptor == nil && len(prevDescriptor.wildcardValues) > 0 {
 			for _, wildcardValue := range prevDescriptor.wildcardValues {
-				finalKey = entry.Key + "_" + wildcardValue
+				wildcardKey := entry.Key + "_" + wildcardValue
 				if strings.HasSuffix(entry.Value, strings.TrimPrefix(wildcardValue, "*")) {
-					nextDescriptor = descriptorsMap[finalKey]
+					nextDescriptor = descriptorsMap[wildcardKey]
 					break
 				}
 				if strings.HasPrefix(entry.Value, strings.TrimSuffix(wildcardValue, "*")) {
-					nextDescriptor = descriptorsMap[finalKey]
+					nextDescriptor = descriptorsMap[wildcardKey]
 					break
 				}
 			}

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -189,7 +189,7 @@ func (this *rateLimitDescriptor) loadDescriptors(config RateLimitConfigToLoad, p
 		newDescriptor.loadDescriptors(config, newParentKey+".", descriptorConfig.Descriptors, statsManager)
 		this.descriptors[finalKey] = newDescriptor
 
-		// Preload keys starting or ending with "*" symbol.
+		// Preload values starting or ending with "*" symbol.
 		if strings.HasPrefix(descriptorConfig.Value, "*") || strings.HasSuffix(descriptorConfig.Value, "*") {
 			this.wildcardValues = append(this.wildcardValues, descriptorConfig.Value)
 		}
@@ -315,12 +315,13 @@ func (this *rateLimitConfigImpl) GetLimit(
 
 		if nextDescriptor == nil && len(prevDescriptor.wildcardValues) > 0 {
 			for _, wildcardValue := range prevDescriptor.wildcardValues {
+				finalKey = entry.Key + "_" + wildcardValue
 				if strings.HasSuffix(entry.Value, strings.TrimPrefix(wildcardValue, "*")) {
-					nextDescriptor = descriptorsMap[entry.Key+"_"+wildcardValue]
+					nextDescriptor = descriptorsMap[finalKey]
 					break
 				}
 				if strings.HasPrefix(entry.Value, strings.TrimSuffix(wildcardValue, "*")) {
-					nextDescriptor = descriptorsMap[entry.Key+"_"+wildcardValue]
+					nextDescriptor = descriptorsMap[finalKey]
 					break
 				}
 			}

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -591,14 +591,24 @@ func TestWildcardConfig(t *testing.T) {
 	wildcard1 := rlConfig.GetLimit(
 		context.TODO(), "test-domain",
 		&pb_struct.RateLimitDescriptor{
-			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "wild", Value: "foo1"}},
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "rightWild", Value: "foo1"}},
 		})
 	wildcard2 := rlConfig.GetLimit(
 		context.TODO(), "test-domain",
 		&pb_struct.RateLimitDescriptor{
-			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "wild", Value: "foo2"}},
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "rightWild", Value: "foo2"}},
 		})
 	wildcard3 := rlConfig.GetLimit(
+		context.TODO(), "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "leftWild", Value: "afoo"}},
+		})
+	wildcard4 := rlConfig.GetLimit(
+		context.TODO(), "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "leftWild", Value: "bfoo"}},
+		})
+	wildcard5 := rlConfig.GetLimit(
 		context.TODO(), "test-domain",
 		&pb_struct.RateLimitDescriptor{
 			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "nestedWild", Value: "val1"}, {Key: "wild", Value: "goo2"}},
@@ -606,6 +616,8 @@ func TestWildcardConfig(t *testing.T) {
 	assert.NotNil(wildcard1)
 	assert.Equal(wildcard1, wildcard2)
 	assert.NotNil(wildcard3)
+	assert.Equal(wildcard3, wildcard4)
+	assert.NotNil(wildcard5)
 
 	// Doesn't match non-matching values
 	noMatch := rlConfig.GetLimit(

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -613,11 +613,17 @@ func TestWildcardConfig(t *testing.T) {
 		&pb_struct.RateLimitDescriptor{
 			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "nestedWild", Value: "val1"}, {Key: "wild", Value: "goo2"}},
 		})
+	wildcard6 := rlConfig.GetLimit(
+		context.TODO(), "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "nestedWild", Value: "val1"}, {Key: "wild", Value: "agoo"}},
+		})
 	assert.NotNil(wildcard1)
 	assert.Equal(wildcard1, wildcard2)
 	assert.NotNil(wildcard3)
 	assert.Equal(wildcard3, wildcard4)
 	assert.NotNil(wildcard5)
+	assert.NotNil(wildcard6)
 
 	// Doesn't match non-matching values
 	noMatch := rlConfig.GetLimit(
@@ -632,6 +638,13 @@ func TestWildcardConfig(t *testing.T) {
 		context.TODO(), "test-domain",
 		&pb_struct.RateLimitDescriptor{
 			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "noWild", Value: "foo1"}},
+		})
+	assert.Nil(eager)
+
+	eager = rlConfig.GetLimit(
+		context.TODO(), "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "noWild", Value: "afoo"}},
 		})
 	assert.Nil(eager)
 

--- a/test/config/wildcard.yaml
+++ b/test/config/wildcard.yaml
@@ -1,8 +1,13 @@
 # Basic configuration for testing.
 domain: test-domain
 descriptors:
-  - key: wild
+  - key: rightWild
     value: foo*
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20
+  - key: leftWild
+    value: "*foo"
     rate_limit:
       unit: minute
       requests_per_unit: 20

--- a/test/config/wildcard.yaml
+++ b/test/config/wildcard.yaml
@@ -33,3 +33,8 @@ descriptors:
         rate_limit:
           unit: minute
           requests_per_unit: 20
+      - key: wild
+        value: "*goo"
+        rate_limit:
+          unit: minute
+          requests_per_unit: 20


### PR DESCRIPTION
Current wildcard implementation doesn't allow to have a following configuration:
```
domain: example-domain
descriptors:
  - key: HOST
    value: "*.example.com"
    rate_limit:
      unit: minute
      requests_per_unit: 20
```

This is useful if one needs to rate limit based on dynamic subdomains, like:
`foo.example.com`, `bar.example.com`, `<unknown_yet>.example.com`