### PR TITLE
fix: pin golang:1.26.2 to multi-arch index digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2@sha256:7095ad02810845fa35d1fb090b8e57dd20dce4ca36b29b42951802350d2ec90e AS build
+FROM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,5 +1,5 @@
 # Running this docker image runs the integration tests.
-FROM golang:1.26.2@sha256:7095ad02810845fa35d1fb090b8e57dd20dce4ca36b29b42951802350d2ec90e
+FROM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716
 
 RUN apt-get update -y && apt-get install sudo stunnel4 redis memcached -y && rm -rf /var/lib/apt/lists/*
 

--- a/examples/xds-sotw-config-server/Dockerfile
+++ b/examples/xds-sotw-config-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2@sha256:7095ad02810845fa35d1fb090b8e57dd20dce4ca36b29b42951802350d2ec90e AS build
+FROM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS build
 WORKDIR /xds-server
 
 COPY . .


### PR DESCRIPTION
Fixes #1133

PR #1124 pinned `FROM golang:1.26.2` by a per-platform (amd64) manifest digest instead of the OCI index digest. 

Under buildx + QEMU this caused every target platform to receive amd64 base layers, producing identical amd64 binaries inside the linux/arm64/v8 manifest and surfacing as `exec /bin/ratelimit: exec format error` on arm64 hosts.