### PR TITLE
fix(dogstatsd_sink): switch from pure map to list of key/value pairs

### DIFF
--- a/src/godogstats/dogstatsd_sink.go
+++ b/src/godogstats/dogstatsd_sink.go
@@ -38,9 +38,15 @@ func WithStatsdPort(port int) goDogStatsSinkOption {
 	}
 }
 
+// WithMogrifier adds a mogrifier to the sink. Map iteration order is randomized, to control order call multiple times.
 func WithMogrifier(mogrifiers map[*regexp.Regexp]func([]string) (string, []string)) goDogStatsSinkOption {
 	return func(g *godogStatsSink) {
-		g.mogrifier = mogrifiers
+		for m, h := range mogrifiers {
+			g.mogrifier = append(g.mogrifier, mogrifierEntry{
+				matcher: m,
+				handler: h,
+			})
+		}
 	}
 }
 

--- a/src/godogstats/dogstatsd_sink_test.go
+++ b/src/godogstats/dogstatsd_sink_test.go
@@ -51,8 +51,11 @@ func TestSeparateExtraTags(t *testing.T) {
 func TestSinkMogrify(t *testing.T) {
 	g := &godogStatsSink{
 		mogrifier: mogrifierMap{
-			regexp.MustCompile(`^ratelimit\.(.*)$`): func(matches []string) (string, []string) {
-				return "custom." + matches[1], []string{"tag1:value1", "tag2:value2"}
+			{
+				matcher: regexp.MustCompile(`^ratelimit\.(.*)$`),
+				handler: func(matches []string) (string, []string) {
+					return "custom." + matches[1], []string{"tag1:value1", "tag2:value2"}
+				},
 			},
 		},
 	}

--- a/src/godogstats/mogrifier_map_test.go
+++ b/src/godogstats/mogrifier_map_test.go
@@ -9,10 +9,13 @@ import (
 
 func testMogrifier() mogrifierMap {
 	return mogrifierMap{
-		regexp.MustCompile(`^ratelimit\.service\.rate_limit\.(.*)\.(.*)\.(.*)$`): func(matches []string) (string, []string) {
-			name := "ratelimit.service.rate_limit." + matches[3]
-			tags := []string{"domain:" + matches[1], "descriptor:" + matches[2]}
-			return name, tags
+		{
+			matcher: regexp.MustCompile(`^ratelimit\.service\.rate_limit\.(.*)\.(.*)\.(.*)$`),
+			handler: func(matches []string) (string, []string) {
+				name := "ratelimit.service.rate_limit." + matches[3]
+				tags := []string{"domain:" + matches[1], "descriptor:" + matches[2]}
+				return name, tags
+			},
 		},
 	}
 }


### PR DESCRIPTION
Flaky build was observed in this run https://github.com/envoyproxy/ratelimit/actions/runs/9600573727/job/26477125368
```
--- FAIL: TestLoadMogrifiersFromEnv (0.00s)
    --- FAIL: TestLoadMogrifiersFromEnv/Two_mogrifiers:_First_match (0.00s)
        mogrifier_map_test.go:146: 
            	Error Trace:	/workdir/src/godogstats/mogrifier_map_test.go:146
            	Error:      	Not equal: 
            	            	expected: "custom.foo"
            	            	actual  : "ratelimit.service.rate_limit.foo"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-custom.foo
            	            	+ratelimit.service.rate_limit.foo
            	Test:       	TestLoadMogrifiersFromEnv/Two_mogrifiers:_First_match
```

The test for `Two mogrifiers: First match` has flaky results because the underlying iteration order from the map is not guaranteed. Sometimes matching first and sometimes matching second mogrifier.

Having a consistent mogrifier order is required for some types of priority based manipulation, and that is how the keys are defined in the environment, so changing the overall implementation to a slice to maintain ordered iteration is the best option. And can be done by only changing the internal private types.

Repro'd originally bug on main and verified results are no longer flaky by running several iterations of the tests:
```
go test -timeout 30s -count=5000 github.com/envoyproxy/ratelimit/src/godogstats
```

See
https://go.dev/blog/maps

> Iteration order
When iterating over a map with a range loop, the iteration order is not specified and is not guaranteed to be the same from one iteration to the next. If you require a stable iteration order you must maintain a separate data structure that specifies that order.