### PR TITLE
fix: Fix CVEs in go package

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.23.9"
+          go-version: "1.25.5"
 
       - name: run pre-commits
         run: |

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.23.9"
+          go-version: "1.25.5"
 
       - name: run pre-commits
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/ratelimit
 
-go 1.23.9
+go 1.25.5
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.5.0


### PR DESCRIPTION
Fix multiple CVEs by bumping the go version to the latest one, they are not fixed in go 1.23.x

Name | Type | Version Installed | Vulnerability ID | Fixed in | Severity | Path
-- | -- | -- | -- | -- | -- | --
stdlib | go-module | go1.25.3 | CVE-2025-61729 | 1.24.11<br>1.25.5 | High | /bin/ratelimit
stdlib | go-module | go1.25.3 | CVE-2025-61727 | 1.24.11<br>1.25.5 | Medium | /bin/ratelimit
