### PR TITLE
Add setting to allow runtime stats to be disabled

### DIFF
--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -244,7 +244,9 @@ func newServer(s settings.Settings, name string, statsManager stats.Manager, loc
 	// setup stats
 	ret.store = statsManager.GetStatsStore()
 	ret.scope = ret.store.ScopeWithTags(name, s.ExtraTags)
-	ret.store.AddStatGenerator(gostats.NewRuntimeStats(ret.scope.Scope("go")))
+	if !s.DisableRuntimeStats {
+		ret.store.AddStatGenerator(gostats.NewRuntimeStats(ret.scope.Scope("go")))
+	}
 	if localCache != nil {
 		ret.store.AddStatGenerator(limiter.NewLocalCacheStats(localCache, ret.scope.Scope("localcache")))
 	}

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -87,6 +87,7 @@ type Settings struct {
 	ExtraTags              map[string]string `envconfig:"EXTRA_TAGS" default:""`
 	StatsFlushInterval     time.Duration     `envconfig:"STATS_FLUSH_INTERVAL" default:"10s"`
 	DisableStats           bool              `envconfig:"DISABLE_STATS" default:"false"`
+	DisableRuntimeStats    bool              `envconfig:"DISABLE_RUNTIME_STATS" default:"false"`
 	UsePrometheus          bool              `envconfig:"USE_PROMETHEUS" default:"false"`
 	PrometheusAddr         string            `envconfig:"PROMETHEUS_ADDR" default:":9090"`
 	PrometheusPath         string            `envconfig:"PROMETHEUS_PATH" default:"/metrics"`


### PR DESCRIPTION
The runtime stats exposed by the [gostats](https://github.com/lyft/gostats) library are quite spammy and incur a lot of costs when exposed as custom metrics to DataDog. 

In this PR the option to disable the RuntimeStats has been added to make them optional.