### PR TITLE
feat: add metrics to json endpoint

### DIFF
--- a/src/metrics/metrics.go
+++ b/src/metrics/metrics.go
@@ -2,11 +2,18 @@ package metrics
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"time"
 
 	stats "github.com/lyft/gostats"
 	"google.golang.org/grpc"
 )
+
+type capturingResponseWriter struct {
+	http.ResponseWriter
+	code int
+}
 
 type serverMetrics struct {
 	totalRequests stats.Counter
@@ -18,12 +25,15 @@ type ServerReporter struct {
 	scope stats.Scope
 }
 
-func newServerMetrics(scope stats.Scope, fullMethod string) *serverMetrics {
-	_, methodName := splitMethodName(fullMethod)
+func newServerMetrics(scope stats.Scope, methodName string, tags map[string]string) *serverMetrics {
 	ret := serverMetrics{}
-	ret.totalRequests = scope.NewCounter(methodName + ".total_requests")
-	ret.responseTime = scope.NewTimer(methodName + ".response_time")
+	ret.totalRequests = scope.NewCounterWithTags(methodName+".total_requests", tags)
+	ret.responseTime = scope.NewTimerWithTags(methodName+".response_time", tags)
 	return &ret
+}
+
+func newCapturingResponseWriter(w http.ResponseWriter) *capturingResponseWriter {
+	return &capturingResponseWriter{w, http.StatusOK}
 }
 
 // NewServerReporter returns a ServerReporter object.
@@ -37,10 +47,30 @@ func NewServerReporter(scope stats.Scope) *ServerReporter {
 func (r *ServerReporter) UnaryServerInterceptor() func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		start := time.Now()
-		s := newServerMetrics(r.scope, info.FullMethod)
+		_, methodName := splitMethodName(info.FullMethod)
+		s := newServerMetrics(r.scope, methodName, map[string]string{})
 		s.totalRequests.Inc()
 		resp, err := handler(ctx, req)
 		s.responseTime.AddValue(float64(time.Since(start).Milliseconds()))
 		return resp, err
 	}
+}
+
+// HttpServerMetricsHandler returns a wrapping handler to add metrics to HTTP requests.
+func (r *ServerReporter) HttpServerMetricsHandler(routeName string, handler func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		start := time.Now()
+		capturingWriter := newCapturingResponseWriter(writer)
+		handler(capturingWriter, request)
+
+		tags := map[string]string{"code": fmt.Sprintf("%v", capturingWriter.code)}
+		s := newServerMetrics(r.scope, routeName, tags)
+		s.totalRequests.Inc()
+		s.responseTime.AddValue(float64(time.Since(start).Milliseconds()))
+	}
+}
+
+func (c *capturingResponseWriter) WriteHeader(code int) {
+	c.code = code
+	c.ResponseWriter.WriteHeader(code)
 }

--- a/src/server/server.go
+++ b/src/server/server.go
@@ -5,6 +5,7 @@ import (
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 
+	"github.com/envoyproxy/ratelimit/src/metrics"
 	"github.com/envoyproxy/ratelimit/src/provider"
 
 	stats "github.com/lyft/gostats"
@@ -28,7 +29,7 @@ type Server interface {
 	 * Add an HTTP endpoint to the local debug port.
 	 */
 	AddDebugHttpEndpoint(path string, help string, handler http.HandlerFunc)
-	AddJsonHandler(pb.RateLimitServiceServer)
+	AddJsonHandler(pb.RateLimitServiceServer, *metrics.ServerReporter)
 
 	/**
 	 * Returns the embedded gRPC server to be used for registering gRPC endpoints.

--- a/src/server/server_impl.go
+++ b/src/server/server_impl.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/envoyproxy/ratelimit/src/metrics"
 	"github.com/envoyproxy/ratelimit/src/provider"
 	"github.com/envoyproxy/ratelimit/src/stats"
 
@@ -158,8 +159,8 @@ func getProviderImpl(s settings.Settings, statsManager stats.Manager, rootStore 
 	}
 }
 
-func (server *server) AddJsonHandler(svc pb.RateLimitServiceServer) {
-	server.router.HandleFunc("/json", NewJsonHandler(svc))
+func (server *server) AddJsonHandler(svc pb.RateLimitServiceServer, serverReporter *metrics.ServerReporter) {
+	server.router.HandleFunc("/json", serverReporter.HttpServerMetricsHandler("json", NewJsonHandler(svc)))
 }
 
 func (server *server) GrpcServer() *grpc.Server {

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -178,7 +178,7 @@ func (runner *Runner) Run() {
 			}
 		})
 
-	srv.AddJsonHandler(service)
+	srv.AddJsonHandler(service, serverReporter)
 
 	// Ratelimit is compatible with the below proto definition
 	// data-plane-api v3 rls.proto: https://github.com/envoyproxy/data-plane-api/blob/master/envoy/service/ratelimit/v3/rls.proto

--- a/src/stats/prom/default_mapper.yaml
+++ b/src/stats/prom/default_mapper.yaml
@@ -78,6 +78,19 @@ mappings:
     labels:
       err_type: "$1"
 
+  - match: "ratelimit_server\\.json\\.total_requests\\.__code=([0-9]+)"
+    match_type: regex
+    name: "ratelimit_service_json_total_requests"
+    match_metric_type: counter
+    labels:
+      code: "$1"
+  - match: "ratelimit_server\\.json\\.response_time\\.__code=([0-9]+)"
+    match_type: regex
+    name: "ratelimit_service_json_response_time_seconds"
+    timer_type: histogram
+    labels:
+      code: "$1"
+
   - match: "ratelimit_server.*.total_requests"
     name: "ratelimit_service_total_requests"
     match_metric_type: counter


### PR DESCRIPTION
This PR adds request count and duration metrics to the `/json` endpoint as there are currently no metrics for this endpoint, they will look something like the following (I am using prom metrics here).

```
# HELP ratelimit_service_json_response_time_seconds Metric autogenerated by statsd_exporter.
# TYPE ratelimit_service_json_response_time_seconds histogram
ratelimit_service_json_response_time_seconds_bucket{code="200",le="0.005"} 1
ratelimit_service_json_response_time_seconds_bucket{code="200",le="0.01"} 1
ratelimit_service_json_response_time_seconds_bucket{code="200",le="0.025"} 1
ratelimit_service_json_response_time_seconds_bucket{code="200",le="0.05"} 1
ratelimit_service_json_response_time_seconds_bucket{code="200",le="0.1"} 1
ratelimit_service_json_response_time_seconds_bucket{code="200",le="0.25"} 1
ratelimit_service_json_response_time_seconds_bucket{code="200",le="0.5"} 1
ratelimit_service_json_response_time_seconds_bucket{code="200",le="1"} 2
ratelimit_service_json_response_time_seconds_bucket{code="200",le="2.5"} 3
ratelimit_service_json_response_time_seconds_bucket{code="200",le="5"} 3
ratelimit_service_json_response_time_seconds_bucket{code="200",le="10"} 3
ratelimit_service_json_response_time_seconds_bucket{code="200",le="+Inf"} 3
ratelimit_service_json_response_time_seconds_sum{code="200"} 3
ratelimit_service_json_response_time_seconds_count{code="200"} 3
ratelimit_service_json_response_time_seconds_bucket{code="429",le="0.005"} 3
ratelimit_service_json_response_time_seconds_bucket{code="429",le="0.01"} 3
ratelimit_service_json_response_time_seconds_bucket{code="429",le="0.025"} 3
ratelimit_service_json_response_time_seconds_bucket{code="429",le="0.05"} 3
ratelimit_service_json_response_time_seconds_bucket{code="429",le="0.1"} 3
ratelimit_service_json_response_time_seconds_bucket{code="429",le="0.25"} 3
ratelimit_service_json_response_time_seconds_bucket{code="429",le="0.5"} 3
ratelimit_service_json_response_time_seconds_bucket{code="429",le="1"} 4
ratelimit_service_json_response_time_seconds_bucket{code="429",le="2.5"} 4
ratelimit_service_json_response_time_seconds_bucket{code="429",le="5"} 4
ratelimit_service_json_response_time_seconds_bucket{code="429",le="10"} 4
ratelimit_service_json_response_time_seconds_bucket{code="429",le="+Inf"} 4
ratelimit_service_json_response_time_seconds_sum{code="429"} 1
ratelimit_service_json_response_time_seconds_count{code="429"} 4
# HELP ratelimit_service_json_total_requests Metric autogenerated by statsd_exporter.
# TYPE ratelimit_service_json_total_requests counter
ratelimit_service_json_total_requests{code="200"} 3
ratelimit_service_json_total_requests{code="429"} 4
```

@mattklein123 @collin-lee @arkodg have this in draft for the moment as a rough POC to demonstrate how this could work as I wanted to see what the apetite for such a change would be before I go investing more effort into tidying it up and adding tests.

If you think this is a valid change I can spend some more time on polishing it up, if not I only throw away an hour of work and all is well 😸 