### PR TITLE
Add integration test for quota based service selection.

### DIFF
--- a/examples/envoy/mock.yaml
+++ b/examples/envoy/mock.yaml
@@ -23,7 +23,35 @@ static_resources:
                           direct_response:
                             status: "200"
                             body:
-                              inline_string: "Hello World"
+                              inline_string: "Hello World from Service 1"
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    - address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 10001
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                codec_type: AUTO
+                stat_prefix: ingress
+                route_config:
+                  name: ingress
+                  virtual_hosts:
+                    - name: backend
+                      domains:
+                        - "*"
+                      routes:
+                        - match:
+                            prefix: "/"
+                          direct_response:
+                            status: "200"
+                            body:
+                              inline_string: "Hello World from Service 2"
                 http_filters:
                   - name: envoy.filters.http.router
                     typed_config:

--- a/examples/envoy/proxy.yaml
+++ b/examples/envoy/proxy.yaml
@@ -34,6 +34,50 @@ static_resources:
                     socket_address:
                       address: envoy-mock
                       port_value: 9999
+    - name: multiservice
+      connect_timeout: 1s
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      lb_subset_config:
+        fallback_policy: ANY_ENDPOINT
+        subset_selectors:
+          - keys:
+              - service
+      load_assignment:
+        cluster_name: multiservice
+        endpoints:
+          - locality:
+              region: "region_1"
+            metadata:
+              filter_metadata:
+                envoy.cluster.locality:
+                  name: "service_1"
+            lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: envoy-mock
+                      port_value: 9999
+                metadata:
+                  filter_metadata:
+                    envoy.lb:
+                      service: "service_1"
+          - locality:
+              region: "region_2"
+            metadata:
+              filter_metadata:
+                envoy.cluster.locality:
+                  name: "service_2"
+            lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: envoy-mock
+                      port_value: 10001
+                metadata:
+                  filter_metadata:
+                    envoy.lb:
+                      service: "service_2"
   listeners:
     - address:
         socket_address:
@@ -61,6 +105,26 @@ static_resources:
                           envoy_grpc:
                             cluster_name: ratelimit
                         transport_api_version: V3
+                  - name: envoy.filters.http.set_header
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+                      mutations:
+                        request_mutations:
+                          - append:
+                              header:
+                                key: "x-envoy-service-with-quota"
+                                value: "%DYNAMIC_METADATA(envoy.filters.http.ratelimit:metadata:service_with_quota:name)%"
+                              append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                  - name: envoy.filters.http.header_to_metadata
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.header_to_metadata.v3.Config
+                      stat_prefix: header_converter
+                      request_rules:
+                        - header: x-envoy-service-with-quota
+                          on_header_present:
+                            metadata_namespace: envoy.lb
+                            key: service
+                            type: STRING
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -196,6 +260,39 @@ static_resources:
                                     - generic_key:
                                         descriptor_value: "service_2"
                                         descriptor_key: "service"
+                                  hits_addend:
+                                    number: 1
+                                  apply_on_stream_done: true
+                        - match:
+                            prefix: /multiservice-tokenquota
+                          route:
+                            cluster: multiservice
+                          typed_per_filter_config:
+                            envoy.filters.http.ratelimit:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+                              vh_rate_limits: INCLUDE
+                              override_option: INCLUDE_POLICY
+                              rate_limits:
+                                - actions:
+                                    - generic_key:
+                                        descriptor_value: "service_1"
+                                        descriptor_key: "service"
+                                  hits_addend:
+                                    number: 0
+                                - actions:
+                                    - generic_key:
+                                        descriptor_value: "service_2"
+                                        descriptor_key: "service"
+                                  hits_addend:
+                                    number: 0
+                                - actions:
+                                    - metadata:
+                                        descriptor_key: "service"
+                                        source: CLUSTER_LOCALITY_ENTRY
+                                        metadata_key:
+                                          key: "envoy.cluster.locality"
+                                          path:
+                                            - key: "name"
                                   hits_addend:
                                     number: 1
                                   apply_on_stream_done: true

--- a/examples/ratelimit/config/example.yaml
+++ b/examples/ratelimit/config/example.yaml
@@ -90,9 +90,15 @@ descriptors:
     rate_limit:
       unit: minute
       requests_per_unit: 1
+    metadata:
+      service_with_quota:
+        name: "service_1"
   - key: service
     value: service_2
     quota_mode: true
     rate_limit:
       unit: minute
       requests_per_unit: 2
+    metadata:
+      service_with_quota:
+        name: "service_2"

--- a/integration-test/docker-compose-integration-test.yml
+++ b/integration-test/docker-compose-integration-test.yml
@@ -51,9 +51,10 @@ services:
       - RUNTIME_ROOT=/data
       - RUNTIME_SUBDIRECTORY=ratelimit
       - RUNTIME_WATCH_ROOT=false
+      - RESPONSE_DYNAMIC_METADATA=true
 
   envoy-proxy:
-    image: envoyproxy/envoy-dev:latest
+    image: envoyproxy/envoy:dev
     entrypoint: "/usr/local/bin/envoy"
     command:
       - "--service-node proxy"
@@ -91,8 +92,10 @@ services:
       - ratelimit-network
     expose:
       - "9999"
+      - "10001"
     ports:
       - "9999:9999"
+      - "10001:10001"
 
   tester:
     build:

--- a/integration-test/scripts/multiservice-tokenquota.sh
+++ b/integration-test/scripts/multiservice-tokenquota.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#
+# request to /multiservice-tokenquota will produce the (service: service_1), (service: service_2) descriptor
+# with 0 addend on request path and on response path descriptor containing the name of service which served the request with addend 1.
+# RL service responds with metadata containing the service name with available quota.
+# service_1 has 1 req/min, service_2 has 2 req/min. Since quota is depbited on response path a total of 2 requests/minute for service_1
+# and 3 requests/minute for service_2 is allowed.
+#
+
+response=$(curl -f -s -H "request-no: 1" http://envoy-proxy:8888/multiservice-tokenquota | grep "from Service 1")
+response=$(curl -f -s -H "request-no: 2" http://envoy-proxy:8888/multiservice-tokenquota | grep "from Service 1")
+# service_1 is out of quota and service_2 should now be used
+response=$(curl -f -s -H "request-no: 3" http://envoy-proxy:8888/multiservice-tokenquota | grep "from Service 2")
+response=$(curl -f -s -H "request-no: 4" http://envoy-proxy:8888/multiservice-tokenquota | grep "from Service 2")
+response=$(curl -f -s -H "request-no: 5" http://envoy-proxy:8888/multiservice-tokenquota | grep "from Service 2")
+
+if [ $? -ne 0 ]; then
+	echo "Quota limit should not trigger yet"
+	exit 1
+fi
+
+# Quota is debited from service_2 bucket on the response path so only the 5th request should be rejected
+response=$(curl -f -s -H "request-no: 6" http://envoy-proxy:8888/multiservice-tokenquota | grep "Hello World from Service")
+
+if [ $? -eq 0 ]; then
+	echo "Quota limiting should fail the request"
+	exit 1
+fi
+
+echo "Waiting 1 minute for quota buckets to be refreshed"
+sleep 60
+
+response=$(curl -f -s -H "request-no: 7" http://envoy-proxy:8888/multiservice-tokenquota | grep "from Service 1")
+if [ $? -ne 0 ]; then
+	echo "Quota bucket should be refreshed and service_1 is used"
+	exit 1
+fi


### PR DESCRIPTION
Add integration test for using metadata in the rate limit service service to determine subset selection.

NOTE:
This test is using workaround for hardcoded namespace where metadata is stored. Once this limitation is addressed in https://github.com/envoyproxy/envoy/pull/44531 the header_mutation and header_to_metadata filters will be removed.