### PR TITLE
make proto configurable

### DIFF
--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Settings struct {
+	Proto string `envconfig:"PROTO" default:"tcp"`
 	// runtime options
 	// This value shall be imported into unary server interceptor in order to enable chaining
 	GrpcUnaryInterceptor grpc.UnaryServerInterceptor


### PR DESCRIPTION
make `Proto` configurable cause I want to use the combination of `reuseport.Listen(“tcp6”, “:8881")`, that will listen on `[::]:8881` and you can access it with `[::]:8881` and `127.0.0.1:8881`


IMO, this more like a bug from reuseport package? Because I think `reuseport.Listen(“tcp”, “:8881")` should be the right way to do this, but it's hard to change a package which isn't updated for three years.