### PR TITLE
bump go version 1.25.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6@sha256:fc24d3881a021e7b968a4610fc024fba749f98fe5c07d4f28e6cfa14dc65a84c AS build
+FROM golang:1.25.7@sha256:85c0ab0b73087fda36bf8692efe2cf67c54a06d7ca3b49c489bbff98c9954d64 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,5 +1,5 @@
 # Running this docker image runs the integration tests.
-FROM golang:1.25.6@sha256:fc24d3881a021e7b968a4610fc024fba749f98fe5c07d4f28e6cfa14dc65a84c
+FROM golang:1.25.7@sha256:85c0ab0b73087fda36bf8692efe2cf67c54a06d7ca3b49c489bbff98c9954d64
 
 RUN apt-get update -y && apt-get install sudo stunnel4 redis memcached -y && rm -rf /var/lib/apt/lists/*
 

--- a/examples/xds-sotw-config-server/Dockerfile
+++ b/examples/xds-sotw-config-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6@sha256:fc24d3881a021e7b968a4610fc024fba749f98fe5c07d4f28e6cfa14dc65a84c AS build
+FROM golang:1.25.7@sha256:85c0ab0b73087fda36bf8692efe2cf67c54a06d7ca3b49c489bbff98c9954d64 AS build
 WORKDIR /xds-server
 
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/ratelimit
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.5.0


### PR DESCRIPTION
Bump go version to 1.25.7 to fix [CVE-2025-68121](https://nvd.nist.gov/vuln/detail/CVE-2025-68121) and [CVE-2025-61732](https://nvd.nist.gov/vuln/detail/CVE-2025-61732)