### PR TITLE
runner: close rate limiter on Stop

### DIFF
--- a/src/utils/multi_closer.go
+++ b/src/utils/multi_closer.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"errors"
+	"io"
+)
+
+type MultiCloser struct {
+	Closers []io.Closer
+}
+
+func (m *MultiCloser) Close() error {
+	var e error
+	for _, closer := range m.Closers {
+		e = errors.Join(closer.Close())
+	}
+	return e
+}


### PR DESCRIPTION
redis client is never closed, even after graceful shutdown via Stop(). It is possible to observe this by creating a runner, and calling Stop(), and stopping the redis server. Runner is expected to be stopped, and all components closed, however still logs can be seen that redis is unavailable.

this patch allows runner to actually gracefully close rate limit implementations, so all components are closed gracefully on Stop.