### PR TITLE
bump go version 1.25.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.3@sha256:6ea52a02734dd15e943286b048278da1e04eca196a564578d718c7720433dbbe AS build
+FROM golang:1.25.6@sha256:fc24d3881a021e7b968a4610fc024fba749f98fe5c07d4f28e6cfa14dc65a84c AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,5 +1,5 @@
 # Running this docker image runs the integration tests.
-FROM golang@sha256:6ea52a02734dd15e943286b048278da1e04eca196a564578d718c7720433dbbe
+FROM golang:1.25.6@sha256:fc24d3881a021e7b968a4610fc024fba749f98fe5c07d4f28e6cfa14dc65a84c
 
 RUN apt-get update -y && apt-get install sudo stunnel4 redis memcached -y && rm -rf /var/lib/apt/lists/*
 

--- a/examples/xds-sotw-config-server/Dockerfile
+++ b/examples/xds-sotw-config-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.3@sha256:6ea52a02734dd15e943286b048278da1e04eca196a564578d718c7720433dbbe AS build
+FROM golang:1.25.6@sha256:fc24d3881a021e7b968a4610fc024fba749f98fe5c07d4f28e6cfa14dc65a84c AS build
 WORKDIR /xds-server
 
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,11 @@
 module github.com/envoyproxy/ratelimit
 
-go 1.23.9
+go 1.25.6
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.5.0
 	github.com/alicebob/miniredis/v2 v2.33.0
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
-	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coocood/freecache v1.2.4
 	github.com/envoyproxy/go-control-plane v0.13.4
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4
@@ -47,6 +46,7 @@ require (
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -236,12 +236,12 @@ func validateYamlKeys(fileName string, config_map map[interface{}]interface{}) {
 	for k, v := range config_map {
 		if _, ok := k.(string); !ok {
 			errorText := fmt.Sprintf("config error, key is not of type string: %v", k)
-			logger.Debugf(errorText)
+			logger.Debug(errorText)
 			panic(newRateLimitConfigError(fileName, errorText))
 		}
 		if _, ok := validKeys[k.(string)]; !ok {
 			errorText := fmt.Sprintf("config error, unknown key '%s'", k)
-			logger.Debugf(errorText)
+			logger.Debug(errorText)
 			panic(newRateLimitConfigError(fileName, errorText))
 		}
 		switch v := v.(type) {
@@ -249,7 +249,7 @@ func validateYamlKeys(fileName string, config_map map[interface{}]interface{}) {
 			for _, e := range v {
 				if _, ok := e.(map[interface{}]interface{}); !ok {
 					errorText := fmt.Sprintf("config error, yaml file contains list of type other than map: %v", e)
-					logger.Debugf(errorText)
+					logger.Debug(errorText)
 					panic(newRateLimitConfigError(fileName, errorText))
 				}
 				element := e.(map[interface{}]interface{})
@@ -268,7 +268,7 @@ func validateYamlKeys(fileName string, config_map map[interface{}]interface{}) {
 		case nil:
 		default:
 			errorText := "error checking config"
-			logger.Debugf(errorText)
+			logger.Debug(errorText)
 			panic(newRateLimitConfigError(fileName, errorText))
 		}
 	}
@@ -571,7 +571,7 @@ func ConfigFileContentToYaml(fileName, content string) *YamlRoot {
 	err := yaml.Unmarshal([]byte(content), &any)
 	if err != nil {
 		errorText := fmt.Sprintf("error loading config file: %s", err.Error())
-		logger.Debugf(errorText)
+		logger.Debug(errorText)
 		panic(newRateLimitConfigError(fileName, errorText))
 	}
 	validateYamlKeys(fileName, any)
@@ -580,7 +580,7 @@ func ConfigFileContentToYaml(fileName, content string) *YamlRoot {
 	err = yaml.Unmarshal([]byte(content), &root)
 	if err != nil {
 		errorText := fmt.Sprintf("error loading config file: %s", err.Error())
-		logger.Debugf(errorText)
+		logger.Debug(errorText)
 		panic(newRateLimitConfigError(fileName, errorText))
 	}
 

--- a/src/memcached/cache_impl.go
+++ b/src/memcached/cache_impl.go
@@ -229,7 +229,7 @@ func newMemcachedFromSrv(srv string, d time.Duration, resolver srv.SrvResolver) 
 	err := refreshServers(serverList, srv, resolver)
 	if err != nil {
 		errorText := "Unable to fetch servers from SRV"
-		logger.Errorf(errorText)
+		logger.Error(errorText)
 		panic(MemcacheError(errorText))
 	}
 

--- a/src/server/health.go
+++ b/src/server/health.go
@@ -97,7 +97,7 @@ func (hc *HealthChecker) Fail(componentName string) error {
 		hc.grpc.SetServingStatus(hc.name, healthpb.HealthCheckResponse_NOT_SERVING)
 	} else {
 		errorText := fmt.Sprintf("Invalid component: %s", componentName)
-		logger.Errorf(errorText)
+		logger.Error(errorText)
 		return errors.New(errorText)
 	}
 	return nil
@@ -118,7 +118,7 @@ func (hc *HealthChecker) Ok(componentName string) error {
 		}
 	} else {
 		errorText := fmt.Sprintf("Invalid component: %s", componentName)
-		logger.Errorf(errorText)
+		logger.Error(errorText)
 		return errors.New(errorText)
 	}
 

--- a/src/srv/srv.go
+++ b/src/srv/srv.go
@@ -24,7 +24,7 @@ func ParseSrv(srv string) (string, string, string, error) {
 	matches := srvRegex.FindStringSubmatch(srv)
 	if matches == nil {
 		errorText := fmt.Sprintf("could not parse %s to SRV parts", srv)
-		logger.Errorf(errorText)
+		logger.Error(errorText)
 		return "", "", "", errors.New(errorText)
 	}
 	return matches[1], matches[2], matches[3], nil


### PR DESCRIPTION
Ref: #1029 
Had to fix these issues that surface with go upgrade:
```
src/srv/srv.go:27:17: non-constant format string in call to github.com/sirupsen/logrus.Errorf
src/config/config_impl.go:239:18: non-constant format string in call to github.com/sirupsen/logrus.Debugf
src/config/config_impl.go:244:18: non-constant format string in call to github.com/sirupsen/logrus.Debugf
src/config/config_impl.go:252:20: non-constant format string in call to github.com/sirupsen/logrus.Debugf
src/config/config_impl.go:271:18: non-constant format string in call to github.com/sirupsen/logrus.Debugf
src/config/config_impl.go:574:17: non-constant format string in call to github.com/sirupsen/logrus.Debugf
src/config/config_impl.go:583:17: non-constant format string in call to github.com/sirupsen/logrus.Debugf
```
