### PR TITLE
fix go-fumpt args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: go-imports
         args: ["-w", "-local", "github.com/envoyproxy/ratelimit"]
       - id: go-fumpt
-        args: ["-w"]
+        args: ["-l", "-w", "."]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.4.1"


### PR DESCRIPTION
follow up: https://github.com/envoyproxy/ratelimit/pull/664#pullrequestreview-2216499279