### PR TITLE
Bridge gostats logs to the ratelimit logging system

### DIFF
--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -59,7 +59,7 @@ func NewRunner(s settings.Settings) Runner {
 		store = gostats.NewStore(gostats.NewTCPStatsdSink(gostats.WithStatsdHost(s.StatsdHost), gostats.WithStatsdPort(s.StatsdPort)), false)
 	} else {
 		logger.Info("Stats initialized for stdout")
-		store = gostats.NewStore(stats.NewLoggingSink(), false)
+		store = gostats.NewStore(&stats.LoggingSink{}, false)
 	}
 
 	logger.Infof("Stats flush interval: %s", s.StatsFlushInterval)

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -9,25 +9,21 @@ import (
 	"sync"
 	"time"
 
-	"github.com/envoyproxy/ratelimit/src/godogstats"
-	"github.com/envoyproxy/ratelimit/src/metrics"
-	"github.com/envoyproxy/ratelimit/src/stats"
-	"github.com/envoyproxy/ratelimit/src/trace"
-
-	gostats "github.com/lyft/gostats"
-
 	"github.com/coocood/freecache"
-
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
-
+	gostats "github.com/lyft/gostats"
 	logger "github.com/sirupsen/logrus"
 
+	"github.com/envoyproxy/ratelimit/src/godogstats"
 	"github.com/envoyproxy/ratelimit/src/limiter"
 	"github.com/envoyproxy/ratelimit/src/memcached"
+	"github.com/envoyproxy/ratelimit/src/metrics"
 	"github.com/envoyproxy/ratelimit/src/redis"
 	"github.com/envoyproxy/ratelimit/src/server"
 	ratelimit "github.com/envoyproxy/ratelimit/src/service"
 	"github.com/envoyproxy/ratelimit/src/settings"
+	"github.com/envoyproxy/ratelimit/src/stats"
+	"github.com/envoyproxy/ratelimit/src/trace"
 	"github.com/envoyproxy/ratelimit/src/utils"
 )
 
@@ -63,7 +59,7 @@ func NewRunner(s settings.Settings) Runner {
 		store = gostats.NewStore(gostats.NewTCPStatsdSink(gostats.WithStatsdHost(s.StatsdHost), gostats.WithStatsdPort(s.StatsdPort)), false)
 	} else {
 		logger.Info("Stats initialized for stdout")
-		store = gostats.NewStore(gostats.NewLoggingSink(), false)
+		store = gostats.NewStore(stats.NewLoggingSink(), false)
 	}
 
 	logger.Infof("Stats flush interval: %s", s.StatsFlushInterval)

--- a/src/stats/logger.go
+++ b/src/stats/logger.go
@@ -1,71 +1,28 @@
 package stats
 
 import (
-	"encoding/json"
-	"fmt"
 	"strconv"
 	"time"
 
-	gostats "github.com/lyft/gostats"
 	logger "github.com/sirupsen/logrus"
 )
 
-// loggingSink is a gostats.FlushableSink that logs all stats using
+const logTemplate = `{"level":"debug","ts":%[1]v,"logger":"gostats.loggingsink","msg":"flushing %[2]v","json":{"name":"%[3]v","type":"%[2]v","value":"%[4]v"}}`
+
+// LoggingSink is a gostats.FlushableSink that logs all stats using
 // the rate limit logger.
-type loggingSink struct {
-	now func() time.Time
-}
+type LoggingSink struct{}
 
-// NewLoggingSink logs the gostats metrics using the rate limit logger.
-// See the gostats.NewLoggingSink function for more details.
-func NewLoggingSink() gostats.FlushableSink {
-	return &loggingSink{now: time.Now}
-}
-
-type sixDecimalPlacesFloat float64
-
-func (f sixDecimalPlacesFloat) MarshalJSON() ([]byte, error) {
-	var ret []byte
-	ret = strconv.AppendFloat(ret, float64(f), 'f', 6, 64)
-	return ret, nil
-}
-
-type logLine struct {
-	Level     string                `json:"level"`
-	Timestamp sixDecimalPlacesFloat `json:"ts"`
-	Logger    string                `json:"logger"`
-	Message   string                `json:"msg"`
-	JSON      map[string]string     `json:"json"`
-}
-
-func (s *loggingSink) log(name, typ string, value float64) {
-	if !logger.IsLevelEnabled(logger.DebugLevel) {
-		return
-	}
-
-	nanos := s.now().UnixNano()
-	sec := sixDecimalPlacesFloat(float64(nanos) / float64(time.Second))
-	kv := map[string]string{
-		"type":  typ,
-		"value": fmt.Sprintf("%f", value),
-	}
-	if name != "" {
-		kv["name"] = name
-	}
-
-	b, err := json.Marshal(logLine{
-		Message:   fmt.Sprintf("flushing %s", typ),
-		Level:     "debug",
-		Timestamp: sec,
-		Logger:    "gostats.loggingsink",
-		JSON:      kv,
-	})
-	if err == nil {
-		logger.Debug(string(b))
+func (s *LoggingSink) log(name, typ string, value float64) {
+	if logger.IsLevelEnabled(logger.DebugLevel) {
+		sec := float64(time.Now().UnixNano()) / float64(time.Second)
+		logger.Debugf(logTemplate, strconv.FormatFloat(sec, 'f', 6, 64), typ, name, value)
 	}
 }
 
-func (s *loggingSink) FlushCounter(name string, value uint64) { s.log(name, "counter", float64(value)) }
-func (s *loggingSink) FlushGauge(name string, value uint64)   { s.log(name, "gauge", float64(value)) }
-func (s *loggingSink) FlushTimer(name string, value float64)  { s.log(name, "timer", value) }
-func (s *loggingSink) Flush()                                 { s.log("", "all stats", 0) }
+// Implementation of the gostats.FlushableSink interface
+
+func (s *LoggingSink) FlushCounter(name string, value uint64) { s.log(name, "counter", float64(value)) }
+func (s *LoggingSink) FlushGauge(name string, value uint64)   { s.log(name, "gauge", float64(value)) }
+func (s *LoggingSink) FlushTimer(name string, value float64)  { s.log(name, "timer", value) }
+func (s *LoggingSink) Flush()                                 { s.log("", "all stats", 0) }

--- a/src/stats/logger.go
+++ b/src/stats/logger.go
@@ -1,0 +1,71 @@
+package stats
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+
+	gostats "github.com/lyft/gostats"
+	logger "github.com/sirupsen/logrus"
+)
+
+// loggingSink is a gostats.FlushableSink that logs all stats using
+// the rate limit logger.
+type loggingSink struct {
+	now func() time.Time
+}
+
+// NewLoggingSink logs the gostats metrics using the rate limit logger.
+// See the gostats.NewLoggingSink function for more details.
+func NewLoggingSink() gostats.FlushableSink {
+	return &loggingSink{now: time.Now}
+}
+
+type sixDecimalPlacesFloat float64
+
+func (f sixDecimalPlacesFloat) MarshalJSON() ([]byte, error) {
+	var ret []byte
+	ret = strconv.AppendFloat(ret, float64(f), 'f', 6, 64)
+	return ret, nil
+}
+
+type logLine struct {
+	Level     string                `json:"level"`
+	Timestamp sixDecimalPlacesFloat `json:"ts"`
+	Logger    string                `json:"logger"`
+	Message   string                `json:"msg"`
+	JSON      map[string]string     `json:"json"`
+}
+
+func (s *loggingSink) log(name, typ string, value float64) {
+	if !logger.IsLevelEnabled(logger.DebugLevel) {
+		return
+	}
+
+	nanos := s.now().UnixNano()
+	sec := sixDecimalPlacesFloat(float64(nanos) / float64(time.Second))
+	kv := map[string]string{
+		"type":  typ,
+		"value": fmt.Sprintf("%f", value),
+	}
+	if name != "" {
+		kv["name"] = name
+	}
+
+	b, err := json.Marshal(logLine{
+		Message:   fmt.Sprintf("flushing %s", typ),
+		Level:     "debug",
+		Timestamp: sec,
+		Logger:    "gostats.loggingsink",
+		JSON:      kv,
+	})
+	if err == nil {
+		logger.Debug(string(b))
+	}
+}
+
+func (s *loggingSink) FlushCounter(name string, value uint64) { s.log(name, "counter", float64(value)) }
+func (s *loggingSink) FlushGauge(name string, value uint64)   { s.log(name, "gauge", float64(value)) }
+func (s *loggingSink) FlushTimer(name string, value float64)  { s.log(name, "timer", value) }
+func (s *loggingSink) Flush()                                 { s.log("", "all stats", 0) }


### PR DESCRIPTION
Related to https://github.com/envoyproxy/ratelimit/issues/321 and https://github.com/envoyproxy/ratelimit/issues/538

This PR bridges the `gostats` logging sink to the ratelimit logger, so that the statsd logs can be enabled/disabled according to the `LOG_LEVEL` env var. The addition is mostly a copy of the private gostats logging sync, using the ratelimit logger to print the log statements.