### PR TITLE
Update alpine version to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY script script
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit -ldflags="-w -s" -v github.com/envoyproxy/ratelimit/src/service_cmd
 
-FROM alpine:3.18.3 AS final
+FROM alpine:3.18.5 AS final
 RUN apk --no-cache add ca-certificates && apk --no-cache update
 COPY --from=build /go/bin/ratelimit /bin/ratelimit


### PR DESCRIPTION
fixes CVEs CVE-2023-5678 CVE-2023-5363 as per https://github.com/alpinelinux/docker-alpine/issues/358