### PR TITLE
Add quota mode to rate limit descriptor proto

### DIFF
--- a/api/ratelimit/config/ratelimit/v3/rls_conf.proto
+++ b/api/ratelimit/config/ratelimit/v3/rls_conf.proto
@@ -45,6 +45,10 @@ message RateLimitDescriptor {
 
   // Setting the `detailed_metric: true` for a descriptor will extend the metrics that are produced.
   bool detailed_metric = 6;
+
+  // Mark the descriptor as quota mode. When quota_mode is true, the rate limit service will allow
+  // requests unless all quota descriptors are over the limit.
+  bool quota_mode = 7;
 }
 
 // Rate-limit policy.

--- a/api/ratelimit/config/ratelimit/v3/rls_conf.proto
+++ b/api/ratelimit/config/ratelimit/v3/rls_conf.proto
@@ -47,7 +47,7 @@ message RateLimitDescriptor {
   bool detailed_metric = 6;
 
   // Mark the descriptor as quota mode. When quota_mode is true, the rate limit service will allow
-  // requests unless all quota descriptors are over the limit.
+  // requests until all quota descriptors are over the limit.
   bool quota_mode = 7;
 }
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/coocood/freecache v1.2.4
 	github.com/envoyproxy/go-control-plane v0.14.0
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0
-	github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20250812085011-4cf7e8485428
+	github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20260131204543-4ca8b9cded3e
 	github.com/go-kit/log v0.2.1
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/envoyproxy/go-control-plane v0.14.0 h1:hbG2kr4RuFj222B6+7T83thSPqLjwB
 github.com/envoyproxy/go-control-plane v0.14.0/go.mod h1:NcS5X47pLl/hfqxU70yPwL9ZMkUlwlKxtAohpi2wBEU=
 github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3reDNEnfOboJ0QySbH736g=
 github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
-github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20250812085011-4cf7e8485428 h1:AkYCu5lno5OO4HujsRKIDJ1XnqymM3saXdBoQ+lpWhk=
-github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20250812085011-4cf7e8485428/go.mod h1:EWppLjKDYW2tcLcDYvR1kDWCZWeMVxH/0v6vaYXo0eA=
+github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20260131204543-4ca8b9cded3e h1:EHL6eLDhQduyYGEKh+QSXE7s7Yhg/hpeeHFT0ET0gBw=
+github.com/envoyproxy/go-control-plane/ratelimit v0.1.1-0.20260131204543-4ca8b9cded3e/go.mod h1:buWyXJdrI6ayYbeGm3upu3Qf/qHHrdWfUHKnVrTD+vM=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.0 h1:TvGH1wof4H33rezVKWSpqKz5NXWg5VPuZ0uONDT6eb4=
 github.com/envoyproxy/protoc-gen-validate v1.3.0/go.mod h1:HvYl7zwPa5mffgyeTUHA9zHIH36nmrm7oCbo4YKoSWA=

--- a/src/config/config_xds.go
+++ b/src/config/config_xds.go
@@ -22,6 +22,7 @@ func rateLimitDescriptorsPbToYaml(pb []*rls_conf_v3.RateLimitDescriptor) []YamlD
 			Descriptors:    rateLimitDescriptorsPbToYaml(d.Descriptors),
 			ShadowMode:     d.ShadowMode,
 			DetailedMetric: d.DetailedMetric,
+			QuotaMode:      d.QuotaMode,
 		}
 	}
 

--- a/test/provider/xds_grpc_sotw_provider_test.go
+++ b/test/provider/xds_grpc_sotw_provider_test.go
@@ -236,6 +236,7 @@ func testDeeperLimitsXdsConfigUpdate(snapVersion *int, setSnapshotFunc common.Se
 											RequestsPerUnit: 15,
 										},
 										ShadowMode: true,
+										QuotaMode:  true,
 									},
 								},
 							},
@@ -271,7 +272,7 @@ func testDeeperLimitsXdsConfigUpdate(snapVersion *int, setSnapshotFunc common.Se
 			"foo.k1_v1.k2_v2: unit=HOUR requests_per_unit=15, shadow_mode: false, quota_mode: false",
 			"foo.j1_v2: unit=UNKNOWN requests_per_unit=0, shadow_mode: false, quota_mode: false",
 			"foo.j1_v2.j2: unit=UNKNOWN requests_per_unit=0, shadow_mode: false, quota_mode: false",
-			"foo.j1_v2.j2_v2: unit=DAY requests_per_unit=15, shadow_mode: true, quota_mode: false",
+			"foo.j1_v2.j2_v2: unit=DAY requests_per_unit=15, shadow_mode: true, quota_mode: true",
 			"bar.k1_v1: unit=MINUTE requests_per_unit=100, shadow_mode: false, quota_mode: false",
 		}, strings.Split(strings.TrimSuffix(config.Dump(), "\n"), "\n"))
 	}


### PR DESCRIPTION
Quota mode was added to the envoy/go-controlp-lane RateLimitDescriptor earlier this year: https://github.com/envoyproxy/go-control-plane/pull/1385/changes#diff-161ce5b2b49a210131bc9a8e7c14c1394a5a3a18f807e1eface73bbb401318f2

This PR updates the go-control-plane to include that change plus parses rl config message to include it.