### PR TITLE
feat: add gRPC load balancer configuration for tracing exporter

### DIFF
--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -117,7 +117,7 @@ func createLimiter(srv server.Server, s settings.Settings, localCache *freecache
 func (runner *Runner) Run() {
 	s := runner.settings
 	if s.TracingEnabled {
-		tp := trace.InitProductionTraceProvider(s.TracingExporterProtocol, s.TracingServiceName, s.TracingServiceNamespace, s.TracingServiceInstanceId, s.TracingSamplingRate)
+		tp := trace.InitProductionTraceProvider(s.TracingExporterProtocol, s.TracingServiceName, s.TracingServiceNamespace, s.TracingServiceInstanceId, s.TracingSamplingRate, s.TracingExporterGRPCBalancer)
 		defer func() {
 			if err := tp.Shutdown(context.Background()); err != nil {
 				logger.Printf("Error shutting down tracer provider: %v", err)

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -189,6 +189,9 @@ type Settings struct {
 	TracingServiceInstanceId string `envconfig:"TRACING_SERVICE_INSTANCE_ID" default:""`
 	// can only be http or gRPC
 	TracingExporterProtocol string `envconfig:"TRACING_EXPORTER_PROTOCOL" default:"http"`
+	// TracingExporterGRPCBalancer specifies the gRPC load balancer to use (e.g., "pick_first", "round_robin")
+	// Only applies when TracingExporterProtocol is "grpc"
+	TracingExporterGRPCBalancer string `envconfig:"TRACING_EXPORTER_GRPC_BALANCER" default:""`
 	// detailed setting of exporter should refer to https://opentelemetry.io/docs/reference/specification/protocol/exporter/, e.g. OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_CERTIFICATE, OTEL_EXPORTER_OTLP_TIMEOUT
 	// TracingSamplingRate defaults to 1 which amounts to using the `AlwaysSample` sampler
 	TracingSamplingRate float64 `envconfig:"TRACING_SAMPLING_RATE" default:"1"`


### PR DESCRIPTION
## Summary

Added flexible gRPC load balancer configuration for OpenTelemetry tracing exporter to prevent trace data concentration on a single collector instance.

## Changes

- Added new environment variable TRACING_EXPORTER_GRPC_BALANCER to configure gRPC client-side load balancing strategy
- Modified trace initialization to accept and apply the gRPC balancer configuration

## Ticket

- Closes https://github.com/envoyproxy/ratelimit/issues/947