### PR TITLE
Add response details to ratelimit debug log

### DIFF
--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -308,7 +308,7 @@ func (this *service) ShouldRateLimit(
 	}()
 
 	response := this.shouldRateLimitWorker(ctx, request)
-	logger.Debugf("returning normal response")
+	logger.Debugf("returning normal response: %+v", response)
 
 	return response, nil
 }


### PR DESCRIPTION
Adds the response to the ratelimit response log, otherwise the logs were not particularly useful.

Before:
```
time="2025-04-08T16:54:12Z" level=debug msg="returning normal response"
```

After:
```
time="2025-04-08T16:54:12Z" level=debug msg="returning normal response: overall_code:OVER_LIMIT  statuses:{code:OVER_LIMIT  current_limit:{requests_per_unit:200  unit:MINUTE}  duration_until_reset:{seconds:48}}"
```