### PR TITLE
Sanitize stats name for remote address

### DIFF
--- a/src/utils/utilities.go
+++ b/src/utils/utilities.go
@@ -63,12 +63,10 @@ func MaskCredentialsInUrl(url string) string {
 	return strings.Join(urls, ",")
 }
 
-var (
-	// remoteAddressRegex is used to replace remote addresses in stat names with a sanitized version.
-	// 1. replace masked_remote_address_1.2.3.4/32 with masked_remote_address_1_2_3_4_32
-	// 2. replace remote_address_1.2.3.4 with remote_address_1_2_3_4
-	remoteAddressRegex = regexp.MustCompile(`remote_address_\d+\.\d+\.\d+\.\d+`)
-)
+// remoteAddressRegex is used to replace remote addresses in stat names with a sanitized version.
+// 1. replace masked_remote_address_1.2.3.4/32 with masked_remote_address_1_2_3_4_32
+// 2. replace remote_address_1.2.3.4 with remote_address_1_2_3_4
+var remoteAddressRegex = regexp.MustCompile(`remote_address_\d+\.\d+\.\d+\.\d+`)
 
 // SanitizeStatName remove invalid characters from the stat name.
 func SanitizeStatName(s string) string {

--- a/src/utils/utilities.go
+++ b/src/utils/utilities.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"regexp"
 	"strings"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
@@ -62,8 +63,20 @@ func MaskCredentialsInUrl(url string) string {
 	return strings.Join(urls, ",")
 }
 
-// Remove invalid characters from the stat name.
+var (
+	// remoteAddressRegex is used to replace remote addresses in stat names with a sanitized version.
+	// 1. replace masked_remote_address_1.2.3.4/32 with masked_remote_address_1_2_3_4_32
+	// 2. replace remote_address_1.2.3.4 with remote_address_1_2_3_4
+	remoteAddressRegex = regexp.MustCompile(`remote_address_\d+\.\d+\.\d+\.\d+`)
+)
+
+// SanitizeStatName remove invalid characters from the stat name.
 func SanitizeStatName(s string) string {
 	r := strings.NewReplacer(":", "_", "|", "_")
-	return r.Replace(s)
+	result := r.Replace(s)
+
+	for _, m := range remoteAddressRegex.FindAllString(s, -1) {
+		result = strings.Replace(result, m, strings.Replace(m, ".", "_", -1), -1)
+	}
+	return result
 }

--- a/src/utils/utilities_test.go
+++ b/src/utils/utilities_test.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestSanitizeStatName(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			input:    "domain.foo|bar",
+			expected: "domain.foo_bar",
+		},
+		{
+			input:    "domain.foo:bar",
+			expected: "domain.foo_bar",
+		},
+		{
+			input:    "domain.masked_remote_address_0.0.0.0/0",
+			expected: "domain.masked_remote_address_0_0_0_0/0",
+		},
+		{
+			input:    "domain.remote_address_172.18.0.1",
+			expected: "domain.remote_address_172_18_0_1",
+		},
+		{
+			input:    "domain.masked_remote_address_0.0.0.0/0_remote_address_172.18.0.1",
+			expected: "domain.masked_remote_address_0_0_0_0/0_remote_address_172_18_0_1",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			if actual := SanitizeStatName(c.input); actual != c.expected {
+				t.Errorf("SanitizeStatName(%s): expected %s, actual %s", c.input, c.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
xref: https://github.com/envoyproxy/gateway/issues/4281

alternative for https://github.com/envoyproxy/envoy/pull/36275, because of what [Joshua said](https://github.com/envoyproxy/envoy/pull/36275#discussion_r1772060469).

> I feel like this change is going to spawn a lot of other changes as well. THere are a ton of places where IP addresses and other things with dots show up in stat names and I'm unsure why this one is different.