### PR TITLE
Send user defined metadata to the client

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -4,6 +4,7 @@ import (
 	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	"golang.org/x/net/context"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/envoyproxy/ratelimit/src/stats"
 )
@@ -29,6 +30,7 @@ type RateLimit struct {
 	// ShareThresholdKeyPattern is a slice of wildcard patterns for descriptor entries
 	// The slice index corresponds to the descriptor entry index.
 	ShareThresholdKeyPattern []string
+	Metadata                 *structpb.Struct
 }
 
 // Interface for interacting with a loaded rate limit config.

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -8,6 +8,7 @@ import (
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	logger "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	"google.golang.org/protobuf/types/known/structpb"
 	"gopkg.in/yaml.v2"
 
 	"github.com/envoyproxy/ratelimit/src/stats"
@@ -35,6 +36,7 @@ type YamlDescriptor struct {
 	DetailedMetric bool `yaml:"detailed_metric"`
 	ValueToMetric  bool `yaml:"value_to_metric"`
 	ShareThreshold bool `yaml:"share_threshold"`
+	Metadata       map[string]interface{}
 }
 
 type YamlRoot struct {
@@ -56,6 +58,7 @@ type rateLimitDescriptor struct {
 	valueToMetric   bool
 	shareThreshold  bool
 	wildcardPattern string // stores the wildcard pattern when share_threshold is true
+	metadata        *structpb.Struct
 }
 
 type rateLimitDomain struct {
@@ -84,6 +87,7 @@ var validKeys = map[string]bool{
 	"detailed_metric":   true,
 	"value_to_metric":   true,
 	"share_threshold":   true,
+	"metadata":          true,
 }
 
 // Create a new rate limit config entry.
@@ -132,6 +136,64 @@ func (this *rateLimitDescriptor) dump() string {
 // @param err supplies the error string.
 func newRateLimitConfigError(name string, err string) RateLimitConfigError {
 	return RateLimitConfigError(fmt.Sprintf("%s: %s", name, err))
+}
+
+func convertMap(m map[interface{}]interface{}) map[string]interface{} {
+	res := make(map[string]interface{})
+	for k, v := range m {
+		strKey := fmt.Sprintf("%v", k)
+		switch val := v.(type) {
+		case map[interface{}]interface{}:
+			res[strKey] = convertMap(val)
+		case []interface{}:
+			res[strKey] = convertSlice(val)
+		default:
+			res[strKey] = v
+		}
+	}
+	return res
+}
+
+func convertSlice(s []interface{}) []interface{} {
+	res := make([]interface{}, len(s))
+	for i, v := range s {
+		switch val := v.(type) {
+		case map[interface{}]interface{}:
+			res[i] = convertMap(val)
+		case []interface{}:
+			res[i] = convertSlice(val)
+		default:
+			res[i] = v
+		}
+	}
+	return res
+}
+
+// Create envoyMetadata from YamlMetadata
+// @param yamlMetadata supplies metadata parsed from config YAML
+func parseMetadata(yamlMetadata map[string]interface{}) (*structpb.Struct, error) {
+	if len(yamlMetadata) == 0 {
+		return nil, nil
+	}
+
+	convertedValue := make(map[string]interface{})
+	for k, v := range yamlMetadata {
+		switch val := v.(type) {
+		case map[interface{}]interface{}:
+			convertedValue[k] = convertMap(val)
+		case []interface{}:
+			convertedValue[k] = convertSlice(val)
+		default:
+			convertedValue[k] = v
+		}
+	}
+
+	pbStruct, err := structpb.NewStruct(convertedValue)
+	if err != nil {
+		return nil, err
+	}
+
+	return pbStruct, nil
 }
 
 // wildcardMatch reports whether value matches a pre-split wildcard pattern.
@@ -268,6 +330,11 @@ func (this *rateLimitDescriptor) loadDescriptors(config RateLimitConfigToLoad, p
 			})
 		}
 
+		metadata, err := parseMetadata(descriptorConfig.Metadata)
+		if err != nil {
+			panic(newRateLimitConfigError(config.Name, fmt.Sprintf("error parsing metadata: %s", err.Error())))
+		}
+
 		logger.Debugf(
 			"loading descriptor: key=%s%s", newParentKey, rateLimitDebugString)
 		newDescriptor := &rateLimitDescriptor{
@@ -277,6 +344,7 @@ func (this *rateLimitDescriptor) loadDescriptors(config RateLimitConfigToLoad, p
 			valueToMetric:   descriptorConfig.ValueToMetric,
 			shareThreshold:  descriptorConfig.ShareThreshold,
 			wildcardPattern: wildcardPattern,
+			metadata:        metadata,
 		}
 		newDescriptor.loadDescriptors(config, newParentKey+".", descriptorConfig.Descriptors, statsManager)
 		this.descriptors[finalKey] = newDescriptor
@@ -297,6 +365,11 @@ func validateYamlKeys(fileName string, config_map map[interface{}]interface{}) {
 			errorText := fmt.Sprintf("config error, unknown key '%s'", k)
 			logger.Debug(errorText)
 			panic(newRateLimitConfigError(fileName, errorText))
+		}
+		if k.(string) == "metadata" {
+			// Do not validate keys/values in the metadata, since they are arbitrary. If config is invalid the parsing fill fail
+			// later when it is converted to protobuf.Struct
+			continue
 		}
 		switch v := v.(type) {
 		case []interface{}:
@@ -516,6 +589,7 @@ func (this *rateLimitConfigImpl) GetLimit(
 					DetailedMetric: originalLimit.DetailedMetric,
 					// Initialize ShareThresholdKeyPattern with correct length, empty strings for entries without share_threshold
 					ShareThresholdKeyPattern: nil,
+					Metadata:                 nextDescriptor.metadata,
 				}
 				// Apply all tracked share_threshold patterns when we find the rate_limit
 				// This works whether the rate_limit is at the wildcard level or deeper

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -207,7 +207,7 @@ func (this *service) shouldRateLimitWorker(
 	var minimumDescriptor *pb.RateLimitResponse_DescriptorStatus = nil
 
 	// Track quota mode violations for metadata
-	var quotaModeViolations []int
+	var passedDescriptors []int
 	failedRateLimitDescriptors := 0
 	failedQuotaDescriptors := 0
 	totalQuotaDescriptors := 0
@@ -231,14 +231,15 @@ func (this *service) shouldRateLimitWorker(
 			isQuotaMode := globalQuotaMode || (limitsToCheck[i] != nil && limitsToCheck[i].QuotaMode)
 			if descriptorStatus.Code == pb.RateLimitResponse_OVER_LIMIT {
 				if isQuotaMode {
-					// In quota mode: track the violation for metadata but keep response as OK
-					quotaModeViolations = append(quotaModeViolations, i)
 					failedQuotaDescriptors += 1
 				} else {
 					failedRateLimitDescriptors += 1
 					minimumDescriptor = descriptorStatus
 					minLimitRemaining = 0
 				}
+			} else {
+				// Keep track of the descriptors that have passed
+				passedDescriptors = append(passedDescriptors, i)
 			}
 			if isQuotaMode {
 				totalQuotaDescriptors += 1
@@ -270,14 +271,14 @@ func (this *service) shouldRateLimitWorker(
 
 	// If response dynamic data enabled, set dynamic data on response.
 	if this.responseDynamicMetadataEnabled {
-		response.DynamicMetadata = ratelimitToMetadata(request, quotaModeViolations, limitsToCheck)
+		response.DynamicMetadata = ratelimitToMetadata(request, passedDescriptors, limitsToCheck)
 	}
 
 	response.OverallCode = finalCode
 	return response
 }
 
-func ratelimitToMetadata(req *pb.RateLimitRequest, quotaModeViolations []int, limitsToCheck []*config.RateLimit) *structpb.Struct {
+func ratelimitToMetadata(req *pb.RateLimitRequest, passedDescriptors []int, limitsToCheck []*config.RateLimit) *structpb.Struct {
 	fields := make(map[string]*structpb.Value)
 
 	// Domain
@@ -301,26 +302,19 @@ func ratelimitToMetadata(req *pb.RateLimitRequest, quotaModeViolations []int, li
 		fields["hitsAddend"] = structpb.NewNumberValue(float64(hitsAddend))
 	}
 
-	// Quota mode information
-	if len(quotaModeViolations) > 0 {
-		violationValues := make([]*structpb.Value, len(quotaModeViolations))
-		for i, violationIndex := range quotaModeViolations {
-			violationValues[i] = structpb.NewNumberValue(float64(violationIndex))
+	passedMetadata := &structpb.Struct{Fields: make(map[string]*structpb.Value)}
+	for _, idx := range passedDescriptors {
+		if idx < len(limitsToCheck) {
+			limit := limitsToCheck[idx]
+			if limit != nil && limit.Metadata != nil {
+				mergeMetadata(passedMetadata, limit.Metadata)
+			}
 		}
-		fields["quotaModeViolations"] = structpb.NewListValue(&structpb.ListValue{
-			Values: violationValues,
-		})
 	}
 
-	// Check if any limits have quota mode enabled
-	quotaModeEnabled := false
-	for _, limit := range limitsToCheck {
-		if limit != nil && limit.QuotaMode {
-			quotaModeEnabled = true
-			break
-		}
+	if len(passedMetadata.GetFields()) > 0 {
+		fields["metadata"] = structpb.NewStructValue(passedMetadata)
 	}
-	fields["quotaModeEnabled"] = structpb.NewBoolValue(quotaModeEnabled)
 
 	return &structpb.Struct{Fields: fields}
 }
@@ -353,6 +347,28 @@ func descriptorToStruct(descriptor *ratelimitv3.RateLimitDescriptor) *structpb.S
 	}
 
 	return &structpb.Struct{Fields: fields}
+}
+
+func mergeMetadata(dest *structpb.Struct, src *structpb.Struct) {
+	if src == nil {
+		return
+	}
+	for k, v := range src.GetFields() {
+		destVal, exists := dest.GetFields()[k]
+		if exists {
+			// If both are structs, merge them recursively
+			if destStruct := destVal.GetStructValue(); destStruct != nil {
+				if srcStruct := v.GetStructValue(); srcStruct != nil {
+					mergeMetadata(destStruct, srcStruct)
+					continue
+				}
+			}
+			// TODO(yanavlasov): add option to overwrite or add if typoe is a list
+		} else {
+			// Otherwise overwrite or add
+			dest.GetFields()[k] = v
+		}
+	}
 }
 
 func (this *service) rateLimitLimitHeader(descriptor *pb.RateLimitResponse_DescriptorStatus) *core.HeaderValue {

--- a/src/service/ratelimit_test.go
+++ b/src/service/ratelimit_test.go
@@ -16,11 +16,11 @@ import (
 
 func TestRatelimitToMetadata(t *testing.T) {
 	cases := []struct {
-		name                string
-		req                 *pb.RateLimitRequest
-		quotaModeViolations []int
-		limitsToCheck       []*config.RateLimit
-		expected            string
+		name              string
+		req               *pb.RateLimitRequest
+		passedDescriptors []int
+		limitsToCheck     []*config.RateLimit
+		expected          string
 	}{
 		{
 			name: "Single descriptor with single entry, no quota violations",
@@ -37,8 +37,8 @@ func TestRatelimitToMetadata(t *testing.T) {
 					},
 				},
 			},
-			quotaModeViolations: nil,
-			limitsToCheck:       []*config.RateLimit{nil},
+			passedDescriptors: nil,
+			limitsToCheck:     []*config.RateLimit{nil},
 			expected: `{
     "descriptors": [
         {
@@ -47,8 +47,7 @@ func TestRatelimitToMetadata(t *testing.T) {
             ]
         }
     ],
-    "domain": "fake-domain",
-    "quotaModeEnabled": false
+    "domain": "fake-domain"
 }`,
 		},
 		{
@@ -66,10 +65,15 @@ func TestRatelimitToMetadata(t *testing.T) {
 					},
 				},
 			},
-			quotaModeViolations: []int{0},
+			passedDescriptors: []int{0},
 			limitsToCheck: []*config.RateLimit{
 				{
 					QuotaMode: true,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"name": structpb.NewStringValue("service_1"),
+						},
+					},
 				},
 			},
 			expected: `{
@@ -81,8 +85,9 @@ func TestRatelimitToMetadata(t *testing.T) {
         }
     ],
     "domain": "quota-domain",
-    "quotaModeEnabled": true,
-    "quotaModeViolations": [0]
+    "metadata": {
+        "name": "service_1"
+    }
 }`,
 		},
 		{
@@ -116,16 +121,31 @@ func TestRatelimitToMetadata(t *testing.T) {
 					},
 				},
 			},
-			quotaModeViolations: []int{1, 2},
+			passedDescriptors: []int{1, 2},
 			limitsToCheck: []*config.RateLimit{
 				{
 					QuotaMode: false,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"name": structpb.NewStringValue("service_1"),
+						},
+					},
 				},
 				{
 					QuotaMode: true,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"name": structpb.NewStringValue("service_2"),
+						},
+					},
 				},
 				{
 					QuotaMode: true,
+					Metadata: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"name": structpb.NewStringValue("service_3"),
+						},
+					},
 				},
 			},
 			expected: `{
@@ -147,8 +167,9 @@ func TestRatelimitToMetadata(t *testing.T) {
         }
     ],
     "domain": "mixed-domain",
-    "quotaModeEnabled": true,
-    "quotaModeViolations": [1, 2]
+    "metadata": {
+        "name": "service_2"
+    }
 }`,
 		},
 		{
@@ -167,7 +188,7 @@ func TestRatelimitToMetadata(t *testing.T) {
 					},
 				},
 			},
-			quotaModeViolations: []int{0},
+			passedDescriptors: []int{0},
 			limitsToCheck: []*config.RateLimit{
 				{
 					QuotaMode: true,
@@ -182,16 +203,14 @@ func TestRatelimitToMetadata(t *testing.T) {
         }
     ],
     "domain": "addend-domain",
-    "hitsAddend": 5,
-    "quotaModeEnabled": true,
-    "quotaModeViolations": [0]
+    "hitsAddend": 5
 }`,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ratelimitToMetadata(tc.req, tc.quotaModeViolations, tc.limitsToCheck)
+			got := ratelimitToMetadata(tc.req, tc.passedDescriptors, tc.limitsToCheck)
 			expected := &structpb.Struct{}
 			err := protojson.Unmarshal([]byte(tc.expected), expected)
 			require.NoError(t, err)

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -2206,5 +2206,58 @@ func TestWildcardStatsBehavior(t *testing.T) {
 	})
 }
 
+func TestMetadata(t *testing.T) {
+	assert := assert.New(t)
+	stats := stats.NewStore(stats.NewNullSink(), false)
+	rlConfig := config.NewRateLimitConfigImpl(loadFile("metadata.yaml"), mockstats.NewMockStatManager(stats), false)
+	rlConfig.Dump()
+	assert.Equal(rlConfig.IsEmptyDomains(), false)
+	assert.Nil(rlConfig.GetLimit(context.TODO(), "test-domain", &pb_struct.RateLimitDescriptor{}))
+	assert.EqualValues(0, stats.NewCounter("test-domain.domain_not_found").Value())
+
+	rl := rlConfig.GetLimit(
+		context.TODO(), "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "key1", Value: "value1"}, {Key: "subkey1", Value: "something"}},
+		})
+	rl.Stats.TotalHits.Inc()
+	rl.Stats.OverLimit.Inc()
+	rl.Stats.NearLimit.Inc()
+	rl.Stats.WithinLimit.Inc()
+	assert.EqualValues(5, rl.Limit.RequestsPerUnit)
+	assert.Equal(pb.RateLimitResponse_RateLimit_SECOND, rl.Limit.Unit)
+	assert.EqualValues(1, stats.NewCounter("test-domain.key1_value1.subkey1.total_hits").Value())
+	assert.EqualValues(1, stats.NewCounter("test-domain.key1_value1.subkey1.over_limit").Value())
+	assert.EqualValues(1, stats.NewCounter("test-domain.key1_value1.subkey1.near_limit").Value())
+	assert.EqualValues(1, stats.NewCounter("test-domain.key1_value1.subkey1.within_limit").Value())
+
+	// Verify metadata for key1_value1.subkey1
+	assert.NotNil(rl.Metadata)
+	nameVal, ok := rl.Metadata.GetFields()["name"]
+	assert.True(ok)
+	assert.Equal("service_1", nameVal.GetStringValue())
+
+	rl = rlConfig.GetLimit(
+		context.TODO(), "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "key2", Value: "something"}},
+		})
+	rl.Stats.TotalHits.Inc()
+	rl.Stats.OverLimit.Inc()
+	rl.Stats.NearLimit.Inc()
+	rl.Stats.WithinLimit.Inc()
+	assert.EqualValues(20, rl.Limit.RequestsPerUnit)
+	assert.Equal(pb.RateLimitResponse_RateLimit_MINUTE, rl.Limit.Unit)
+	assert.EqualValues(1, stats.NewCounter("test-domain.key2.total_hits").Value())
+	assert.EqualValues(1, stats.NewCounter("test-domain.key2.over_limit").Value())
+	assert.EqualValues(1, stats.NewCounter("test-domain.key2.near_limit").Value())
+	assert.EqualValues(1, stats.NewCounter("test-domain.key2.within_limit").Value())
+
+	assert.NotNil(rl.Metadata)
+	serviceVal, ok := rl.Metadata.GetFields()["service_with_quota"]
+	assert.True(ok)
+	assert.Equal("service_2", serviceVal.GetStructValue().GetFields()["name"].GetStringValue())
+}
+
 // share_threshold parity (middle+trailing wildcards produce the same shared-counter
 // behaviour as trailing-only) is covered by TestShareThreshold Cases 5-7.

--- a/test/config/metadata.yaml
+++ b/test/config/metadata.yaml
@@ -1,0 +1,28 @@
+domain: test-domain
+descriptors:
+  # Top level key/value with no default rate limit.
+  - key: key1
+    value: value1
+    descriptors:
+      # 2nd level key only with default rate limit.
+      - key: subkey1
+        rate_limit:
+          unit: second
+          requests_per_unit: 5
+        metadata:
+          name: service_1
+
+      # 2nd level key/value with limit. Specific override at 2nd level.
+      - key: subkey1
+        value: subvalue1
+        rate_limit:
+          unit: second
+          requests_per_unit: 10
+
+  - key: key2
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20
+    metadata:
+      service_with_quota:
+        name: service_2

--- a/test/service/ratelimit_test.go
+++ b/test/service/ratelimit_test.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/envoyproxy/ratelimit/src/trace"
 
@@ -719,7 +720,7 @@ func TestServiceGlobalQuotaMode(test *testing.T) {
 	t.assert.Nil(err)
 }
 
-func TestServiceQuotaModeWithMetadata(test *testing.T) {
+func TestMetadataReturnedForPassedDescriptors(test *testing.T) {
 	os.Setenv("QUOTA_MODE", "true")
 	os.Setenv("RESPONSE_DYNAMIC_METADATA", "true")
 	defer func() {
@@ -749,6 +750,9 @@ func TestServiceQuotaModeWithMetadata(test *testing.T) {
 		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
 		config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key2"), false, false, true, "", nil, false),
 	}
+	limits[0].Metadata = &structpb.Struct{Fields: map[string]*structpb.Value{"name": structpb.NewStringValue("service_1")}}
+	limits[1].Metadata = &structpb.Struct{Fields: map[string]*structpb.Value{"name": structpb.NewStringValue("service_2")}}
+
 	t.config.EXPECT().GetLimit(context.Background(), "quota-domain", request.Descriptors[0]).Return(limits[0])
 	t.config.EXPECT().GetLimit(context.Background(), "quota-domain", request.Descriptors[1]).Return(limits[1])
 	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
@@ -757,23 +761,149 @@ func TestServiceQuotaModeWithMetadata(test *testing.T) {
 			{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[1].Limit, LimitRemaining: 0},
 		})
 	response, err := service.ShouldRateLimit(context.Background(), request)
+	test.Logf("DynamicMetadata: %+v", response.DynamicMetadata)
 
 	// Verify response includes metadata about quota violations
 	t.assert.Nil(err)
 	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
 	t.assert.NotNil(response.DynamicMetadata)
 
-	// Check that quota violation is tracked in metadata for descriptor index 1
-	quotaViolations := response.DynamicMetadata.Fields["quotaModeViolations"]
-	t.assert.NotNil(quotaViolations)
-	violations := quotaViolations.GetListValue()
-	t.assert.Len(violations.Values, 1)
-	t.assert.Equal(float64(1), violations.Values[0].GetNumberValue())
+	// Verify metadata for passed limits
+	passedMetadataVal, ok := response.DynamicMetadata.GetFields()["metadata"]
+	t.assert.True(ok)
+	passedMetadata := passedMetadataVal.GetStructValue()
+	t.assert.NotNil(passedMetadata)
 
-	// Check that quotaModeEnabled is true
-	quotaModeEnabled := response.DynamicMetadata.Fields["quotaModeEnabled"]
-	t.assert.NotNil(quotaModeEnabled)
-	t.assert.True(quotaModeEnabled.GetBoolValue())
+	fields := passedMetadata.GetFields()
+	nameVal, ok := fields["name"]
+	t.assert.True(ok)
+	// Since descriptor 1 has passed and 2 had failed, metadata from the first descriptors should be returned
+	t.assert.Equal("service_1", nameVal.GetStringValue())
+}
+
+func TestMetadataReturnedForAllPassedDescriptors(test *testing.T) {
+	os.Setenv("QUOTA_MODE", "true")
+	os.Setenv("RESPONSE_DYNAMIC_METADATA", "true")
+	defer func() {
+		os.Unsetenv("QUOTA_MODE")
+		os.Unsetenv("RESPONSE_DYNAMIC_METADATA")
+	}()
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+
+	service := t.setupBasicService()
+
+	// Force a config reload to pick up environment variables.
+	barrier := newBarrier()
+	t.configUpdateEvent.EXPECT().GetConfig().DoAndReturn(func() (config.RateLimitConfig, any) {
+		barrier.signal()
+		return t.config, nil
+	})
+	t.configUpdateEventChan <- t.configUpdateEvent
+	barrier.wait()
+
+	// Make a request.
+	request := common.NewRateLimitRequest(
+		"quota-domain", [][][2]string{{{"regular", "limit"}}, {{"quota", "limit"}}}, 1)
+
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, true, "", nil, false),
+		config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key2"), false, false, true, "", nil, false),
+	}
+	limits[0].Metadata = &structpb.Struct{Fields: map[string]*structpb.Value{"name": structpb.NewStringValue("service_1")}}
+	limits[1].Metadata = &structpb.Struct{Fields: map[string]*structpb.Value{"some_other_name": structpb.NewStringValue("service_2")}}
+
+	t.config.EXPECT().GetLimit(context.Background(), "quota-domain", request.Descriptors[0]).Return(limits[0])
+	t.config.EXPECT().GetLimit(context.Background(), "quota-domain", request.Descriptors[1]).Return(limits[1])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{
+			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5},
+			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[1].Limit, LimitRemaining: 6},
+		})
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	test.Logf("DynamicMetadata: %+v", response.DynamicMetadata)
+
+	// Verify response includes metadata about quota violations
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+	t.assert.NotNil(response.DynamicMetadata)
+
+	// Verify metadata for passed limits
+	passedMetadataVal, ok := response.DynamicMetadata.GetFields()["metadata"]
+	t.assert.True(ok)
+	passedMetadata := passedMetadataVal.GetStructValue()
+	t.assert.NotNil(passedMetadata)
+
+	fields := passedMetadata.GetFields()
+	nameVal, ok := fields["name"]
+	t.assert.True(ok)
+	// Both descriptors have passed metadata should contain values from both descriptors
+	t.assert.Equal("service_1", nameVal.GetStringValue())
+	nameVal, ok = fields["some_other_name"]
+	t.assert.True(ok)
+	t.assert.Equal("service_2", nameVal.GetStringValue())
+}
+
+func TestOverlappingMetadataReturnsTheFirstValue(test *testing.T) {
+	os.Setenv("QUOTA_MODE", "true")
+	os.Setenv("RESPONSE_DYNAMIC_METADATA", "true")
+	defer func() {
+		os.Unsetenv("QUOTA_MODE")
+		os.Unsetenv("RESPONSE_DYNAMIC_METADATA")
+	}()
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+
+	service := t.setupBasicService()
+
+	// Force a config reload to pick up environment variables.
+	barrier := newBarrier()
+	t.configUpdateEvent.EXPECT().GetConfig().DoAndReturn(func() (config.RateLimitConfig, any) {
+		barrier.signal()
+		return t.config, nil
+	})
+	t.configUpdateEventChan <- t.configUpdateEvent
+	barrier.wait()
+
+	// Make a request.
+	request := common.NewRateLimitRequest(
+		"quota-domain", [][][2]string{{{"regular", "limit"}}, {{"quota", "limit"}}}, 1)
+
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, true, "", nil, false),
+		config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key2"), false, false, true, "", nil, false),
+	}
+	limits[0].Metadata = &structpb.Struct{Fields: map[string]*structpb.Value{"name": structpb.NewStringValue("service_1")}}
+	limits[1].Metadata = &structpb.Struct{Fields: map[string]*structpb.Value{"name": structpb.NewStringValue("service_2")}}
+
+	t.config.EXPECT().GetLimit(context.Background(), "quota-domain", request.Descriptors[0]).Return(limits[0])
+	t.config.EXPECT().GetLimit(context.Background(), "quota-domain", request.Descriptors[1]).Return(limits[1])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{
+			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5},
+			{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[1].Limit, LimitRemaining: 6},
+		})
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	test.Logf("DynamicMetadata: %+v", response.DynamicMetadata)
+
+	// Verify response includes metadata about quota violations
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+	t.assert.NotNil(response.DynamicMetadata)
+
+	// Verify metadata for passed limits
+	passedMetadataVal, ok := response.DynamicMetadata.GetFields()["metadata"]
+	t.assert.True(ok)
+	passedMetadata := passedMetadataVal.GetStructValue()
+	t.assert.NotNil(passedMetadata)
+
+	fields := passedMetadata.GetFields()
+	nameVal, ok := fields["name"]
+	t.assert.True(ok)
+	// Metadata from the first descriptor takes precendence
+	t.assert.Equal("service_1", nameVal.GetStringValue())
 }
 
 func TestServicePerDescriptorQuotaMode(test *testing.T) {


### PR DESCRIPTION
Add per descriptor metadata that is sent to the client when the descriptor is under the limit.

This is a prerequisite for the quota based routing. The rate limit service will send metadata with the service names that correspond to descriptors with available quota. Envoy will use this metadata to select a service for forwarding the request.