### PR TITLE
Add support for starting the server on a unix domain sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
   - [GRPC Keepalive](#grpc-keepalive)
   - [Health-check](#health-check)
     - [Health-check configurations](#health-check-configurations)
+  - [GRPC server](#grpc-server)
 - [Request Fields](#request-fields)
 - [GRPC Client](#grpc-client)
   - [Commandline flags](#commandline-flags)
@@ -747,6 +748,13 @@ HEALTHY_WITH_AT_LEAST_ONE_CONFIG_LOADED default:"false"`
 
 If `HEALTHY_WITH_AT_LEAST_ONE_CONFIG_LOADED` is enabled then health check will start as unhealthy and becomes healthy if
 it detects at least one domain is loaded with the config. If it detects no config again then it will change to unhealthy.
+
+## GRPC server
+
+By default the ratelimit gRPC server binds to `0.0.0.0:8081`. To change this set
+`GRPC_HOST` and/or `GRPC_PORT`. If you want to run the server on a unix domain
+socket then set `GRPC_UDS`, e.g. `GRPC_UDS=/<dir>/ratelimit.sock` and leave
+`GRPC_HOST` and `GRPC_PORT` unmodified.
 
 # Request Fields
 

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -21,6 +21,9 @@ type Settings struct {
 	DebugPort int    `envconfig:"DEBUG_PORT" default:"6070"`
 
 	// GRPC server settings
+	// If GrpcUds is set we'll listen on the specified unix domain socket address
+	// rather then GrpcHost:GrpcPort. e.g. GrpcUds=/tmp/ratelimit.sock
+	GrpcUds  string `envconfig:"GRPC_UDS" default:""`
 	GrpcHost string `envconfig:"GRPC_HOST" default:"0.0.0.0"`
 	GrpcPort int    `envconfig:"GRPC_PORT" default:"8081"`
 	// GrpcServerTlsConfig configures grpc for the server


### PR DESCRIPTION
Some folks may want the ability to start the rate limiter on a unix domain socket rather than a TCP/IP endpoint. This PR adds support for that.

* introduce a new environment variable `GRPC_UDS`
* if this variable is set we'll attempt to start the gRPC server on the unix domain socket address specified, otherwise we'll default to starting on `GRPC_HOST:GRPC_PORT`.

Example startup logs:
```
time="2024-03-20T11:10:23Z" level=info msg="Tracing disabled"
time="2024-03-20T11:10:23Z" level=warning msg="connecting to redis on redis-cluster-headless:6379 with pool size 10"
time="2024-03-20T11:10:23Z" level=warning msg="Creating cluster with urls [redis-cluster-headless:6379]"
time="2024-03-20T11:10:23Z" level=info msg="Waiting for initial ratelimit config update event"
time="2024-03-20T11:10:23Z" level=info msg="Successfully loaded new configuration"
time="2024-03-20T11:10:23Z" level=info msg="Successfully loaded the initial ratelimit configs"
time="2024-03-20T11:10:23Z" level=warning msg="Listening for HTTP on '0.0.0.0:8080'"
time="2024-03-20T11:10:23Z" level=warning msg="Listening for gRPC on '/tmp/grpc.sock'"
time="2024-03-20T11:10:23Z" level=warning msg="Listening for debug on '0.0.0.0:6070'"
```

I didn't see an obvious place to extend the unit tests.