### PR TITLE
Update alpine to 3.18.6 to address openssl vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY script script
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit -ldflags="-w -s" -v github.com/envoyproxy/ratelimit/src/service_cmd
 
-FROM alpine:3.18.5@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0 AS final
+FROM alpine:3.18.6@sha256:11e21d7b981a59554b3f822c49f6e9f57b6068bb74f49c4cd5cc4c663c7e5160 AS final
 RUN apk --no-cache add ca-certificates && apk --no-cache update
 COPY --from=build /go/bin/ratelimit /bin/ratelimit


### PR DESCRIPTION
https://hub.docker.com/layers/library/alpine/3.18.5/images/sha256-d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389?context=explore

Has 2 medium vulnerability in openssl 3.1.4-r1


