### PR TITLE
Update to golang 1.26.3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: run pre-commits
         run: |

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.26.2"
+          go-version: "1.26.3"
 
       - name: run pre-commits
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS build
+FROM golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS build
 WORKDIR /ratelimit
 
 ENV GOPROXY=https://proxy.golang.org

--- a/Dockerfile.integration
+++ b/Dockerfile.integration
@@ -1,5 +1,5 @@
 # Running this docker image runs the integration tests.
-FROM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716
+FROM golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a
 
 RUN apt-get update -y && apt-get install sudo stunnel4 redis memcached -y && rm -rf /var/lib/apt/lists/*
 

--- a/examples/xds-sotw-config-server/Dockerfile
+++ b/examples/xds-sotw-config-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2@sha256:b54cbf583d390341599d7bcbc062425c081105cc5ef6d170ced98ef9d047c716 AS build
+FROM golang:1.26.3@sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a AS build
 WORKDIR /xds-server
 
 COPY . .

--- a/examples/xds-sotw-config-server/go.mod
+++ b/examples/xds-sotw-config-server/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/ratelimit/examples/xds-sotw-config-server
 
-go 1.26.1
+go 1.26.3
 
 require (
 	github.com/envoyproxy/go-control-plane v0.12.1-0.20240123181358-841e293a220b

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/ratelimit
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.5.0


### PR DESCRIPTION
  Summary
  
  - Update Go from 1.26.2 to 1.26.3 across all Dockerfiles, go.mod files, and CI workflows
  - Pin Dockerfile images to the multi-arch index digest (sha256:2d6c80227255c3112a4d08e67ba98e58efd3846daf15d9d7d4c389565d881b1a) covering linux/amd64, linux/arm64/v8, arm/v7, 386, ppc64le, riscv64, s390x, and windows/amd64

  Files changed

  - Dockerfile
  - Dockerfile.integration
  - examples/xds-sotw-config-server/Dockerfile
  - go.mod
  - examples/xds-sotw-config-server/go.mod
  - .github/workflows/main.yaml
  - .github/workflows/pullrequest.yaml