### PR TITLE
fix: correct typos in memcache error messages and variable name

### DIFF
--- a/src/memcached/cache_impl.go
+++ b/src/memcached/cache_impl.go
@@ -97,7 +97,8 @@ func (this *rateLimitMemcacheImpl) DoLimit(
 	}
 
 	// Generate trace
-	_, span := tracer.Start(ctx, "Memcached Fetch Execution",
+	_, span := tracer.Start(
+		ctx, "Memcached Fetch Execution",
 		trace.WithAttributes(
 			attribute.Int("keysToGet length", len(keysToGet)),
 		),
@@ -202,7 +203,7 @@ func refreshServersPeriodically(serverList *memcache.ServerList, srv string, d t
 		case <-t.C:
 			err := refreshServers(serverList, srv, resolver)
 			if err != nil {
-				logger.Warn("failed to refresh memcahce hosts")
+				logger.Warn("failed to refresh memcache hosts")
 			} else {
 				logger.Debug("refreshed memcache hosts")
 			}
@@ -246,7 +247,7 @@ func newMemcachedFromSrv(srv string, d time.Duration, resolver srv.SrvResolver) 
 
 func newMemcacheFromSettings(s settings.Settings) Client {
 	if s.MemcacheSrv != "" && len(s.MemcacheHostPort) > 0 {
-		panic(MemcacheError("Both MEMCADHE_HOST_PORT and MEMCACHE_SRV are set"))
+		panic(MemcacheError("Both MEMCACHE_HOST_PORT and MEMCACHE_SRV are set"))
 	}
 	var client *memcache.Client
 	if s.MemcacheSrv != "" {

--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -42,7 +42,7 @@ func pipelineAppendtoGet(client Client, pipeline *Pipeline, key string, result *
 }
 
 func (this *fixedRateLimitCacheImpl) getHitsAddend(hitsAddend uint64, isCacheKeyOverlimit, isCacheKeyNearlimit,
-	isNearLimt bool,
+	isNearLimit bool,
 ) uint64 {
 	// If stopCacheKeyIncrementWhenOverlimit is false, then we always increment the cache key.
 	if !this.stopCacheKeyIncrementWhenOverlimit {
@@ -64,7 +64,7 @@ func (this *fixedRateLimitCacheImpl) getHitsAddend(hitsAddend uint64, isCacheKey
 
 	// If stopCacheKeyIncrementWhenOverlimit is true, and some of the keys are near limit, then
 	// we only increment the cache key if the key is near limit.
-	if isNearLimt {
+	if isNearLimit {
 		return hitsAddend
 	}
 
@@ -187,7 +187,8 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 	}
 
 	// Generate trace
-	_, span := tracer.Start(ctx, "Redis Pipeline Execution",
+	_, span := tracer.Start(
+		ctx, "Redis Pipeline Execution",
 		trace.WithAttributes(
 			attribute.Int("pipeline length", len(pipeline)),
 			attribute.Int("perSecondPipeline length", len(perSecondPipeline)),

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -363,7 +363,7 @@ func mergeMetadata(dest *structpb.Struct, src *structpb.Struct) {
 					continue
 				}
 			}
-			// TODO(yanavlasov): add option to overwrite or add if typoe is a list
+			// TODO(yanavlasov): add option to overwrite or add if type is a list
 		} else {
 			// Otherwise overwrite or add
 			dest.GetFields()[k] = v
@@ -403,7 +403,8 @@ func (this *service) ShouldRateLimit(
 ) (finalResponse *pb.RateLimitResponse, finalError error) {
 	logger.Debugf("ShouldRateLimit: %+v", request)
 	// Generate trace
-	_, span := tracer.Start(ctx, "ShouldRateLimit Execution",
+	_, span := tracer.Start(
+		ctx, "ShouldRateLimit Execution",
 		trace.WithAttributes(
 			attribute.String("domain", request.Domain),
 			attribute.String("request string", request.String()),


### PR DESCRIPTION
Few typos that crept in

`MEMCADHE_HOST_PORT` in the panic message at `newMemcacheFromSettings` is the worst one - if you set both `MEMCACHE_HOST_PORT` and `MEMCACHE_SRV` you get a panic that says a completely different env var name, so you end up grep'ing for something that doesn't exist.

Also fixed:
- `memcahce` -> `memcache` in the SRV refresh warning log
- `isNearLimt` -> `isNearLimit` parameter in `getHitsAddend` (inconsistent with all neighbors like `isCacheKeyNearlimit`)
- `typoe` -> `type` in a TODO comment in `mergeMetadata`

How to reproduce the panic message bug:

```
export MEMCACHE_HOST_PORT=localhost:11211
export MEMCACHE_SRV=_memcache._tcp.example.com
export BACKEND_TYPE=memcache
./ratelimit
```

Panic says `Both MEMCADHE_HOST_PORT and MEMCACHE_SRV are set` - wrong env var name, sends you on a wild goose chase.