### PR TITLE
Update example prom-statsd-exporter config

### DIFF
--- a/examples/prom-statsd-exporter/conf.yaml
+++ b/examples/prom-statsd-exporter/conf.yaml
@@ -1,53 +1,45 @@
 mappings: # Requires statsd exporter >= v0.6.0 since it uses the "drop" action.
   - match: "ratelimit.service.rate_limit.*.*.near_limit"
     name: "ratelimit_service_rate_limit_near_limit"
-    timer_type: "histogram"
     labels:
       domain: "$1"
       key1: "$2"
   - match: "ratelimit.service.rate_limit.*.*.over_limit"
     name: "ratelimit_service_rate_limit_over_limit"
-    timer_type: "histogram"
     labels:
       domain: "$1"
       key1: "$2"
   - match: "ratelimit.service.rate_limit.*.*.total_hits"
     name: "ratelimit_service_rate_limit_total_hits"
-    timer_type: "histogram"
     labels:
       domain: "$1"
       key1: "$2"
   - match: "ratelimit.service.rate_limit.*.*.within_limit"
     name: "ratelimit_service_rate_limit_within_limit"
-    timer_type: "histogram"
     labels:
       domain: "$1"
       key1: "$2"
 
   - match: "ratelimit.service.rate_limit.*.*.*.near_limit"
     name: "ratelimit_service_rate_limit_near_limit"
-    timer_type: "histogram"
     labels:
       domain: "$1"
       key1: "$2"
       key2: "$3"
   - match: "ratelimit.service.rate_limit.*.*.*.over_limit"
     name: "ratelimit_service_rate_limit_over_limit"
-    timer_type: "histogram"
     labels:
       domain: "$1"
       key1: "$2"
       key2: "$3"
   - match: "ratelimit.service.rate_limit.*.*.*.total_hits"
     name: "ratelimit_service_rate_limit_total_hits"
-    timer_type: "histogram"
     labels:
       domain: "$1"
       key1: "$2"
       key2: "$3"
   - match: "ratelimit.service.rate_limit.*.*.*.within_limit"
     name: "ratelimit_service_rate_limit_within_limit"
-    timer_type: "histogram"
     labels:
       domain: "$1"
       key1: "$2"
@@ -67,7 +59,7 @@ mappings: # Requires statsd exporter >= v0.6.0 since it uses the "drop" action.
 
   - match: "ratelimit_server.*.response_time"
     name: "ratelimit_service_response_time_seconds"
-    timer_type: histogram
+    observer_type: histogram
     labels:
       grpc_method: "$1"
 
@@ -78,9 +70,14 @@ mappings: # Requires statsd exporter >= v0.6.0 since it uses the "drop" action.
     name: "ratelimit_service_config_load_error"
     match_metric_type: counter
 
+  - match: "ratelimit.service.rate_limit.*.*.shadow_mode"
+    name: "ratelimit_service_rate_limit_shadow_mode"
+    labels:
+      domain: "$1"
+      key1: "$2"
+
   - match: "ratelimit.service.rate_limit.*.*.*.shadow_mode"
     name: "ratelimit_service_rate_limit_shadow_mode"
-    timer_type: "histogram"
     labels:
       domain: "$1"
       key1: "$2"


### PR DESCRIPTION
Few cleanups for folks using this as a baseline (aka myself):

1. Remove `timer_type` for counter metrics, this field is a no-op as-is and is just confusing.
2. Where it is needed (ratelimit_service_rate_limit_shadow_mode), switch to `observer_type`, since `timer_type` has been deprecated since at least 2020: https://github.com/prometheus/statsd_exporter/commit/4a64979563442b948c6b929daee10f3b15493681
3. Add a single-key shadow mode match (even if this is not necessary/used by the example ratelimit setup)