### PR TITLE
Fix time conversion for year

### DIFF
--- a/src/utils/utilities.go
+++ b/src/utils/utilities.go
@@ -29,7 +29,7 @@ func UnitToDivider(unit pb.RateLimitResponse_RateLimit_Unit) int64 {
 	case pb.RateLimitResponse_RateLimit_MONTH:
 		return 60 * 60 * 24 * 30
 	case pb.RateLimitResponse_RateLimit_YEAR:
-		return 60 * 60 * 24 * 356
+		return 60 * 60 * 24 * 365
 	}
 
 	panic("should not get here")


### PR DESCRIPTION
* 365 days in a year, not 356