### PR TITLE
feat: add support for weekly ratelimit unit

### DIFF
--- a/api/ratelimit/config/ratelimit/v3/rls_conf.proto
+++ b/api/ratelimit/config/ratelimit/v3/rls_conf.proto
@@ -92,6 +92,9 @@ enum RateLimitUnit {
   // The time unit representing a day.
   DAY = 4;
 
+  // The time unit representing a week.
+  WEEK = 7;
+
   // The time unit representing a month.
   MONTH = 5;
 

--- a/src/utils/utilities.go
+++ b/src/utils/utilities.go
@@ -26,6 +26,8 @@ func UnitToDivider(unit pb.RateLimitResponse_RateLimit_Unit) int64 {
 		return 60 * 60
 	case pb.RateLimitResponse_RateLimit_DAY:
 		return 60 * 60 * 24
+	case pb.RateLimitResponse_RateLimit_WEEK:
+		return 60 * 60 * 24 * 7
 	case pb.RateLimitResponse_RateLimit_MONTH:
 		return 60 * 60 * 24 * 30
 	case pb.RateLimitResponse_RateLimit_YEAR:


### PR DESCRIPTION
This PR adds support for the weekly ratelimit unit which I added over in https://github.com/envoyproxy/envoy/pull/37494 that has now been shipped in go-control-plane v0.13.2.