### PR TITLE
fix: report the correct caller in assert panics

### DIFF
--- a/src/assert/assert.go
+++ b/src/assert/assert.go
@@ -7,10 +7,10 @@ import (
 
 func Assert(something bool) {
 	if !something {
-		pc := make([]uintptr, 10)
-		runtime.Callers(2, pc)
-		f := runtime.FuncForPC(pc[0])
-		file, line := f.FileLine(pc[0])
-		panic(fmt.Sprintf("assertion failed at %s:%d %s\n", file, line, f.Name()))
+		pc := make([]uintptr, 1)
+		n := runtime.Callers(2, pc)
+		frames := runtime.CallersFrames(pc[:n])
+		frame, _ := frames.Next()
+		panic(fmt.Sprintf("assertion failed at %s:%d %s\n", frame.File, frame.Line, frame.Function))
 	}
 }

--- a/src/assert/assert_test.go
+++ b/src/assert/assert_test.go
@@ -1,0 +1,44 @@
+package assert
+
+import (
+	"strings"
+	"testing"
+)
+
+func assertFailure() {
+	Assert(false)
+}
+
+func TestAssertReportsCallerLocation(t *testing.T) {
+	var got string
+
+	func() {
+		defer func() {
+			r := recover()
+			if r == nil {
+				t.Fatal("expected panic")
+			}
+
+			msg, ok := r.(string)
+			if !ok {
+				t.Fatalf("expected panic string, got %T", r)
+			}
+
+			got = msg
+		}()
+
+		assertFailure()
+	}()
+
+	if !strings.Contains(got, "src/assert/assert_test.go:") {
+		t.Fatalf("expected panic to report assert test file, got %q", got)
+	}
+
+	if !strings.Contains(got, "github.com/envoyproxy/ratelimit/src/assert.assertFailure") {
+		t.Fatalf("expected panic to report assertFailure function, got %q", got)
+	}
+
+	if strings.Contains(got, "TestAssertReportsCallerLocation") {
+		t.Fatalf("expected panic to report immediate caller instead of outer test frame, got %q", got)
+	}
+}


### PR DESCRIPTION
small fix, but this panic output was kinda lying.
`assert.Assert(false)` could report the outer frame instead of the real caller, so debugging was a bit meh.

Related: #1007

What changed
- switch `src/assert.Assert` to `runtime.CallersFrames`
- add a regression test for the reported file/function

Repro
1. create `/tmp/assert_repro.go`:

```go
package main

import "github.com/envoyproxy/ratelimit/src/assert"

func fail() { assert.Assert(false) }
func main() { fail() }
```

2. run `go run /tmp/assert_repro.go`
3. before this change the panic points at `main.main`
4. after this change it points at `main.fail`, which is the real call site

Checks
- `go test ./src/assert`
- `go test ./...`
