### PR TITLE
feat: implement is_negative_hits in rate limit descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
     - [Health-check configurations](#health-check-configurations)
   - [GRPC server](#grpc-server)
 - [Request Fields](#request-fields)
+  - [Negative hits](#negative-hits)
 - [GRPC Client](#grpc-client)
   - [Commandline flags](#commandline-flags)
 - [Global ShadowMode](#global-shadowmode)
@@ -961,6 +962,21 @@ socket then set `GRPC_UDS`, e.g. `GRPC_UDS=/<dir>/ratelimit.sock` and leave
 For information on the fields of a Ratelimit gRPC request please read the information
 on the RateLimitRequest message type in the Ratelimit [proto file.](https://github.com/envoyproxy/envoy/blob/master/api/envoy/service/ratelimit/v3/rls.proto)
 
+## Negative hits
+
+Each descriptor entry may set the `is_negative_hits` field. When it is `true`, the descriptor's
+`hits_addend` is subtracted from the rate limit counter instead of being added to it, effectively
+refunding previously consumed capacity.
+
+Negative-hit behavior:
+
+- The counter is floored at `0` and can never go negative. Redis performs the decrement-and-floor
+  atomically via a Lua script; Memcached uses its native `Decrement`, which floors at `0` by default.
+- A negative-hit descriptor always returns `OK`. It bypasses the over-limit and near-limit checks and
+  does not trigger any over-limit side effects (over-limit stats or local-cache poisoning), even when
+  the counter is still above the limit after the decrement.
+- The requested decrement is counted in the `total_negative_hits` statistic (see [Statistics](#statistics-1)).
+
 # GRPC Client
 
 The [gRPC client](https://github.com/envoyproxy/ratelimit/blob/master/src/client_cmd/main.go) will interact with ratelimit server and tell you if the requests are over limit.
@@ -1026,6 +1042,7 @@ STAT:
 - near_limit: Number of rule hits over the NearLimit ratio threshold (currently 80%) but under the threshold rate.
 - over_limit: Number of rule hits exceeding the threshold rate
 - total_hits: Number of rule hits in total
+- total_negative_hits: Number of rule hits requested as negative hits (decrements/refunds via `is_negative_hits`)
 - shadow_mode: Number of rule hits where shadow_mode would trigger and override the over_limit result
 
 To use a custom near_limit ratio threshold, you can specify with `NEAR_LIMIT_RATIO` environment variable. It defaults to `0.8` (0-1 scale). These are examples of generated stats for some configured rate limit rules from the above examples:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874
 	github.com/coocood/freecache v1.2.4
 	github.com/envoyproxy/go-control-plane v0.14.0
-	github.com/envoyproxy/go-control-plane/envoy v1.37.0
+	github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260409083702-98966259b99a
 	github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20260629194254-5581fade6089
 	github.com/go-kit/log v0.2.1
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwBIfQawTkC++2HA=
 github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9ZMkUlwlKxtAohpi2wBEU=
-github.com/envoyproxy/go-control-plane/envoy v1.37.0 h1:u3riX6BoYRfF4Dr7dwSOroNfdSbEPe9Yyl09/B6wBrQ=
-github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
+github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260409083702-98966259b99a h1:qrP4J6AWJ9yd6CINhPMRL/MbFXNiV7qimRsCDTOV0a0=
+github.com/envoyproxy/go-control-plane/envoy v1.37.1-0.20260409083702-98966259b99a/go.mod h1:5yRfenlmRH8sxKrhXyiFtK8BDz3syDWcFm81rkCcATM=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20260629194254-5581fade6089 h1:tft2Nib7aYTUNFyDuYxeERxPIQxGtI1FScjT5RYDMnI=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20260629194254-5581fade6089/go.mod h1:YySqCcozu0HwklKZzeX6N98q+TyqEkgX2sg7DQqiJfU=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=

--- a/src/limiter/base_limiter.go
+++ b/src/limiter/base_limiter.go
@@ -14,6 +14,18 @@ import (
 	"github.com/envoyproxy/ratelimit/src/utils"
 )
 
+// DecrementScript atomically decrements a rate limit counter, floored at 0.
+// If the key does not exist there is nothing to refund, so it returns 0 without
+// creating a phantom key.
+const DecrementScript = `
+local current = redis.call('GET', KEYS[1])                   -- get current count
+if current == false then return 0 end                        -- key absent: nothing to refund
+local new_val = math.floor(math.max(0, tonumber(current) - tonumber(ARGV[1]))) -- subtract hits, floor at 0
+redis.call('SET', KEYS[1], tostring(new_val))                -- persist new value
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))             -- reset TTL
+return new_val                                               -- return count after decrement
+`
+
 type BaseRateLimiter struct {
 	timeSource                 utils.TimeSource
 	JitterRand                 *rand.Rand
@@ -44,7 +56,7 @@ func NewRateLimitInfo(limit *config.RateLimit, limitBeforeIncrease uint64, limit
 // Generates cache keys for given rate limit request. Each cache key is represented by a concatenation of
 // domain, descriptor and current timestamp.
 func (this *BaseRateLimiter) GenerateCacheKeys(request *pb.RateLimitRequest,
-	limits []*config.RateLimit, hitsAddends []uint64,
+	limits []*config.RateLimit, hitsAddends []utils.HitsAddend,
 ) []CacheKey {
 	assert.Assert(len(request.Descriptors) == len(limits))
 	cacheKeys := make([]CacheKey, len(request.Descriptors))
@@ -55,7 +67,11 @@ func (this *BaseRateLimiter) GenerateCacheKeys(request *pb.RateLimitRequest,
 		cacheKeys[i] = this.cacheKeyGenerator.GenerateCacheKey(request.Domain, request.Descriptors[i], limits[i], now)
 		// Increase statistics for limits hit by their respective requests.
 		if limits[i] != nil {
-			limits[i].Stats.TotalHits.Add(hitsAddends[i])
+			if hitsAddends[i].IsNegative {
+				limits[i].Stats.TotalNegativeHits.Add(hitsAddends[i].Value)
+			} else {
+				limits[i].Stats.TotalHits.Add(hitsAddends[i].Value)
+			}
 		}
 	}
 	return cacheKeys
@@ -140,6 +156,28 @@ func (this *BaseRateLimiter) GetResponseDescriptorStatus(key string, limitInfo *
 	}
 
 	return responseDescriptorStatus
+}
+
+// GetResponseDescriptorStatusForNegativeHits generates a response for a negative-hit
+// (decrement/refund) request. Refunds release capacity rather than consuming it, so they
+// always return OK regardless of the counter value and never trigger over-limit side
+// effects (over-limit stats, local-cache poisoning). currentValue is the counter value
+// after the decrement; LimitRemaining is reported as the remaining capacity, clamped at 0
+// in case the counter is still above the limit.
+func (this *BaseRateLimiter) GetResponseDescriptorStatusForNegativeHits(key string, limit *config.RateLimit,
+	currentValue uint64,
+) *pb.RateLimitResponse_DescriptorStatus {
+	if key == "" {
+		return this.generateResponseDescriptorStatus(pb.RateLimitResponse_OK, nil, 0)
+	}
+
+	overLimitThreshold := uint64(limit.Limit.RequestsPerUnit)
+	var limitRemaining uint64
+	if overLimitThreshold > currentValue {
+		limitRemaining = overLimitThreshold - currentValue
+	}
+
+	return this.generateResponseDescriptorStatus(pb.RateLimitResponse_OK, limit.Limit, uint32(limitRemaining))
 }
 
 func NewBaseRateLimit(timeSource utils.TimeSource, jitterRand *rand.Rand, expirationJitterMaxSeconds int64,

--- a/src/memcached/cache_impl.go
+++ b/src/memcached/cache_impl.go
@@ -85,6 +85,12 @@ func (this *rateLimitMemcacheImpl) DoLimit(
 			continue
 		}
 
+		// Negative hits skip the over-limit check — they always proceed.
+		if hitsAddends[i].IsNegative {
+			keysToGet = append(keysToGet, cacheKey.Key)
+			continue
+		}
+
 		// Check if key is over the limit in local cache.
 		if this.baseRateLimiter.IsOverLimitWithLocalCache(cacheKey.Key) {
 			isOverLimitWithLocalCache[i] = true
@@ -130,15 +136,26 @@ func (this *rateLimitMemcacheImpl) DoLimit(
 			} else {
 				limitBeforeIncrease = uint64(decoded)
 			}
-
 		}
 
-		limitAfterIncrease := limitBeforeIncrease + hitsAddends[i]
+		if hitsAddends[i].IsNegative {
+			// Predict the post-decrement value (guard against uint64 underflow).
+			var limitAfterDecrease uint64
+			if limitBeforeIncrease > hitsAddends[i].Value {
+				limitAfterDecrease = limitBeforeIncrease - hitsAddends[i].Value
+			}
+			// Negative hits (refunds) always return OK with the remaining capacity,
+			// even if the post-decrement counter is still above the limit.
+			responseDescriptorStatuses[i] = this.baseRateLimiter.GetResponseDescriptorStatusForNegativeHits(
+				cacheKey.Key, limits[i], limitAfterDecrease)
+		} else {
+			limitAfterIncrease := limitBeforeIncrease + hitsAddends[i].Value
 
-		limitInfo := limiter.NewRateLimitInfo(limits[i], limitBeforeIncrease, limitAfterIncrease, 0, 0)
+			limitInfo := limiter.NewRateLimitInfo(limits[i], limitBeforeIncrease, limitAfterIncrease, 0, 0)
 
-		responseDescriptorStatuses[i] = this.baseRateLimiter.GetResponseDescriptorStatus(cacheKey.Key,
-			limitInfo, isOverLimitWithLocalCache[i], hitsAddends[i])
+			responseDescriptorStatuses[i] = this.baseRateLimiter.GetResponseDescriptorStatus(cacheKey.Key,
+				limitInfo, isOverLimitWithLocalCache[i], hitsAddends[i].Value)
+		}
 	}
 
 	this.waitGroup.Add(1)
@@ -151,7 +168,7 @@ func (this *rateLimitMemcacheImpl) DoLimit(
 }
 
 func (this *rateLimitMemcacheImpl) increaseAsync(cacheKeys []limiter.CacheKey, isOverLimitWithLocalCache []bool,
-	limits []*config.RateLimit, hitsAddends []uint64,
+	limits []*config.RateLimit, hitsAddends []utils.HitsAddend,
 ) {
 	defer this.waitGroup.Done()
 	for i, cacheKey := range cacheKeys {
@@ -159,7 +176,16 @@ func (this *rateLimitMemcacheImpl) increaseAsync(cacheKeys []limiter.CacheKey, i
 			continue
 		}
 
-		_, err := this.client.Increment(cacheKey.Key, hitsAddends[i])
+		if hitsAddends[i].IsNegative {
+			// Memcached Decrement natively floors at 0.
+			_, err := this.client.Decrement(cacheKey.Key, hitsAddends[i].Value)
+			if err != nil && err != memcache.ErrCacheMiss {
+				logger.Errorf("Failed to decrement key %s: %s", cacheKey.Key, err)
+			}
+			continue
+		}
+
+		_, err := this.client.Increment(cacheKey.Key, hitsAddends[i].Value)
 		if err == memcache.ErrCacheMiss {
 			expirationSeconds := utils.UnitToDivider(limits[i].Limit.Unit)
 			if this.expirationJitterMaxSeconds > 0 {
@@ -169,13 +195,13 @@ func (this *rateLimitMemcacheImpl) increaseAsync(cacheKeys []limiter.CacheKey, i
 			// Need to add instead of increment.
 			err = this.client.Add(&memcache.Item{
 				Key:        cacheKey.Key,
-				Value:      []byte(strconv.FormatUint(hitsAddends[i], 10)),
+				Value:      []byte(strconv.FormatUint(hitsAddends[i].Value, 10)),
 				Expiration: int32(expirationSeconds),
 			})
 			if err == memcache.ErrNotStored {
 				// There was a race condition to do this add. We should be able to increment
 				// now instead.
-				_, err := this.client.Increment(cacheKey.Key, hitsAddends[i])
+				_, err := this.client.Increment(cacheKey.Key, hitsAddends[i].Value)
 				if err != nil {
 					logger.Errorf("Failed to increment key %s after failing to add: %s", cacheKey.Key, err)
 					continue

--- a/src/memcached/client.go
+++ b/src/memcached/client.go
@@ -17,5 +17,6 @@ var _ Client = (*memcache.Client)(nil)
 type Client interface {
 	GetMulti(keys []string) (map[string]*memcache.Item, error)
 	Increment(key string, delta uint64) (newValue uint64, err error)
+	Decrement(key string, delta uint64) (newValue uint64, err error)
 	Add(item *memcache.Item) error
 }

--- a/src/memcached/stats_collecting_client.go
+++ b/src/memcached/stats_collecting_client.go
@@ -13,6 +13,9 @@ type statsCollectingClient struct {
 	incrementSuccess stats.Counter
 	incrementMiss    stats.Counter
 	incrementError   stats.Counter
+	decrementSuccess stats.Counter
+	decrementMiss    stats.Counter
+	decrementError   stats.Counter
 	addSuccess       stats.Counter
 	addError         stats.Counter
 	addNotStored     stats.Counter
@@ -28,6 +31,9 @@ func CollectStats(c Client, scope stats.Scope) Client {
 		incrementSuccess: scope.NewCounterWithTags("increment", map[string]string{"code": "success"}),
 		incrementMiss:    scope.NewCounterWithTags("increment", map[string]string{"code": "miss"}),
 		incrementError:   scope.NewCounterWithTags("increment", map[string]string{"code": "error"}),
+		decrementSuccess: scope.NewCounterWithTags("decrement", map[string]string{"code": "success"}),
+		decrementMiss:    scope.NewCounterWithTags("decrement", map[string]string{"code": "miss"}),
+		decrementError:   scope.NewCounterWithTags("decrement", map[string]string{"code": "error"}),
 		addSuccess:       scope.NewCounterWithTags("add", map[string]string{"code": "success"}),
 		addError:         scope.NewCounterWithTags("add", map[string]string{"code": "error"}),
 		addNotStored:     scope.NewCounterWithTags("add", map[string]string{"code": "not_stored"}),
@@ -60,6 +66,19 @@ func (scc statsCollectingClient) Increment(key string, delta uint64) (newValue u
 		scc.incrementSuccess.Inc()
 	default:
 		scc.incrementError.Inc()
+	}
+	return
+}
+
+func (scc statsCollectingClient) Decrement(key string, delta uint64) (newValue uint64, err error) {
+	newValue, err = scc.c.Decrement(key, delta)
+	switch err {
+	case memcache.ErrCacheMiss:
+		scc.decrementMiss.Inc()
+	case nil:
+		scc.decrementSuccess.Inc()
+	default:
+		scc.decrementError.Inc()
 	}
 	return
 }

--- a/src/redis/driver.go
+++ b/src/redis/driver.go
@@ -32,6 +32,21 @@ type Client interface {
 	// @param args supplies the additional arguments.
 	PipeAppend(pipeline Pipeline, rcv interface{}, cmd, key string, args ...interface{}) Pipeline
 
+	// PipeAppendWithRoutingKey appends a command onto the pipeline queue whose
+	// Redis key differs from the command's first positional argument. This is
+	// needed for commands like EVAL, where the first argument is the script body
+	// and the actual key appears later in the argument list. In Redis Cluster
+	// mode the routing key determines which slot/node the command is sent to, so
+	// it must be the real key rather than the script text.
+	//
+	// @param pipeline supplies the queue for pending commands.
+	// @param routingKey supplies the key used for cluster slot routing/grouping.
+	// @param rcv supplies receiver for the result.
+	// @param cmd supplies the command to append.
+	// @param key supplies the first positional argument of the command.
+	// @param args supplies the additional arguments.
+	PipeAppendWithRoutingKey(pipeline Pipeline, routingKey string, rcv interface{}, cmd, key string, args ...interface{}) Pipeline
+
 	// PipeDo writes multiple commands to a Conn in
 	// a single write, then reads their responses in a single read. This reduces
 	// network delay into a single round-trip.

--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -353,13 +353,17 @@ func (c *clientImpl) NumActiveConns() int {
 }
 
 func (c *clientImpl) PipeAppend(pipeline Pipeline, rcv interface{}, cmd, key string, args ...interface{}) Pipeline {
+	return c.PipeAppendWithRoutingKey(pipeline, key, rcv, cmd, key, args...)
+}
+
+func (c *clientImpl) PipeAppendWithRoutingKey(pipeline Pipeline, routingKey string, rcv interface{}, cmd, key string, args ...interface{}) Pipeline {
 	// Combine key and args into a single slice
 	allArgs := make([]interface{}, 0, 1+len(args))
 	allArgs = append(allArgs, key)
 	allArgs = append(allArgs, args...)
 	return append(pipeline, PipelineAction{
 		Action: radix.FlatCmd(rcv, cmd, allArgs...),
-		Key:    key,
+		Key:    routingKey,
 	})
 }
 

--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -37,11 +37,32 @@ func pipelineAppend(client Client, pipeline *Pipeline, key string, hitsAddend ui
 	*pipeline = client.PipeAppend(*pipeline, nil, "EXPIRE", key, expirationSeconds)
 }
 
+func pipelineAppendDecrement(client Client, pipeline *Pipeline, key string, hitsAddend uint64, result *uint64, expirationSeconds int64) {
+	// EVAL's first positional argument is the script body, not the key, so the
+	// real cache key must be passed explicitly as the routing key. Otherwise, in
+	// Redis Cluster mode the command would be routed using the script text,
+	// causing MOVED/CROSSSLOT errors or misrouting.
+	*pipeline = client.PipeAppendWithRoutingKey(*pipeline, key, result, "EVAL", limiter.DecrementScript, 1, key, hitsAddend, expirationSeconds)
+}
+
+func (this *fixedRateLimitCacheImpl) selectPipeline(cacheKey limiter.CacheKey, pipeline *Pipeline, perSecondPipeline *Pipeline) (Client, *Pipeline) {
+	if this.perSecondClient != nil && cacheKey.PerSecond {
+		if *perSecondPipeline == nil {
+			*perSecondPipeline = Pipeline{}
+		}
+		return this.perSecondClient, perSecondPipeline
+	}
+	if *pipeline == nil {
+		*pipeline = Pipeline{}
+	}
+	return this.client, pipeline
+}
+
 func pipelineAppendtoGet(client Client, pipeline *Pipeline, key string, result *uint64) {
 	*pipeline = client.PipeAppend(*pipeline, result, "GET", key)
 }
 
-func (this *fixedRateLimitCacheImpl) getHitsAddend(hitsAddend uint64, isCacheKeyOverlimit, isCacheKeyNearlimit,
+func (this *fixedRateLimitCacheImpl) getHitsAddendValue(hitsAddend uint64, isCacheKeyOverlimit, isCacheKeyNearlimit,
 	isNearLimit bool,
 ) uint64 {
 	// If stopCacheKeyIncrementWhenOverlimit is false, then we always increment the cache key.
@@ -94,8 +115,9 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 	isCacheKeyNearlimit := false
 
 	// Check if any of the keys are already to the over limit in cache.
+	// Negative hits (decrements) skip this check — they always proceed.
 	for i, cacheKey := range cacheKeys {
-		if cacheKey.Key == "" {
+		if cacheKey.Key == "" || hitsAddends[i].IsNegative {
 			continue
 		}
 
@@ -116,7 +138,7 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 	// then we check if any of the keys are near limit in redis cache.
 	if this.stopCacheKeyIncrementWhenOverlimit && !isCacheKeyOverlimit {
 		for i, cacheKey := range cacheKeys {
-			if cacheKey.Key == "" {
+			if cacheKey.Key == "" || hitsAddends[i].IsNegative {
 				continue
 			}
 
@@ -141,12 +163,12 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 		}
 
 		for i, cacheKey := range cacheKeys {
-			if cacheKey.Key == "" {
+			if cacheKey.Key == "" || hitsAddends[i].IsNegative {
 				continue
 			}
 			// Now fetch the pipeline.
 			limitBeforeIncrease := currentCount[i]
-			limitAfterIncrease := limitBeforeIncrease + hitsAddends[i]
+			limitAfterIncrease := limitBeforeIncrease + hitsAddends[i].Value
 
 			limitInfo := limiter.NewRateLimitInfo(limits[i], limitBeforeIncrease, limitAfterIncrease, 0, 0)
 
@@ -157,7 +179,7 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 		}
 	}
 
-	// Now, actually setup the pipeline to increase the usage of cache key, skipping empty cache keys.
+	// Now, actually setup the pipeline to increase/decrease the usage of cache key, skipping empty cache keys.
 	for i, cacheKey := range cacheKeys {
 		if cacheKey.Key == "" || overlimitIndexes[i] {
 			continue
@@ -170,19 +192,12 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 			expirationSeconds += this.baseRateLimiter.JitterRand.Int63n(this.baseRateLimiter.ExpirationJitterMaxSeconds)
 		}
 
-		// Use the perSecondConn if it is not nil and the cacheKey represents a per second Limit.
-		if this.perSecondClient != nil && cacheKey.PerSecond {
-			if perSecondPipeline == nil {
-				perSecondPipeline = Pipeline{}
-			}
-			pipelineAppend(this.perSecondClient, &perSecondPipeline, cacheKey.Key, this.getHitsAddend(hitsAddends[i],
-				isCacheKeyOverlimit, isCacheKeyNearlimit, nearlimitIndexes[i]), &results[i], expirationSeconds)
+		client, p := this.selectPipeline(cacheKey, &pipeline, &perSecondPipeline)
+		if hitsAddends[i].IsNegative {
+			pipelineAppendDecrement(client, p, cacheKey.Key, hitsAddends[i].Value, &results[i], expirationSeconds)
 		} else {
-			if pipeline == nil {
-				pipeline = Pipeline{}
-			}
-			pipelineAppend(this.client, &pipeline, cacheKey.Key, this.getHitsAddend(hitsAddends[i], isCacheKeyOverlimit,
-				isCacheKeyNearlimit, nearlimitIndexes[i]), &results[i], expirationSeconds)
+			pipelineAppend(client, p, cacheKey.Key, this.getHitsAddendValue(hitsAddends[i].Value,
+				isCacheKeyOverlimit, isCacheKeyNearlimit, nearlimitIndexes[i]), &results[i], expirationSeconds)
 		}
 	}
 
@@ -207,14 +222,20 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 	responseDescriptorStatuses := make([]*pb.RateLimitResponse_DescriptorStatus,
 		len(request.Descriptors))
 	for i, cacheKey := range cacheKeys {
+		if hitsAddends[i].IsNegative {
+			// Negative hits (refunds) always return OK with the remaining capacity,
+			// even if the post-decrement counter is still above the limit.
+			responseDescriptorStatuses[i] = this.baseRateLimiter.GetResponseDescriptorStatusForNegativeHits(
+				cacheKey.Key, limits[i], results[i])
+		} else {
+			limitAfterIncrease := results[i]
+			limitBeforeIncrease := limitAfterIncrease - hitsAddends[i].Value
 
-		limitAfterIncrease := results[i]
-		limitBeforeIncrease := limitAfterIncrease - hitsAddends[i]
+			limitInfo := limiter.NewRateLimitInfo(limits[i], limitBeforeIncrease, limitAfterIncrease, 0, 0)
 
-		limitInfo := limiter.NewRateLimitInfo(limits[i], limitBeforeIncrease, limitAfterIncrease, 0, 0)
-
-		responseDescriptorStatuses[i] = this.baseRateLimiter.GetResponseDescriptorStatus(cacheKey.Key,
-			limitInfo, isOverLimitWithLocalCache[i], hitsAddends[i])
+			responseDescriptorStatuses[i] = this.baseRateLimiter.GetResponseDescriptorStatus(cacheKey.Key,
+				limitInfo, isOverLimitWithLocalCache[i], hitsAddends[i].Value)
+		}
 	}
 
 	return responseDescriptorStatuses

--- a/src/stats/manager.go
+++ b/src/stats/manager.go
@@ -54,6 +54,7 @@ type RateLimitStats struct {
 	OverLimitWithLocalCache gostats.Counter
 	WithinLimit             gostats.Counter
 	ShadowMode              gostats.Counter
+	TotalNegativeHits       gostats.Counter
 }
 
 // Stats for a domain entry

--- a/src/stats/manager_impl.go
+++ b/src/stats/manager_impl.go
@@ -36,6 +36,7 @@ func (this *ManagerImpl) NewStats(key string) RateLimitStats {
 	ret.OverLimitWithLocalCache = this.rlStatsScope.NewCounter(key + ".over_limit_with_local_cache")
 	ret.WithinLimit = this.rlStatsScope.NewCounter(key + ".within_limit")
 	ret.ShadowMode = this.rlStatsScope.NewCounter(key + ".shadow_mode")
+	ret.TotalNegativeHits = this.rlStatsScope.NewCounter(key + ".total_negative_hits")
 	return ret
 }
 

--- a/src/utils/utilities.go
+++ b/src/utils/utilities.go
@@ -72,19 +72,25 @@ func SanitizeStatName(s string) string {
 	})
 }
 
-func GetHitsAddends(request *pb.RateLimitRequest) []uint64 {
-	hitsAddends := make([]uint64, len(request.Descriptors))
+type HitsAddend struct {
+	Value      uint64
+	IsNegative bool
+}
+
+func GetHitsAddends(request *pb.RateLimitRequest) []HitsAddend {
+	hitsAddends := make([]HitsAddend, len(request.Descriptors))
 
 	for i, descriptor := range request.Descriptors {
 		if descriptor.HitsAddend != nil {
 			// If the per descriptor hits_addend is set, use that. It allows to be zero. The zero value is
 			// means check only by no increment the hits.
-			hitsAddends[i] = descriptor.HitsAddend.Value
+			hitsAddends[i].Value = descriptor.HitsAddend.Value
 		} else {
 			// If the per descriptor hits_addend is not set, use the request's hits_addend. If the value is
 			// zero (default value if not specified by the caller), use 1 for backward compatibility.
-			hitsAddends[i] = uint64(max(1, uint64(request.HitsAddend)))
+			hitsAddends[i].Value = uint64(max(1, uint64(request.HitsAddend)))
 		}
+		hitsAddends[i].IsNegative = descriptor.GetIsNegativeHits()
 	}
 	return hitsAddends
 }

--- a/test/common/common.go
+++ b/test/common/common.go
@@ -83,6 +83,17 @@ func NewRateLimitRequestWithPerDescriptorHitsAddend(domain string, descriptors [
 	return request
 }
 
+func NewRateLimitRequestWithNegativeHits(domain string, descriptors [][][2]string,
+	hitsAddends []uint64, negativeFlags []bool,
+) *pb.RateLimitRequest {
+	request := NewRateLimitRequest(domain, descriptors, 1)
+	for i, hitsAddend := range hitsAddends {
+		request.Descriptors[i].HitsAddend = &wrapperspb.UInt64Value{Value: hitsAddend}
+		request.Descriptors[i].IsNegativeHits = negativeFlags[i]
+	}
+	return request
+}
+
 func AssertProtoEqual(assert *assert.Assertions, expected proto.Message, actual proto.Message) {
 	assert.True(proto.Equal(expected, actual),
 		fmt.Sprintf("These two protobuf messages are not equal:\nexpected: %v\nactual:  %v", expected, actual))

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -89,6 +89,52 @@ func makeSimpleRedisSettingsWithStopCacheKeyIncrementWhenOverlimit(redisPort int
 	return s
 }
 
+func TestNegativeHitsIntegration(t *testing.T) {
+	common.WithMultiRedis(t, []common.RedisConfig{
+		{Port: 6383},
+	}, func() {
+		t.Run("Redis", testNegativeHits(makeSimpleRedisSettings(6383, 6380, false, 0)))
+	})
+}
+
+func testNegativeHits(s settings.Settings) func(*testing.T) {
+	return func(t *testing.T) {
+		runner := startTestRunner(t, s)
+		defer runner.Stop()
+
+		assert := assert.New(t)
+		conn, err := grpc.Dial(fmt.Sprintf("localhost:%v", s.GrpcPort), grpc.WithInsecure())
+		assert.NoError(err)
+		defer conn.Close()
+		c := pb.NewRateLimitServiceClient(conn)
+
+		// Consume 5 hits from a limit of 50/second.
+		response, err := c.ShouldRateLimit(
+			context.Background(),
+			common.NewRateLimitRequest("basic", [][][2]string{{{"key1", "foo"}}}, 5))
+		assert.NoError(err)
+		assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+		assert.Equal(uint32(45), response.Statuses[0].LimitRemaining)
+
+		// Now send a negative hits request to refill 3 tokens.
+		response, err = c.ShouldRateLimit(
+			context.Background(),
+			common.NewRateLimitRequestWithNegativeHits("basic", [][][2]string{{{"key1", "foo"}}}, []uint64{3}, []bool{true}))
+		assert.NoError(err)
+		assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+		// Counter was 5, decremented by 3 = 2. Remaining = 50 - 2 = 48.
+		assert.Equal(uint32(48), response.Statuses[0].LimitRemaining)
+
+		// Verify by consuming 1 more hit - remaining should be 47.
+		response, err = c.ShouldRateLimit(
+			context.Background(),
+			common.NewRateLimitRequest("basic", [][][2]string{{{"key1", "foo"}}}, 1))
+		assert.NoError(err)
+		assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+		assert.Equal(uint32(47), response.Statuses[0].LimitRemaining)
+	}
+}
+
 func TestBasicConfig(t *testing.T) {
 	common.WithMultiRedis(t, []common.RedisConfig{
 		{Port: 6383},

--- a/test/limiter/base_limiter_test.go
+++ b/test/limiter/base_limiter_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/envoyproxy/ratelimit/src/config"
 	"github.com/envoyproxy/ratelimit/src/limiter"
+	"github.com/envoyproxy/ratelimit/src/utils"
 	"github.com/envoyproxy/ratelimit/test/common"
 	mock_utils "github.com/envoyproxy/ratelimit/test/mocks/utils"
 )
@@ -31,10 +32,34 @@ func TestGenerateCacheKeys(t *testing.T) {
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
 	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
-	cacheKeys := baseRateLimit.GenerateCacheKeys(request, limits, []uint64{1})
+	cacheKeys := baseRateLimit.GenerateCacheKeys(request, limits, []utils.HitsAddend{{Value: 1}})
 	assert.Equal(1, len(cacheKeys))
 	assert.Equal("domain_key_value_1234", cacheKeys[0].Key)
 	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
+}
+
+func TestGenerateCacheKeysNegativeHits(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	jitterSource := mock_utils.NewMockJitterRandSource(controller)
+	statsStore := stats.NewStore(stats.NewNullSink(), false)
+	sm := mockstats.NewMockStatManager(statsStore)
+	timeSource.EXPECT().UnixNow().Return(int64(1234))
+	baseRateLimit := limiter.NewBaseRateLimit(timeSource, rand.New(jitterSource), 3600, nil, 0.8, "", sm)
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(0), limits[0].Stats.TotalNegativeHits.Value())
+
+	cacheKeys := baseRateLimit.GenerateCacheKeys(request, limits, []utils.HitsAddend{{Value: 3, IsNegative: true}})
+	assert.Equal(1, len(cacheKeys))
+	assert.Equal("domain_key_value_1234", cacheKeys[0].Key)
+	// TotalHits should NOT be incremented for negative hits.
+	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
+	// TotalNegativeHits should be incremented.
+	assert.Equal(uint64(3), limits[0].Stats.TotalNegativeHits.Value())
 }
 
 func TestGenerateCacheKeysPrefix(t *testing.T) {
@@ -50,7 +75,7 @@ func TestGenerateCacheKeysPrefix(t *testing.T) {
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
 	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
-	cacheKeys := baseRateLimit.GenerateCacheKeys(request, limits, []uint64{1})
+	cacheKeys := baseRateLimit.GenerateCacheKeys(request, limits, []utils.HitsAddend{{Value: 1}})
 	assert.Equal(1, len(cacheKeys))
 	assert.Equal("prefix:domain_key_value_1234", cacheKeys[0].Key)
 	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
@@ -73,13 +98,13 @@ func TestGenerateCacheKeysWithShareThreshold(t *testing.T) {
 
 	request1 := common.NewRateLimitRequest("domain", [][][2]string{{{"files", "files/a.pdf"}}}, 1)
 	limits1 := []*config.RateLimit{limit}
-	cacheKeys1 := baseRateLimit.GenerateCacheKeys(request1, limits1, []uint64{1})
+	cacheKeys1 := baseRateLimit.GenerateCacheKeys(request1, limits1, []utils.HitsAddend{{Value: 1}})
 	assert.Equal(1, len(cacheKeys1))
 	assert.Equal("domain_files_files/*_1234", cacheKeys1[0].Key)
 
 	request2 := common.NewRateLimitRequest("domain", [][][2]string{{{"files", "files/b.csv"}}}, 1)
 	limits2 := []*config.RateLimit{limit}
-	cacheKeys2 := baseRateLimit.GenerateCacheKeys(request2, limits2, []uint64{1})
+	cacheKeys2 := baseRateLimit.GenerateCacheKeys(request2, limits2, []utils.HitsAddend{{Value: 1}})
 	assert.Equal(1, len(cacheKeys2))
 	// Should generate the same cache key as the first request
 	assert.Equal("domain_files_files/*_1234", cacheKeys2[0].Key)
@@ -89,7 +114,7 @@ func TestGenerateCacheKeysWithShareThreshold(t *testing.T) {
 	testValues := []string{"files/c.txt", "files/d.json", "files/e.xml", "files/subdir/f.txt"}
 	for _, value := range testValues {
 		request := common.NewRateLimitRequest("domain", [][][2]string{{{"files", value}}}, 1)
-		cacheKeys := baseRateLimit.GenerateCacheKeys(request, limits1, []uint64{1})
+		cacheKeys := baseRateLimit.GenerateCacheKeys(request, limits1, []utils.HitsAddend{{Value: 1}})
 		assert.Equal(1, len(cacheKeys))
 		assert.Equal("domain_files_files/*_1234", cacheKeys[0].Key, "Value %s should generate same cache key", value)
 	}
@@ -102,14 +127,14 @@ func TestGenerateCacheKeysWithShareThreshold(t *testing.T) {
 		{{"parent", "value1"}, {"files", "nested/file1.txt"}},
 	}, 1)
 	limits3a := []*config.RateLimit{limitNested}
-	cacheKeys3a := baseRateLimit.GenerateCacheKeys(request3a, limits3a, []uint64{1})
+	cacheKeys3a := baseRateLimit.GenerateCacheKeys(request3a, limits3a, []utils.HitsAddend{{Value: 1}})
 	assert.Equal(1, len(cacheKeys3a))
 	assert.Equal("domain_parent_value1_files_nested/*_1234", cacheKeys3a[0].Key)
 
 	request3b := common.NewRateLimitRequest("domain", [][][2]string{
 		{{"parent", "value1"}, {"files", "nested/file2.csv"}},
 	}, 1)
-	cacheKeys3b := baseRateLimit.GenerateCacheKeys(request3b, limits3a, []uint64{1})
+	cacheKeys3b := baseRateLimit.GenerateCacheKeys(request3b, limits3a, []utils.HitsAddend{{Value: 1}})
 	assert.Equal(1, len(cacheKeys3b))
 	// Should generate the same cache key despite different file values
 	assert.Equal("domain_parent_value1_files_nested/*_1234", cacheKeys3b[0].Key)
@@ -123,14 +148,14 @@ func TestGenerateCacheKeysWithShareThreshold(t *testing.T) {
 		{{"files", "top/file1.txt"}, {"files", "nested/sub1.txt"}},
 	}, 1)
 	limits4a := []*config.RateLimit{limitMulti}
-	cacheKeys4a := baseRateLimit.GenerateCacheKeys(request4a, limits4a, []uint64{1})
+	cacheKeys4a := baseRateLimit.GenerateCacheKeys(request4a, limits4a, []utils.HitsAddend{{Value: 1}})
 	assert.Equal(1, len(cacheKeys4a))
 	assert.Equal("domain_files_top/*_files_nested/*_1234", cacheKeys4a[0].Key)
 
 	request4b := common.NewRateLimitRequest("domain", [][][2]string{
 		{{"files", "top/file2.pdf"}, {"files", "nested/sub2.csv"}},
 	}, 1)
-	cacheKeys4b := baseRateLimit.GenerateCacheKeys(request4b, limits4a, []uint64{1})
+	cacheKeys4b := baseRateLimit.GenerateCacheKeys(request4b, limits4a, []utils.HitsAddend{{Value: 1}})
 	assert.Equal(1, len(cacheKeys4b))
 	// Should generate the same cache key despite different values
 	assert.Equal("domain_files_top/*_files_nested/*_1234", cacheKeys4b[0].Key)

--- a/test/memcached/cache_impl_test.go
+++ b/test/memcached/cache_impl_test.go
@@ -695,3 +695,135 @@ func getMultiResult(vals map[string]int) map[string]*memcache.Item {
 	}
 	return result
 }
+
+func TestMemcachedNegativeHits(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	client := mock_memcached.NewMockClient(controller)
+	statsStore := stats.NewStore(stats.NewNullSink(), false)
+	sm := mockstats.NewMockStatManager(statsStore)
+	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, sm, 0.8, "")
+
+	// Counter at 7, requesting -3. Memcached Decrement floors at 0 natively.
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().GetMulti([]string{"domain_key_value_1234"}).Return(
+		getMultiResult(map[string]int{"domain_key_value_1234": 7}), nil,
+	)
+	client.EXPECT().Decrement("domain_key_value_1234", uint64(3)).Return(uint64(4), nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{3}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	cache.Flush()
+
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(6), uint64(result[0].LimitRemaining))
+	assert.Equal(limits[0].Limit, result[0].CurrentLimit)
+	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(3), limits[0].Stats.TotalNegativeHits.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+}
+
+func TestMemcachedNegativeHitsFloorAtZero(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	client := mock_memcached.NewMockClient(controller)
+	statsStore := stats.NewStore(stats.NewNullSink(), false)
+	sm := mockstats.NewMockStatManager(statsStore)
+	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, sm, 0.8, "")
+
+	// Counter at 2, requesting -5. Floor at 0.
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().GetMulti([]string{"domain_key_value_1234"}).Return(
+		getMultiResult(map[string]int{"domain_key_value_1234": 2}), nil,
+	)
+	client.EXPECT().Decrement("domain_key_value_1234", uint64(5)).Return(uint64(0), nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{5}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	cache.Flush()
+
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(10), uint64(result[0].LimitRemaining))
+	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(5), limits[0].Stats.TotalNegativeHits.Value())
+}
+
+// TestMemcachedNegativeHitsStillOverLimitReturnsOK verifies that when the
+// predicted post-decrement value is still above the limit, the refund still
+// returns OK with LimitRemaining clamped at 0 and records no over-limit stats.
+func TestMemcachedNegativeHitsStillOverLimitReturnsOK(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	client := mock_memcached.NewMockClient(controller)
+	statsStore := stats.NewStore(stats.NewNullSink(), false)
+	sm := mockstats.NewMockStatManager(statsStore)
+	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, nil, sm, 0.8, "")
+
+	// Counter at 15, requesting -3. Predicted post-decrement value is 12, still above the limit of 10.
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().GetMulti([]string{"domain_key_value_1234"}).Return(
+		getMultiResult(map[string]int{"domain_key_value_1234": 15}), nil,
+	)
+	client.EXPECT().Decrement("domain_key_value_1234", uint64(3)).Return(uint64(12), nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{3}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	cache.Flush()
+
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(0), uint64(result[0].LimitRemaining))
+	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(3), limits[0].Stats.TotalNegativeHits.Value())
+}
+
+func TestMemcachedNegativeHitsSkipsOverLimitCheck(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	client := mock_memcached.NewMockClient(controller)
+	statsStore := stats.NewStore(stats.NewNullSink(), false)
+	sm := mockstats.NewMockStatManager(statsStore)
+	localCache := freecache.NewCache(100)
+	cache := memcached.NewRateLimitCacheImpl(client, timeSource, nil, 0, localCache, sm, 0.8, "")
+
+	// Set the key as over-limit in local cache.
+	localCache.Set([]byte("domain_key_value_1234"), []byte{}, 60)
+
+	// Negative hits should still proceed despite key being in over-limit local cache.
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().GetMulti([]string{"domain_key_value_1234"}).Return(
+		getMultiResult(map[string]int{"domain_key_value_1234": 10}), nil,
+	)
+	client.EXPECT().Decrement("domain_key_value_1234", uint64(2)).Return(uint64(8), nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{2}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	cache.Flush()
+
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimitWithLocalCache.Value())
+}

--- a/test/mocks/memcached/client.go
+++ b/test/mocks/memcached/client.go
@@ -77,3 +77,18 @@ func (mr *MockClientMockRecorder) Increment(arg0, arg1 interface{}) *gomock.Call
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Increment", reflect.TypeOf((*MockClient)(nil).Increment), arg0, arg1)
 }
+
+// Decrement mocks base method
+func (m *MockClient) Decrement(arg0 string, arg1 uint64) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Decrement", arg0, arg1)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Decrement indicates an expected call of Decrement
+func (mr *MockClientMockRecorder) Decrement(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Decrement", reflect.TypeOf((*MockClient)(nil).Decrement), arg0, arg1)
+}

--- a/test/mocks/redis/redis.go
+++ b/test/mocks/redis/redis.go
@@ -102,6 +102,25 @@ func (mr *MockClientMockRecorder) PipeAppend(arg0, arg1, arg2, arg3 interface{},
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PipeAppend", reflect.TypeOf((*MockClient)(nil).PipeAppend), varargs...)
 }
 
+// PipeAppendWithRoutingKey mocks base method
+func (m *MockClient) PipeAppendWithRoutingKey(arg0 redis.Pipeline, arg1 string, arg2 interface{}, arg3, arg4 string, arg5 ...interface{}) redis.Pipeline {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2, arg3, arg4}
+	for _, a := range arg5 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "PipeAppendWithRoutingKey", varargs...)
+	ret0, _ := ret[0].(redis.Pipeline)
+	return ret0
+}
+
+// PipeAppendWithRoutingKey indicates an expected call of PipeAppendWithRoutingKey
+func (mr *MockClientMockRecorder) PipeAppendWithRoutingKey(arg0, arg1, arg2, arg3, arg4 interface{}, arg5 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2, arg3, arg4}, arg5...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PipeAppendWithRoutingKey", reflect.TypeOf((*MockClient)(nil).PipeAppendWithRoutingKey), varargs...)
+}
+
 // PipeDo mocks base method
 func (m *MockClient) PipeDo(arg0 context.Context, arg1 redis.Pipeline) error {
 	m.ctrl.T.Helper()

--- a/test/mocks/stats/manager.go
+++ b/test/mocks/stats/manager.go
@@ -44,6 +44,7 @@ func (m *MockStatManager) NewStats(key string) stats.RateLimitStats {
 	ret.OverLimitWithLocalCache = m.store.NewCounter(key + ".over_limit_with_local_cache")
 	ret.WithinLimit = m.store.NewCounter(key + ".within_limit")
 	ret.ShadowMode = m.store.NewCounter(key + ".shadow_mode")
+	ret.TotalNegativeHits = m.store.NewCounter(key + ".total_negative_hits")
 
 	return ret
 }

--- a/test/redis/fixed_cache_impl_test.go
+++ b/test/redis/fixed_cache_impl_test.go
@@ -29,6 +29,154 @@ import (
 
 var testSpanExporter = trace.GetTestSpanExporter()
 
+func TestNegativeHits(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+
+	client := mock_redis.NewMockClient(controller)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false)
+
+	// Decrement from a counter at 5, requesting -3. Lua returns 2 (5-3=2).
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", limiter.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1)).SetArg(2, uint64(2)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{3}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(8), uint64(result[0].LimitRemaining))
+	assert.Equal(limits[0].Limit, result[0].CurrentLimit)
+	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(3), limits[0].Stats.TotalNegativeHits.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+}
+
+func TestNegativeHitsFloorAtZero(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+
+	client := mock_redis.NewMockClient(controller)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false)
+
+	// Counter at 2, requesting -5. Lua floors at 0 and returns 0.
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", limiter.DecrementScript, 1, "domain_key_value_1234", uint64(5), int64(1)).SetArg(2, uint64(0)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{5}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(10), uint64(result[0].LimitRemaining))
+	assert.Equal(uint64(0), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(5), limits[0].Stats.TotalNegativeHits.Value())
+}
+
+func TestNegativeHitsSkipsOverLimitCheck(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+
+	client := mock_redis.NewMockClient(controller)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	localCache := freecache.NewCache(100)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, localCache, 0.8, "", sm, false)
+
+	// Set the key as over-limit in local cache.
+	localCache.Set([]byte("domain_key_value_1234"), []byte{}, 60)
+
+	// Even though the key is in the over-limit local cache, negative hits should still proceed.
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", limiter.DecrementScript, 1, "domain_key_value_1234", uint64(2), int64(1)).SetArg(2, uint64(8)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{2}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(2), uint64(result[0].LimitRemaining))
+	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(0), limits[0].Stats.OverLimitWithLocalCache.Value())
+}
+
+// TestNegativeHitsStillOverLimitReturnsOK verifies that when the post-decrement
+// counter is still above the limit, a negative hit (refund) still returns OK and
+// does not record any over-limit stats. LimitRemaining is clamped at 0.
+func TestNegativeHitsStillOverLimitReturnsOK(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+
+	client := mock_redis.NewMockClient(controller)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false)
+
+	// Counter at 15, requesting -3. Lua returns 12, which is still above the limit of 10.
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", limiter.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1)).SetArg(2, uint64(12)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{3}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(0), uint64(result[0].LimitRemaining))
+	assert.Equal(uint64(0), limits[0].Stats.OverLimit.Value())
+	assert.Equal(uint64(3), limits[0].Stats.TotalNegativeHits.Value())
+}
+
+// TestNegativeHitsWithStopCacheKeyIncrementWhenOverlimit verifies that negative hits
+// behave correctly (always decrement, always return OK) when the cache is configured
+// with stopCacheKeyIncrementWhenOverlimit=true. Negative hits must skip the near-limit
+// GET pre-check entirely and never be suppressed.
+func TestNegativeHitsWithStopCacheKeyIncrementWhenOverlimit(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+
+	client := mock_redis.NewMockClient(controller)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, true)
+
+	// Counter at 5, requesting -3. Lua returns 2. No GET pre-check should be issued for
+	// the negative hit, only the EVAL decrement.
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", limiter.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1)).SetArg(2, uint64(2)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{3}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(8), uint64(result[0].LimitRemaining))
+	assert.Equal(uint64(3), limits[0].Stats.TotalNegativeHits.Value())
+}
+
 func TestRedis(t *testing.T) {
 	t.Run("WithoutPerSecondRedis", testRedis(false))
 	t.Run("WithPerSecondRedis", testRedis(true))
@@ -38,6 +186,13 @@ func pipeAppend(pipeline redis.Pipeline, rcv interface{}, cmd, key string, args 
 	return append(pipeline, redis.PipelineAction{
 		Action: radix.FlatCmd(rcv, cmd, append([]interface{}{key}, args...)...),
 		Key:    key,
+	})
+}
+
+func pipeAppendWithRoutingKey(pipeline redis.Pipeline, routingKey string, rcv interface{}, cmd, key string, args ...interface{}) redis.Pipeline {
+	return append(pipeline, redis.PipelineAction{
+		Action: radix.FlatCmd(rcv, cmd, append([]interface{}{key}, args...)...),
+		Key:    routingKey,
 	})
 }
 


### PR DESCRIPTION
## Summary

Add support for the `is_negative_hits` field on rate limit descriptors. When set, the
hits_addend value decrements the rate limit counter instead of incrementing it, effectively
refilling previously consumed tokens. The counter is floored at 0 (cannot go negative).

- Upgrade go-control-plane/envoy to v1.37.1 (adds IsNegativeHits proto field)
- Redis: uses an atomic Lua script (EVAL) to decrement and floor at 0 in a single operation
- Memcached: uses native Decrement which floors at 0 by default
- Negative hits bypass over-limit and near-limit checks (always return OK)
- New `total_negative_hits` stat tracks requested decrements per descriptor

Fixes https://github.com/envoyproxy/envoy/issues/41219