### PR TITLE
update docs on stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -856,6 +856,7 @@ ratelimit.service.rate_limit.messaging.auth-service.over_limit.shadow_mode: 1
 To enable dogstatsd integration set:
 
 1. `USE_DOG_STATSD`: `true` to use [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/?code-lang=go)
+2. `USE_STATSD`: `false` to disable StatsD (both cannot be enabled at the same time)
 
 dogstatsd also enables so called `mogrifiers` which can
 convert from traditional stats tags into a combination of stat name and tags.
@@ -907,9 +908,10 @@ Then, declare additional rules for the `DESCRIPTOR` mogrifier
 To enable Prometheus integration set:
 
 1. `USE_PROMETHEUS`: `true` to use [Prometheus](https://prometheus.io/)
-2. `PROMETHEUS_ADDR`: The port to listen on for Prometheus metrics. Defaults to `:9090`
-3. `PROMETHEUS_PATH`: The path to listen on for Prometheus metrics. Defaults to `/metrics`
-4. `PROMETHEUS_MAPPER_YAML`: The path to the YAML file that defines the mapping from statsd to prometheus metrics.
+2. `USE_STATSD`: `false` to disable StatsD (both cannot be enabled at the same time)
+3. `PROMETHEUS_ADDR`: The port to listen on for Prometheus metrics. Defaults to `:9090`
+4. `PROMETHEUS_PATH`: The path to listen on for Prometheus metrics. Defaults to `/metrics`
+5. `PROMETHEUS_MAPPER_YAML`: The path to the YAML file that defines the mapping from statsd to prometheus metrics.
 
 Define the mapping from statsd to prometheus metrics in a YAML file.
 Find more information about the mapping in the [Metric Mapping and Configuration](https://github.com/prometheus/statsd_exporter?tab=readme-ov-file#metric-mapping-and-configuration).


### PR DESCRIPTION
When trying to switch to the new prometheus sink instead of a custom statsd-exporter, the pod crashed since `USE_STATSD` defaults to true and I hit the below error: https://github.com/envoyproxy/ratelimit/blob/28b1629a21e885bdd2b527d6a1c1de8483dc47d4/src/service_cmd/runner/runner.go#L65-L68.

This PR should make it clearer that `USE_STATSD: false` is required for prometheus and dog_stats.