### PR TITLE
Add TLS support to memcache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,7 +1009,7 @@ To configure a Memcache instance use the following environment variables instead
 1. `CACHE_KEY_PREFIX`: a string to prepend to all cache keys
 1. `MEMCACHE_MAX_IDLE_CONNS=2`: the maximum number of idle TCP connections per memcache node, `2` is the default of the underlying library
 1. `MEMCACHE_TLS`: set to `"true"` to connect to the server with TLS.
-1. `MEMCACHE_TLS_CLIENT_CERT`, `MEMCACHE_TLS_CLIENT_KEY`, and `MEMCACHE_TLS_CACERT` to provide files that parameterize the memcache client TLS connection configuration. 
+1. `MEMCACHE_TLS_CLIENT_CERT`, `MEMCACHE_TLS_CLIENT_KEY`, and `MEMCACHE_TLS_CACERT` to provide files that parameterize the memcache client TLS connection configuration.
 1. `MEMCACHE_TLS_SKIP_HOSTNAME_VERIFICATION` set to `"true"` will skip hostname verification in environments where the certificate has an invalid hostname.
 
 With memcache mode increments will happen asynchronously, so it's technically possible for

--- a/README.md
+++ b/README.md
@@ -1008,6 +1008,9 @@ To configure a Memcache instance use the following environment variables instead
 1. `BACKEND_TYPE=memcache`
 1. `CACHE_KEY_PREFIX`: a string to prepend to all cache keys
 1. `MEMCACHE_MAX_IDLE_CONNS=2`: the maximum number of idle TCP connections per memcache node, `2` is the default of the underlying library
+1. `MEMCACHE_TLS`: set to `"true"` to connect to the server with TLS.
+1. `MEMCACHE_TLS_CLIENT_CERT`, `MEMCACHE_TLS_CLIENT_KEY`, and `MEMCACHE_TLS_CACERT` to provide files that parameterize the memcache client TLS connection configuration. 
+1. `MEMCACHE_TLS_SKIP_HOSTNAME_VERIFICATION` set to `"true"` will skip hostname verification in environments where the certificate has an invalid hostname.
 
 With memcache mode increments will happen asynchronously, so it's technically possible for
 a client to exceed quota briefly if multiple requests happen at exactly the same time.


### PR DESCRIPTION
Memcache supports TLS connections for client-server communication. Add support for configuring a TLS connection to memcached using TLS in a way that mirrors the existing redis configuration options.

Also, ensure that configuration options that apply to the "normal" enumeration of host:port pairs also apply to the DNS SRV discovery mechanism. I don't see a reason why they should not.