### PR TITLE
fix(redis): use logger instead of println

### DIFF
--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -42,7 +42,7 @@ func poolTrace(ps *poolStats, healthCheckActiveConnection bool, srv server.Serve
 					}
 				}
 			} else {
-				fmt.Println("creating redis connection error :", newConn.Err)
+				logger.Errorf("creating redis connection error : %v", newConn.Err)
 			}
 		},
 		ConnClosed: func(_ trace.PoolConnClosed) {


### PR DESCRIPTION
Fix: https://github.com/envoyproxy/ratelimit/issues/605

cc: @envoyproxy/ratelimit-maintainers