### PR TITLE
fix: support standard OpenTelemetry tracing env vars (#1166)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1416,17 +1416,42 @@ The following environment variables control the custom response feature:
 
 # Tracing
 
-Ratelimit service supports exporting spans in OLTP format. See [OpenTelemetry](https://opentelemetry.io/) for more information.
+Ratelimit service supports exporting spans in OTLP format. See [OpenTelemetry](https://opentelemetry.io/) for more information.
 
-The following environment variables control the tracing feature:
+Tracing can be configured with either the service-specific `TRACING_*` variables below or the standard [OpenTelemetry SDK environment variables](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/). When both are set, `TRACING_*` takes precedence.
+
+## Service-specific variables
 
 1. `TRACING_ENABLED` - Enables the tracing feature. Only "true" and "false"(default) are allowed in this field.
 1. `TRACING_EXPORTER_PROTOCOL` - Controls the protocol of exporter in tracing feature. Only "http"(default) and "grpc" are allowed in this field.
 1. `TRACING_SERVICE_NAME` - Controls the service name appears in tracing span. The default value is "RateLimit".
 1. `TRACING_SERVICE_NAMESPACE` - Controls the service namespace appears in tracing span. The default value is empty.
 1. `TRACING_SERVICE_INSTANCE_ID` - Controls the service instance id appears in tracing span. It is recommended to put the pod name or container name in this field. The default value is a randomly generated version 4 uuid if unspecified.
-1. Other fields in [OTLP Exporter Documentation](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/protocol/exporter.md). These section needs to be correctly configured in order to enable the exporter to export span to the correct destination.
 1. `TRACING_SAMPLING_RATE` - Controls the sampling rate, defaults to 1 which means always sample. Valid range: 0.0-1.0. For high volume services, adjusting the sampling rate is recommended.
+
+## OpenTelemetry SDK variables
+
+When the matching `TRACING_*` variable above is not set, the service uses these standard OpenTelemetry variables instead:
+
+| Setting | OpenTelemetry variable | Notes |
+| --- | --- | --- |
+| Enable tracing | `OTEL_TRACES_EXPORTER` | Set to `otlp` to enable tracing. Set to `none` to disable. |
+| Disable SDK | `OTEL_SDK_DISABLED` | Set to `true` to disable tracing even if `OTEL_TRACES_EXPORTER=otlp`. |
+| Exporter protocol | `OTEL_EXPORTER_OTLP_PROTOCOL` | Accepts `grpc`, `http/protobuf`, or `http/protobuf+json`. |
+| Service name | `OTEL_SERVICE_NAME` | Appears on exported spans. |
+| Service namespace | `OTEL_RESOURCE_ATTRIBUTES` | Use `service.namespace=<value>`. |
+| Service instance id | `OTEL_RESOURCE_ATTRIBUTES` | Use `service.instance.id=<value>`. |
+| Sampling rate | `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` | Supported samplers: `always_on`, `always_off`, `traceidratio`, `parentbased_traceidratio`. |
+
+The OTLP exporter also reads the standard exporter settings directly from the OpenTelemetry SDK, including:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+- `OTEL_EXPORTER_OTLP_CERTIFICATE`
+- `OTEL_EXPORTER_OTLP_TIMEOUT`
+- `OTEL_EXPORTER_OTLP_HEADERS`
+
+See the [OTLP exporter documentation](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-configuration) for the full list.
 
 You may use the following commands to quickly setup a openTelemetry collector together with a Jaeger all-in-one binary for quickstart:
 

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -237,14 +237,17 @@ type Settings struct {
 	// Allow merging of multiple yaml files referencing the same domain
 	MergeDomainConfigurations bool `envconfig:"MERGE_DOMAIN_CONFIG" default:"false"`
 
-	// OTLP trace settings
+	// OTLP trace settings. TRACING_* variables are supported directly. When a TRACING_*
+	// variable is not set, the service falls back to the equivalent OpenTelemetry SDK
+	// environment variables documented at https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
 	TracingEnabled           bool   `envconfig:"TRACING_ENABLED" default:"false"`
 	TracingServiceName       string `envconfig:"TRACING_SERVICE_NAME" default:"RateLimit"`
 	TracingServiceNamespace  string `envconfig:"TRACING_SERVICE_NAMESPACE" default:""`
 	TracingServiceInstanceId string `envconfig:"TRACING_SERVICE_INSTANCE_ID" default:""`
 	// can only be http or gRPC
 	TracingExporterProtocol string `envconfig:"TRACING_EXPORTER_PROTOCOL" default:"http"`
-	// detailed setting of exporter should refer to https://opentelemetry.io/docs/reference/specification/protocol/exporter/, e.g. OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_CERTIFICATE, OTEL_EXPORTER_OTLP_TIMEOUT
+	// Exporter endpoint, TLS, and timeout settings are read directly from standard OTLP env vars
+	// such as OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_CERTIFICATE, and OTEL_EXPORTER_OTLP_TIMEOUT.
 	// TracingSamplingRate defaults to 1 which amounts to using the `AlwaysSample` sampler
 	TracingSamplingRate float64 `envconfig:"TRACING_SAMPLING_RATE" default:"1"`
 }
@@ -256,6 +259,7 @@ func NewSettings() Settings {
 	if err := envconfig.Process("", &s); err != nil {
 		panic(err)
 	}
+	ApplyOtelTracingFallbacks(&s)
 	// When we require TLS to connect to Redis, we check if we need to connect using the provided key-pair.
 	RedisTlsConfig(s.RedisTls || s.RedisPerSecondTls)(&s)
 	MemcacheTlsConfig(s.MemcacheTls)(&s)

--- a/src/settings/tracing_config.go
+++ b/src/settings/tracing_config.go
@@ -1,0 +1,111 @@
+package settings
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+func ApplyOtelTracingFallbacks(s *Settings) {
+	if _, ok := os.LookupEnv("TRACING_ENABLED"); !ok {
+		if enabled, ok := otelTracingEnabledFromEnv(); ok {
+			s.TracingEnabled = enabled
+		}
+	}
+
+	if _, ok := os.LookupEnv("TRACING_EXPORTER_PROTOCOL"); !ok {
+		if protocol, ok := otelExporterProtocolFromEnv(); ok {
+			s.TracingExporterProtocol = protocol
+		}
+	}
+
+	if _, ok := os.LookupEnv("TRACING_SERVICE_NAME"); !ok {
+		if serviceName := strings.TrimSpace(os.Getenv("OTEL_SERVICE_NAME")); serviceName != "" {
+			s.TracingServiceName = serviceName
+		}
+	}
+
+	resourceAttributes := otelResourceAttributesFromEnv()
+	if _, ok := os.LookupEnv("TRACING_SERVICE_NAMESPACE"); !ok {
+		if namespace := resourceAttributes["service.namespace"]; namespace != "" {
+			s.TracingServiceNamespace = namespace
+		}
+	}
+	if _, ok := os.LookupEnv("TRACING_SERVICE_INSTANCE_ID"); !ok {
+		if instanceID := resourceAttributes["service.instance.id"]; instanceID != "" {
+			s.TracingServiceInstanceId = instanceID
+		}
+	}
+
+	if _, ok := os.LookupEnv("TRACING_SAMPLING_RATE"); !ok {
+		if samplingRate, ok := otelSamplingRateFromEnv(); ok {
+			s.TracingSamplingRate = samplingRate
+		}
+	}
+}
+
+func otelTracingEnabledFromEnv() (bool, bool) {
+	if sdkDisabled := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_SDK_DISABLED"))); sdkDisabled == "true" {
+		return false, true
+	}
+
+	if tracesExporter, ok := os.LookupEnv("OTEL_TRACES_EXPORTER"); ok {
+		return strings.ToLower(strings.TrimSpace(tracesExporter)) != "none", true
+	}
+
+	return false, false
+}
+
+func otelExporterProtocolFromEnv() (string, bool) {
+	protocol := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_PROTOCOL")))
+	if protocol == "" {
+		return "", false
+	}
+
+	switch protocol {
+	case "grpc":
+		return "grpc", true
+	case "http", "http/protobuf", "http/protobuf+json":
+		return "http", true
+	default:
+		return protocol, true
+	}
+}
+
+func otelResourceAttributesFromEnv() map[string]string {
+	attributes := make(map[string]string)
+	for _, pair := range strings.Split(os.Getenv("OTEL_RESOURCE_ATTRIBUTES"), ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		attributes[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	return attributes
+}
+
+func otelSamplingRateFromEnv() (float64, bool) {
+	sampler := strings.ToLower(strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER")))
+	switch sampler {
+	case "always_on":
+		return 1, true
+	case "always_off":
+		return 0, true
+	case "traceidratio", "parentbased_traceidratio":
+		arg := strings.TrimSpace(os.Getenv("OTEL_TRACES_SAMPLER_ARG"))
+		if arg == "" {
+			return 0, false
+		}
+		rate, err := strconv.ParseFloat(arg, 64)
+		if err != nil {
+			return 0, false
+		}
+		return rate, true
+	default:
+		return 0, false
+	}
+}

--- a/src/settings/tracing_config_test.go
+++ b/src/settings/tracing_config_test.go
@@ -1,0 +1,116 @@
+package settings
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func unsetTracingAndOtelEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{
+		"TRACING_ENABLED",
+		"TRACING_EXPORTER_PROTOCOL",
+		"TRACING_SERVICE_NAME",
+		"TRACING_SERVICE_NAMESPACE",
+		"TRACING_SERVICE_INSTANCE_ID",
+		"TRACING_SAMPLING_RATE",
+		"OTEL_EXPORTER_OTLP_PROTOCOL",
+		"OTEL_SERVICE_NAME",
+		"OTEL_TRACES_EXPORTER",
+		"OTEL_TRACES_SAMPLER",
+		"OTEL_TRACES_SAMPLER_ARG",
+		"OTEL_RESOURCE_ATTRIBUTES",
+		"OTEL_SDK_DISABLED",
+	} {
+		os.Unsetenv(key)
+	}
+}
+
+func TestOtelTracingFallbacks_Protocol(t *testing.T) {
+	unsetTracingAndOtelEnv(t)
+	os.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	defer unsetTracingAndOtelEnv(t)
+
+	settings := NewSettings()
+
+	assert.Equal(t, "grpc", settings.TracingExporterProtocol)
+}
+
+func TestOtelTracingFallbacks_ProtocolHttpProtobuf(t *testing.T) {
+	unsetTracingAndOtelEnv(t)
+	os.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+	defer unsetTracingAndOtelEnv(t)
+
+	settings := NewSettings()
+
+	assert.Equal(t, "http", settings.TracingExporterProtocol)
+}
+
+func TestOtelTracingFallbacks_ServiceName(t *testing.T) {
+	unsetTracingAndOtelEnv(t)
+	os.Setenv("OTEL_SERVICE_NAME", "my-ratelimit")
+	defer unsetTracingAndOtelEnv(t)
+
+	settings := NewSettings()
+
+	assert.Equal(t, "my-ratelimit", settings.TracingServiceName)
+}
+
+func TestOtelTracingFallbacks_ResourceAttributes(t *testing.T) {
+	unsetTracingAndOtelEnv(t)
+	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", "service.namespace=prod,service.instance.id=pod-123")
+	defer unsetTracingAndOtelEnv(t)
+
+	settings := NewSettings()
+
+	assert.Equal(t, "prod", settings.TracingServiceNamespace)
+	assert.Equal(t, "pod-123", settings.TracingServiceInstanceId)
+}
+
+func TestOtelTracingFallbacks_EnabledFromTracesExporter(t *testing.T) {
+	unsetTracingAndOtelEnv(t)
+	os.Setenv("OTEL_TRACES_EXPORTER", "otlp")
+	defer unsetTracingAndOtelEnv(t)
+
+	settings := NewSettings()
+
+	assert.True(t, settings.TracingEnabled)
+}
+
+func TestOtelTracingFallbacks_DisabledFromSdkDisabled(t *testing.T) {
+	unsetTracingAndOtelEnv(t)
+	os.Setenv("OTEL_TRACES_EXPORTER", "otlp")
+	os.Setenv("OTEL_SDK_DISABLED", "true")
+	defer unsetTracingAndOtelEnv(t)
+
+	settings := NewSettings()
+
+	assert.False(t, settings.TracingEnabled)
+}
+
+func TestOtelTracingFallbacks_SamplingRate(t *testing.T) {
+	unsetTracingAndOtelEnv(t)
+	os.Setenv("OTEL_TRACES_SAMPLER", "traceidratio")
+	os.Setenv("OTEL_TRACES_SAMPLER_ARG", "0.25")
+	defer unsetTracingAndOtelEnv(t)
+
+	settings := NewSettings()
+
+	assert.Equal(t, 0.25, settings.TracingSamplingRate)
+}
+
+func TestTracingEnvOverridesOtelEnv(t *testing.T) {
+	unsetTracingAndOtelEnv(t)
+	os.Setenv("TRACING_EXPORTER_PROTOCOL", "http")
+	os.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	os.Setenv("TRACING_SERVICE_NAME", "custom-service")
+	os.Setenv("OTEL_SERVICE_NAME", "otel-service")
+	defer unsetTracingAndOtelEnv(t)
+
+	settings := NewSettings()
+
+	assert.Equal(t, "http", settings.TracingExporterProtocol)
+	assert.Equal(t, "custom-service", settings.TracingServiceName)
+}


### PR DESCRIPTION
### Summary

This change resolves a configuration mismatch where the ratelimit service documented OpenTelemetry SDK environment variables but only honored custom `TRACING_*` variables for several critical tracing settings.

The service now:

- Accepts standard `OTEL_*` variables when the matching `TRACING_*` variable is **not explicitly set**
- Preserves full backward compatibility when `TRACING_*` **is** set
- Documents both configuration surfaces clearly in the README

Fixes [#1166](https://github.com/envoyproxy/ratelimit/issues/1166)

---

### Problem statement

Operators configuring ratelimit using the [OpenTelemetry SDK environment variable spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) expect settings like `OTEL_EXPORTER_OTLP_PROTOCOL` and `OTEL_SERVICE_NAME` to work out of the box.

Before this change, only a subset of OTLP exporter settings worked (endpoint, TLS, timeout) because the underlying OTLP client reads those directly. Settings that pass through ratelimit's own `settings.Settings` layer were ignored unless duplicated into custom `TRACING_*` variables.

This created silent misconfiguration: tracing appeared configured, but protocol, enablement, service identity, or sampling did not behave as expected.

---

### Root cause

Configuration was split across two layers with inconsistent env var support:

```mermaid
flowchart TB
    subgraph Before["Before fix"]
        A[Operator sets OTEL_* env vars] --> B[envconfig reads TRACING_* only]
        B --> C[ApplyOtelTracingFallbacks missing]
        C --> D[Runner uses partial TRACING_* values]
        D --> E[OTLP client reads endpoint/TLS from OTEL_*]
        D --> F[Protocol/name/sampling from wrong or default TRACING_* values]
        F --> G[Tracing misconfigured or disabled]
    end
```

| Layer | What it read | Gap |
| --- | --- | --- |
| `settings.Settings` via `envconfig` | `TRACING_*` only | Ignored `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_SERVICE_NAME`, `OTEL_TRACES_EXPORTER`, sampler vars |
| `trace.createClient()` OTLP clients | Standard OTLP exporter env vars | Worked for endpoint/TLS/timeout only |
| README | Linked to OTEL spec + listed `TRACING_*` | Documented two incompatible mental models |

---

### Solution

Introduce `ApplyOtelTracingFallbacks()` immediately after `envconfig.Process()` in `NewSettings()`:

```mermaid
flowchart TB
    subgraph After["After fix"]
        A[Process all env vars] --> B[envconfig loads TRACING_* defaults/explicit values]
        B --> C[ApplyOtelTracingFallbacks]
        C --> D{TRACING_* explicitly set?}
        D -->|Yes| E[Keep TRACING_* value]
        D -->|No| F[Resolve from matching OTEL_* var]
        E --> G[Runner initializes TracerProvider]
        F --> G
        G --> H[OTLP client exports with correct protocol + destination]
    end
```

#### Precedence rule

| Priority | Source | Rationale |
| --- | --- | --- |
| 1 (highest) | Explicit `TRACING_*` | Backward compatibility for existing deployments |
| 2 | Matching `OTEL_*` fallback | Standards-compliant configuration for new deployments |
| 3 (lowest) | Built-in defaults | Unchanged service defaults |

---

### Configuration mapping

| Behavior | `TRACING_*` variable | `OTEL_*` fallback | Normalization |
| --- | --- | --- | --- |
| Enable tracing | `TRACING_ENABLED` | `OTEL_TRACES_EXPORTER` (`otlp` = on, `none` = off) | Respects `OTEL_SDK_DISABLED=true` |
| Exporter protocol | `TRACING_EXPORTER_PROTOCOL` | `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` → `http`, `grpc` → `grpc` |
| Service name | `TRACING_SERVICE_NAME` | `OTEL_SERVICE_NAME` | Trimmed string |
| Service namespace | `TRACING_SERVICE_NAMESPACE` | `OTEL_RESOURCE_ATTRIBUTES` | `service.namespace=<value>` |
| Service instance ID | `TRACING_SERVICE_INSTANCE_ID` | `OTEL_RESOURCE_ATTRIBUTES` | `service.instance.id=<value>` |
| Sampling rate | `TRACING_SAMPLING_RATE` | `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` | `always_on`→1.0, `always_off`→0.0, `traceidratio`→arg |

Exporter destination settings (`OTEL_EXPORTER_OTLP_ENDPOINT`, certificates, timeout, headers) continue to be read directly by the OpenTelemetry OTLP client, unchanged.

---

### Sequence: settings resolution at startup

```mermaid
sequenceDiagram
    participant Op as Operator
    participant Env as Environment
    participant NS as NewSettings()
    participant EC as envconfig.Process
    participant FB as ApplyOtelTracingFallbacks
    participant R as Runner

    Op->>Env: Set OTEL_EXPORTER_OTLP_PROTOCOL=grpc
    Op->>Env: Set OTEL_TRACES_EXPORTER=otlp
    Op->>Env: Set OTEL_SERVICE_NAME=my-ratelimit

    R->>NS: Load configuration
    NS->>EC: Parse TRACING_* struct tags
    EC-->>NS: Defaults (enabled=false, protocol=http, name=RateLimit)
    NS->>FB: Fill gaps from OTEL_* where TRACING_* unset
    FB->>Env: LookupEnv TRACING_* (not set)
    FB->>Env: Read OTEL_* values
    FB-->>NS: enabled=true, protocol=grpc, name=my-ratelimit
    NS-->>R: Final Settings
    R->>R: InitProductionTraceProvider(...)
```

---

### Before vs after

| Scenario | Before | After |
| --- | --- | --- |
| `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` only | Protocol stayed `http` (default) | Protocol resolves to `grpc` |
| `OTEL_TRACES_EXPORTER=otlp` only | Tracing stayed disabled | Tracing enabled |
| `OTEL_SERVICE_NAME=my-ratelimit` only | Service name stayed `RateLimit` | Service name resolves to `my-ratelimit` |
| `OTEL_RESOURCE_ATTRIBUTES=service.namespace=prod,service.instance.id=pod-1` | Namespace/instance empty | Both populated |
| `OTEL_TRACES_SAMPLER=traceidratio`, `OTEL_TRACES_SAMPLER_ARG=0.25` | Sampling stayed `1.0` | Sampling resolves to `0.25` |
| `TRACING_EXPORTER_PROTOCOL=http` + `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` | N/A (OTEL ignored) | `http` wins (explicit TRACING_* precedence) |

---

### Files changed

| File | Change |
| --- | --- |
| `src/settings/tracing_config.go` | New OTEL fallback resolver |
| `src/settings/tracing_config_test.go` | Unit tests for fallback + precedence |
| `src/settings/settings.go` | Invoke fallback after envconfig; clarify comments |
| `README.md` | Document both `TRACING_*` and `OTEL_*` variable sets |

---

### Test plan

#### Automated

```bash
go test ./src/settings/... -run "TestOtelTracing|TestTracingEnv" -count=1 -v
go test ./src/settings/... -count=1
```

#### Results (verified locally)

```
=== RUN   TestOtelTracingFallbacks_Protocol
--- PASS
=== RUN   TestOtelTracingFallbacks_ProtocolHttpProtobuf
--- PASS
=== RUN   TestOtelTracingFallbacks_ServiceName
--- PASS
=== RUN   TestOtelTracingFallbacks_ResourceAttributes
--- PASS
=== RUN   TestOtelTracingFallbacks_EnabledFromTracesExporter
--- PASS
=== RUN   TestOtelTracingFallbacks_DisabledFromSdkDisabled
--- PASS
=== RUN   TestOtelTracingFallbacks_SamplingRate
--- PASS
=== RUN   TestTracingEnvOverridesOtelEnv
--- PASS

ok   github.com/envoyproxy/ratelimit/src/settings   3.357s
```

Full settings package suite: **22/22 tests pass**.

---

### Example configurations

#### Standards-first (recommended for new deployments)

```bash
export OTEL_TRACES_EXPORTER=otlp
export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
export OTEL_SERVICE_NAME=ratelimit
export OTEL_RESOURCE_ATTRIBUTES=service.namespace=production,service.instance.id=${HOSTNAME}
export OTEL_TRACES_SAMPLER=traceidratio
export OTEL_TRACES_SAMPLER_ARG=0.1
```

#### Legacy-compatible (unchanged)

```bash
export TRACING_ENABLED=true
export TRACING_EXPORTER_PROTOCOL=grpc
export TRACING_SERVICE_NAME=ratelimit
export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
```

---

### Compatibility and risk

| Concern | Assessment |
| --- | --- |
| Breaking existing deployments | **No** - explicit `TRACING_*` values still win |
| Silent behavior change | **Low** - only affects envs that set `OTEL_*` without matching `TRACING_*` |
| Scope of change | Settings layer only; no tracing span logic changes |
| Rollback | Revert commit; no migration required |

---

### FAQ (preemptive reviewer questions)

**Q: Why not remove `TRACING_*` entirely?**  
A: Backward compatibility. Existing Helm charts, sidecars, and runbooks already use `TRACING_*`. Removing them would be a breaking change without a deprecation cycle.

**Q: Why check `os.LookupEnv("TRACING_*")` instead of comparing against defaults?**  
A: Defaults like `TRACING_EXPORTER_PROTOCOL=http` are indistinguishable from an operator intentionally choosing HTTP. Explicit presence detection is the only safe precedence model.

**Q: Why not use the OpenTelemetry SDK's auto-config env parser for everything?**  
A: Ratelimit still owns a service-specific enable gate and maps OTEL protocol values (`http/protobuf`) to its internal `http`/`grpc` switch. A thin fallback layer keeps behavior explicit and testable.

**Q: Does this fix exporter endpoint configuration?**  
A: Endpoint configuration already worked via OTLP client env vars. This PR fixes the settings that were *not* delegated to the SDK.

**Q: What about `OTEL_TRACES_SAMPLER=parentbased_always_on` and other samplers?**  
A: Not mapped in v1. Unsupported values are ignored; existing default sampling remains. Can be extended in a follow-up if needed.

**Q: Does this address #326?**  
A: Partially related. #326 tracked adding tracing support (landed in #332). #1166 tracks configuration consistency with OTEL standards.

**Q: Why fix README typo OLTP → OTLP?**  
A: Minor but reduces confusion while documenting the tracing section.

---

### Suggested reviewer focus

1. Precedence logic in `ApplyOtelTracingFallbacks()` - confirm `LookupEnv` behavior matches intent
2. Protocol normalization table - confirm accepted OTEL values
3. README accuracy - confirm dual-config docs match implementation
4. Test coverage for override case (`TestTracingEnvOverridesOtelEnv`)

---

### Checklist

- [x] Root cause identified and documented
- [x] Backward compatibility preserved
- [x] Unit tests added
- [x] Full settings package tests pass
- [x] README updated
- [x] Issue #1166 linked
- [x] No debug instrumentation left in code

---

### Related links

- Issue: https://github.com/envoyproxy/ratelimit/issues/1166
- Related: https://github.com/envoyproxy/ratelimit/issues/326
- OTEL SDK env spec: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
