### PR TITLE
feat: expose configured rate limit as a gauge metric

### DIFF
--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -99,6 +99,7 @@ var validKeys = map[string]bool{
 func NewRateLimit(requestsPerUnit uint32, unit pb.RateLimitResponse_RateLimit_Unit, rlStats stats.RateLimitStats,
 	unlimited bool, shadowMode bool, quotaMode bool, name string, replaces []string, detailedMetric bool,
 ) *RateLimit {
+	rlStats.RateLimit.Set(uint64(requestsPerUnit))
 	return &RateLimit{
 		FullKey: rlStats.GetKey(),
 		Stats:   rlStats,

--- a/src/stats/manager.go
+++ b/src/stats/manager.go
@@ -54,6 +54,7 @@ type RateLimitStats struct {
 	OverLimitWithLocalCache gostats.Counter
 	WithinLimit             gostats.Counter
 	ShadowMode              gostats.Counter
+	RateLimit               gostats.Gauge
 }
 
 // Stats for a domain entry

--- a/src/stats/manager_impl.go
+++ b/src/stats/manager_impl.go
@@ -36,6 +36,7 @@ func (this *ManagerImpl) NewStats(key string) RateLimitStats {
 	ret.OverLimitWithLocalCache = this.rlStatsScope.NewCounter(key + ".over_limit_with_local_cache")
 	ret.WithinLimit = this.rlStatsScope.NewCounter(key + ".within_limit")
 	ret.ShadowMode = this.rlStatsScope.NewCounter(key + ".shadow_mode")
+	ret.RateLimit = this.rlStatsScope.NewGauge(key + ".rate_limit")
 	return ret
 }
 

--- a/src/stats/prom/default_mapper.yaml
+++ b/src/stats/prom/default_mapper.yaml
@@ -30,6 +30,12 @@ mappings:
     labels:
       domain: "$1"
       key1: "$2"
+  - match: "ratelimit.service.rate_limit.*.*.rate_limit"
+    name: "ratelimit_service_rate_limit_limit"
+    match_metric_type: gauge
+    labels:
+      domain: "$1"
+      key1: "$2"
 
   - match: "ratelimit\\.service\\.rate_limit\\.([^\\.]*)\\.([^\\.]*)\\.([^\\.]*)(\\..*)?\\.near_limit"
     match_type: regex
@@ -67,6 +73,14 @@ mappings:
     match_type: regex
     name: "ratelimit_service_rate_limit_shadow_mode"
     timer_type: "histogram"
+    labels:
+      domain: "$1"
+      key1: "$2"
+      key2: "$3"
+  - match: "ratelimit\\.service\\.rate_limit\\.([^\\.]*)\\.([^\\.]*)\\.([^\\.]*)(\\..*)?\\.rate_limit"
+    match_type: regex
+    name: "ratelimit_service_rate_limit_limit"
+    match_metric_type: gauge
     labels:
       domain: "$1"
       key1: "$2"

--- a/test/mocks/stats/manager.go
+++ b/test/mocks/stats/manager.go
@@ -44,6 +44,7 @@ func (m *MockStatManager) NewStats(key string) stats.RateLimitStats {
 	ret.OverLimitWithLocalCache = m.store.NewCounter(key + ".over_limit_with_local_cache")
 	ret.WithinLimit = m.store.NewCounter(key + ".within_limit")
 	ret.ShadowMode = m.store.NewCounter(key + ".shadow_mode")
+	ret.RateLimit = m.store.NewGauge(key + ".rate_limit")
 
 	return ret
 }

--- a/test/stats/manager_impl_test.go
+++ b/test/stats/manager_impl_test.go
@@ -12,6 +12,19 @@ import (
 	"github.com/envoyproxy/ratelimit/src/stats"
 )
 
+func TestNewStatsCreatesRateLimitGauge(t *testing.T) {
+	mockSink := gostatsMock.NewSink()
+	statsStore := gostats.NewStore(mockSink, false)
+	statsManager := stats.NewStatManager(statsStore, settings.Settings{})
+
+	s := statsManager.NewStats("test-domain.key1")
+	assert.NotNil(t, s.RateLimit)
+
+	s.RateLimit.Set(100)
+	statsManager.GetStatsStore().Flush()
+	mockSink.AssertGaugeEquals(t, "ratelimit.service.rate_limit.test-domain.key1.rate_limit", 100)
+}
+
 func TestEscapingInvalidChartersInMetricName(t *testing.T) {
 	mockSink := gostatsMock.NewSink()
 	statsStore := gostats.NewStore(mockSink, false)


### PR DESCRIPTION
## Problem

The existing `near_limit` counter fires at a fixed percentage controlled by the global `NEAR_LIMIT_RATIO` env var (default 80%). There is no way to:

1. Set a different threshold per-service/descriptor (e.g. alert at 60% for a critical service).
2. Build a utilization ratio in Prometheus because the configured `requests_per_unit` value is never exported as a metric — the denominator simply doesn't exist.

## Solution

Add a `rate_limit` **gauge** to `RateLimitStats` that holds the configured `requests_per_unit` for each descriptor. The gauge is populated once at config load time inside `NewRateLimit()`, so it reflects the current config and is updated on hot-reload.

With this gauge, operators can construct arbitrary utilization alerts in Prometheus without touching `NEAR_LIMIT_RATIO`:

```promql
# Alert when any descriptor exceeds 60% utilization
ratelimit_service_rate_limit_total_hits
  / ratelimit_service_rate_limit_limit > 0.6

# Per-domain alert at a custom threshold
ratelimit_service_rate_limit_total_hits{domain="payments"}
  / ratelimit_service_rate_limit_limit{domain="payments"} > 0.9
```

Unlimited descriptors (`requests_per_unit: 0`) emit `0`, which produces `+Inf`/`NaN` in ratio queries and does not trigger threshold alerts.

## Changes

| File | Change |
|---|---|
| `src/stats/manager.go` | Add `RateLimit gostats.Gauge` field to `RateLimitStats` |
| `src/stats/manager_impl.go` | Initialize gauge in `NewStats()` |
| `test/mocks/stats/manager.go` | Mirror gauge initialization in test mock |
| `src/config/config_impl.go` | Set gauge value in `NewRateLimit()` at config load time |
| `src/stats/prom/default_mapper.yaml` | Add glob (1-key) and regex (2-key) mapper entries for `ratelimit_service_rate_limit_limit` |
| `test/stats/manager_impl_test.go` | New test asserting the gauge emits the correct `requests_per_unit` value |

## Test plan

- [x] `go test ./test/stats/...` — new `TestNewStatsCreatesRateLimitGauge` passes
- [x] `go test ./test/config/... ./test/limiter/... ./test/redis/... ./test/memcached/... ./test/service/...` — all existing tests pass
- [x] `go build ./...` — compiles cleanly