### PR TITLE
fix(Stats): restore stdout stats option, allow flush interval to be configured with env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,14 @@ The rate limit service generates various statistics for each configured rate lim
 users both for visibility and for setting alarms. Ratelimit uses [gostats](https://github.com/lyft/gostats) as its statistics library. Please refer
 to [gostats' documentation](https://godoc.org/github.com/lyft/gostats) for more information on the library.
 
+Statistics default to using [StatsD](https://github.com/statsd/statsd) and configured via the env vars from [gostats](https://github.com/lyft/gostats).
+
+To output statistics to stdout instead, set env var `USE_STATSD` to `false`
+
+Configure statistics output frequency with `STATS_FLUSH_INTERVAL`, where the type is `time.Duration`, e.g. `10s` is the default value.
+
+To disable statistics entirely, set env var `DISABLE_STATS` to `true`
+
 Rate Limit Statistic Path:
 
 ```

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -76,10 +76,12 @@ type Settings struct {
 	XdsClientBackoffJitter          bool          `envconfig:"XDS_CLIENT_BACKOFF_JITTER" default:"true"`
 
 	// Stats-related settings
-	UseStatsd  bool              `envconfig:"USE_STATSD" default:"true"`
-	StatsdHost string            `envconfig:"STATSD_HOST" default:"localhost"`
-	StatsdPort int               `envconfig:"STATSD_PORT" default:"8125"`
-	ExtraTags  map[string]string `envconfig:"EXTRA_TAGS" default:""`
+	UseStatsd          bool              `envconfig:"USE_STATSD" default:"true"`
+	StatsdHost         string            `envconfig:"STATSD_HOST" default:"localhost"`
+	StatsdPort         int               `envconfig:"STATSD_PORT" default:"8125"`
+	ExtraTags          map[string]string `envconfig:"EXTRA_TAGS" default:""`
+	StatsFlushInterval time.Duration     `envconfig:"STATS_FLUSH_INTERVAL" default:"10s"`
+	DisableStats       bool              `envconfig:"DISABLE_STATS" default:"false"`
 
 	// Settings for rate limit configuration
 	RuntimePath           string `envconfig:"RUNTIME_ROOT" default:"/srv/runtime_data/current"`


### PR DESCRIPTION
This fixes up a couple of issue introduced in #520 

Closes #550 