### PR TITLE
update proto to support metadata

### DIFF
--- a/api/ratelimit/config/ratelimit/v3/rls_conf.proto
+++ b/api/ratelimit/config/ratelimit/v3/rls_conf.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package ratelimit.config.ratelimit.v3;
 
+import "google/protobuf/struct.proto";
+
 option java_package = "io.envoyproxy.ratelimit.config.ratelimit.v3";
 option java_outer_classname = "RlsConfigProto";
 option java_multiple_files = true;
@@ -49,6 +51,10 @@ message RateLimitDescriptor {
   // Mark the descriptor as quota mode. When quota_mode is true, the rate limit service will allow
   // requests until all quota descriptors are over the limit.
   bool quota_mode = 7;
+
+  // Optional metadata associated with the descriptor. When a rate limit match occurs,
+  // this metadata is included in the rate limit response's DynamicMetadata field.
+  google.protobuf.Struct metadata = 8;
 }
 
 // Rate-limit policy.


### PR DESCRIPTION
Metadata is already defined in https://github.com/envoyproxy/ratelimit/blob/main/src/config/config.go#L33. I want to expose it on the proto. 

This is PR 1 of 3. 

Putting a subsequent PR (as step 2) in go-control-plane to update the rls_config.pb.go similar to [this PR](https://github.com/envoyproxy/go-control-plane/commit/4ca8b9cded3e7cf2bb63418b7ba601bee5a02448). -- edit: This is [PR 2](https://github.com/envoyproxy/go-control-plane/pull/1493) of 3.

As step 3, a [PR similar to this](https://github.com/envoyproxy/ratelimit/pull/1148/changes#diff-46d6c97f07e8fde1f5d0230d12003397357e025735959f07fcad1d8a18363691) will be added to reference the go-control-plane new metadata field in `src/config/config_xds.go`