### PR TITLE
Use a scratch based image to limit vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ COPY script script
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/ratelimit -ldflags="-w -s" -v github.com/envoyproxy/ratelimit/src/service_cmd
 
-FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412 AS final
+FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412 AS cacerts
 RUN apk --no-cache add ca-certificates && apk --no-cache update
+
+FROM scratch
+COPY --from=cacerts /etc/ssl/cert.pem /etc/ssl/cert.pem
 COPY --from=build /go/bin/ratelimit /bin/ratelimit


### PR DESCRIPTION
The alpine base image isn't needed as the statically linked go binary runs fine without it. Using a scratch based image reduces the number of vulnerabilities brought up by scanning tools in the alpine image, and makes the image a bit smaller.