### PR TITLE
fixed key on midWild use case on config tests

### DIFF
--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -626,11 +626,11 @@ func TestWildcardConfig(t *testing.T) {
 		})
 	assert.Nil(eager)
 
-	// Wildcard in the middle of value is not supported.
+	// Wildcard in the middle of value is not supported
 	midWildcard := rlConfig.GetLimit(
 		context.TODO(), "test-domain",
 		&pb_struct.RateLimitDescriptor{
-			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "midWildcard", Value: "barab"}},
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "midWild", Value: "barab"}},
 		})
 	assert.Nil(midWildcard)
 }


### PR DESCRIPTION
Mid wild card on descriptor values is not supported by ratelimit service. However the test around this use case ( on test/config/config_test.go ) fails because the key on the RateLimitDescriptor is `midWildcard` instead of `midWild` as it's defined on the wildcard.yaml https://github.com/envoyproxy/ratelimit/blob/main/test/config/wildcard.yaml#L18

On this PR I'm changing the key to `midWild` so it matches to how it's defined on the wildcard.yaml and now the test fails rightfully for not supporting the mid wildcards.

cc: @envoyproxy/ratelimit-maintainers