### PR TITLE
Add CertProvider to hot reload TLS certs for gRPC service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ BUILDX_PLATFORMS := linux/amd64,linux/arm64/v8
 # Root dir returns absolute path of current directory. It has a trailing "/".
 PROJECT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 export PROJECT_DIR
+ifneq ($(shell docker compose version 2>/dev/null),)
+  DOCKER_COMPOSE=docker compose
+else
+  DOCKER_COMPOSE=docker-compose
+endif
 
 .PHONY: bootstrap
 bootstrap: ;
@@ -142,7 +147,7 @@ docker_multiarch_push: docker_multiarch_image
 
 .PHONY: integration_tests
 integration_tests:
-	docker-compose --project-directory $(PWD)  -f integration-test/docker-compose-integration-test.yml up --build  --exit-code-from tester
+	$(DOCKER_COMPOSE) --project-directory $(PWD)  -f integration-test/docker-compose-integration-test.yml up --build  --exit-code-from tester
 
 .PHONY: precommit_install
 precommit_install:

--- a/README.md
+++ b/README.md
@@ -1052,17 +1052,26 @@ otelcol-contrib --config examples/otlp-collector/config.yaml
 docker run -d --name jaeger -p 16686:16686 -p 14250:14250 jaegertracing/all-in-one:1.33
 ```
 
+# TLS
+
+Ratelimit supports TLS for it's gRPC endpoint.
+
+The following environment variables control the TLS feature:
+
+1. `GRPC_SERVER_USE_TLS` - Enables gRPC connections to server over TLS
+1. `GRPC_SERVER_TLS_CERT` - Path to the file containing the server cert chain
+1. `GRPC_SERVER_TLS_KEY` - Path to the file containing the server private key
+
+Ratelimit uses [goruntime](https://github.com/lyft/goruntime) to watch the TLS certificate and key and will hot reload them on changes.
+
 # mTLS
 
 Ratelimit supports mTLS when Envoy sends requests to the service.
 
-The following environment variables control the mTLS feature:
+TLS must be enabled on the gRPC endpoint in order for mTLS to work see [TLS](#TLS).
 
 The following variables can be set to enable mTLS on the Ratelimit service.
 
-1. `GRPC_SERVER_USE_TLS` - Enables gprc connections to server over TLS
-1. `GRPC_SERVER_TLS_CERT` - Path to the file containing the server cert chain
-1. `GRPC_SERVER_TLS_KEY` - Path to the file containing the server private key
 1. `GRPC_CLIENT_TLS_CACERT` - Path to the file containing the client CA certificate.
 1. `GRPC_CLIENT_TLS_SAN` - (Optional) DNS Name to validate from the client cert during mTLS auth
 

--- a/src/provider/cert_provider.go
+++ b/src/provider/cert_provider.go
@@ -1,0 +1,109 @@
+package provider
+
+import (
+	"crypto/tls"
+	"path/filepath"
+	"sync"
+
+	"github.com/lyft/goruntime/loader"
+	gostats "github.com/lyft/gostats"
+	logger "github.com/sirupsen/logrus"
+
+	"github.com/envoyproxy/ratelimit/src/settings"
+)
+
+// CertProvider will watch certDirectory for changes via goruntime/loader and reload the cert and key files
+type CertProvider struct {
+	settings           settings.Settings
+	runtime            loader.IFace
+	runtimeUpdateEvent chan int
+	rootStore          gostats.Store
+	certLock           sync.RWMutex
+	cert               *tls.Certificate
+	certDirectory      string
+	certFile           string
+	keyFile            string
+}
+
+// GetCertificateFunc returns a function compatible with tls.Config.GetCertificate, fetching the current certificate
+func (p *CertProvider) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		p.certLock.RLock()
+		defer p.certLock.RUnlock()
+		return p.cert, nil
+	}
+}
+
+func (p *CertProvider) watch() {
+	p.runtime.AddUpdateCallback(p.runtimeUpdateEvent)
+
+	go func() {
+		for {
+			logger.Debugf("CertProvider: waiting for runtime update")
+			<-p.runtimeUpdateEvent
+			logger.Debugf("CertProvider: got runtime update and reloading config")
+			p.reloadCert()
+		}
+	}()
+}
+
+// reloadCert loads the cert and key files and updates the tls.Certificate in memory
+func (p *CertProvider) reloadCert() {
+	tlsKeyPair, err := tls.LoadX509KeyPair(p.certFile, p.keyFile)
+	if err != nil {
+		logger.Errorf("CertProvider failed to load TLS key pair (%s, %s): %v", p.certFile, p.keyFile, err)
+		// panic in case there is no cert already loaded as this would mean starting up without TLS
+		if p.cert == nil {
+			logger.Fatalf("CertProvider failed to load any certificate, exiting.")
+		}
+		return // keep the old cert if we have one
+	}
+	p.certLock.Lock()
+	defer p.certLock.Unlock()
+	p.cert = &tlsKeyPair
+	logger.Infof("CertProvider reloaded cert from (%s, %s)", p.certFile, p.keyFile)
+}
+
+// setupRuntime sets up the goruntime loader to watch the certDirectory
+// Will panic if it fails to set up the loader
+func (p *CertProvider) setupRuntime() {
+	var err error
+
+	// runtimePath is the parent folder of certPath
+	runtimePath := filepath.Dir(p.certDirectory)
+	// runtimeSubdirectory is the name of the folder to watch, containing the certs
+	runtimeSubdirectory := filepath.Base(p.certDirectory)
+
+	p.runtime, err = loader.New2(
+		runtimePath,
+		runtimeSubdirectory,
+		p.rootStore.ScopeWithTags("certs", p.settings.ExtraTags),
+		&loader.DirectoryRefresher{},
+		loader.IgnoreDotFiles)
+
+	if err != nil {
+		logger.Fatalf("Failed to set up goruntime loader: %v", err)
+	}
+}
+
+// NewCertProvider creates a new CertProvider
+// Will panic if it fails to set up gruntime or fails to load the initial certificate
+func NewCertProvider(settings settings.Settings, rootStore gostats.Store, certFile, keyFile string) *CertProvider {
+	certDirectory := filepath.Dir(certFile)
+	if certDirectory != filepath.Dir(keyFile) {
+		logger.Fatalf("certFile and keyFile must be in the same directory")
+	}
+	p := &CertProvider{
+		settings:           settings,
+		runtimeUpdateEvent: make(chan int),
+		rootStore:          rootStore,
+		certDirectory:      certDirectory,
+		certFile:           certFile,
+		keyFile:            keyFile,
+	}
+	p.setupRuntime()
+	// Initially load the certificate (or panic)
+	p.reloadCert()
+	go p.watch()
+	return p
+}

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -26,7 +26,6 @@ import (
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	"github.com/gorilla/mux"
 	reuseport "github.com/kavu/go_reuseport"
-	"github.com/lyft/goruntime/loader"
 	gostats "github.com/lyft/gostats"
 	logger "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -67,7 +66,6 @@ type server struct {
 	store            gostats.Store
 	scope            gostats.Scope
 	provider         provider.RateLimitConfigProvider
-	runtime          loader.IFace
 	debugListener    serverDebugListener
 	httpServer       *http.Server
 	listenerMu       sync.Mutex


### PR DESCRIPTION
This implements a goruntime instance to watch for on disk changes of gRPC certificates.

Certificates will be reloaded in case of change and the gRPC service will always fetch the latest one via GetCertificate on new connections instead of the static Certificates slice.