### PR TITLE
redis: optionally close pooled connections on READONLY error replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,23 @@ To configure whether to return health check failure if there is no active redis 
 
 1. `REDIS_HEALTH_CHECK_ACTIVE_CONNECTION` : (default is "false")
 
+## Recovering from a failover (READONLY errors)
+
+1. `REDIS_CLOSE_CONNECTION_ON_READONLY_ERROR` : (default is "false")
+
+When a Redis master is failed over by repointing an address at the new master (a Kubernetes
+Service, DNS, or a proxy — common with Redis-compatible servers like Dragonfly, or Redis
+deployments without Sentinel), the demoted master keeps already-established connections open.
+Pooled connections are only discarded on IO errors, so every write on those stale connections
+keeps failing with `READONLY You can't write against a read only replica.` until the process
+restarts.
+
+Setting `REDIS_CLOSE_CONNECTION_ON_READONLY_ERROR` to `"true"` closes a pooled connection
+whenever a command on it fails with a READONLY error reply, so the pool reconnects through the
+configured address and reaches the current master. The failing command still returns its error
+to the caller; only the connection handling changes. Applies to both the main and the
+per-second Redis clients.
+
 # Memcache
 
 Experimental Memcache support has been added as an alternative to Redis in v1.5.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
   - [One Redis Instance](#one-redis-instance)
   - [Two Redis Instances](#two-redis-instances)
   - [Health Checking for Redis Active Connection](#health-checking-for-redis-active-connection)
+  - [Recovering from a failover (READONLY errors)](#recovering-from-a-failover-readonly-errors)
 - [Memcache](#memcache)
 - [Custom headers](#custom-headers)
 - [Tracing](#tracing)

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -22,7 +22,8 @@ func NewRateLimiterCacheImplFromSettings(ctx context.Context, s settings.Setting
 			s.RedisPerSecondType, s.RedisPerSecondUrl, s.RedisPerSecondPoolSize, s.RedisPerSecondPipelineWindow, s.RedisPerSecondPipelineLimit, s.RedisTlsConfig, s.RedisHealthCheckActiveConnection, srv, s.RedisPerSecondTimeout,
 			s.RedisPerSecondPoolOnEmptyBehavior, s.RedisPerSecondSentinelAuth,
 			s.RedisStartupInitialInterval, s.RedisStartupMaxInterval, s.RedisStartupMaxElapsedTime,
-			s.RedisPerSecondClusterPipelineParallelism)
+			s.RedisPerSecondClusterPipelineParallelism,
+			s.RedisCloseConnectionOnReadOnlyError)
 		closer.Closers = append(closer.Closers, perSecondPool)
 	}
 
@@ -30,7 +31,8 @@ func NewRateLimiterCacheImplFromSettings(ctx context.Context, s settings.Setting
 		s.RedisPipelineWindow, s.RedisPipelineLimit, s.RedisTlsConfig, s.RedisHealthCheckActiveConnection, srv, s.RedisTimeout,
 		s.RedisPoolOnEmptyBehavior, s.RedisSentinelAuth,
 		s.RedisStartupInitialInterval, s.RedisStartupMaxInterval, s.RedisStartupMaxElapsedTime,
-		s.RedisClusterPipelineParallelism)
+		s.RedisClusterPipelineParallelism,
+		s.RedisCloseConnectionOnReadOnlyError)
 	closer.Closers = append(closer.Closers, otherPool)
 
 	return NewFixedRateLimitCacheImpl(

--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -147,11 +147,13 @@ func NewClientImpl(ctx context.Context, scope stats.Scope, useTls bool, auth, re
 	pipelineWindow time.Duration, pipelineLimit int, tlsConfig *tls.Config, healthCheckActiveConnection bool, srv server.Server,
 	timeout time.Duration, poolOnEmptyBehavior string, sentinelAuth string,
 	startupInitialInterval, startupMaxInterval, startupMaxElapsedTime time.Duration,
+	closeConnectionOnReadOnlyError bool,
 ) Client {
 	return newClientImpl(ctx, scope, useTls, auth, redisSocketType, redisType, url, poolSize,
 		pipelineWindow, pipelineLimit, tlsConfig, healthCheckActiveConnection, srv,
 		timeout, poolOnEmptyBehavior, sentinelAuth,
-		startupInitialInterval, startupMaxInterval, startupMaxElapsedTime, 1)
+		startupInitialInterval, startupMaxInterval, startupMaxElapsedTime, 1,
+		closeConnectionOnReadOnlyError)
 }
 
 func newClientImpl(ctx context.Context, scope stats.Scope, useTls bool, auth, redisSocketType, redisType, url string, poolSize int,
@@ -159,6 +161,7 @@ func newClientImpl(ctx context.Context, scope stats.Scope, useTls bool, auth, re
 	timeout time.Duration, poolOnEmptyBehavior string, sentinelAuth string,
 	startupInitialInterval, startupMaxInterval, startupMaxElapsedTime time.Duration,
 	clusterPipelineParallelism int,
+	closeConnectionOnReadOnlyError bool,
 ) Client {
 	maskedUrl := utils.MaskCredentialsInUrl(url)
 	logger.Warnf("connecting to redis on %s with pool size %d", maskedUrl, poolSize)
@@ -189,6 +192,16 @@ func newClientImpl(ctx context.Context, scope stats.Scope, useTls bool, auth, re
 	if isCluster && pipelineWindow > 0 {
 		poolConfig.Dialer.WriteFlushInterval = pipelineWindow
 		logger.Debugf("Cluster mode: setting WriteFlushInterval to %v", pipelineWindow)
+	}
+
+	// Discard pooled connections whose commands fail with READONLY (the server
+	// behind them was demoted to replica by a failover) so the pool re-dials
+	// and reaches the current master. Installed last because CustomConn
+	// replaces every other Dialer field (TLS, auth, write buffering), which
+	// must all be final before being captured.
+	if closeConnectionOnReadOnlyError {
+		logger.Warnf("Redis pool %s: closing connections on READONLY error replies", maskedUrl)
+		poolConfig.Dialer = wrapDialerCloseOnReadOnly(poolConfig.Dialer)
 	}
 
 	effectivePipelineParallelism := clusterPipelineParallelism

--- a/src/redis/readonly_conn.go
+++ b/src/redis/readonly_conn.go
@@ -1,0 +1,68 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/mediocregopher/radix/v4"
+	"github.com/mediocregopher/radix/v4/resp"
+	"github.com/mediocregopher/radix/v4/resp/resp3"
+	logger "github.com/sirupsen/logrus"
+)
+
+// readOnlyClosingConn wraps a radix.Conn so that a READONLY error reply marks
+// the connection as unusable, which makes the enclosing pool discard it and
+// dial a replacement.
+//
+// A READONLY reply means the server behind this connection is a replica.
+// Redis-compatible deployments that fail over by repointing an address at the
+// new master (a Kubernetes Service, DNS, or a proxy — e.g. Redis without
+// Sentinel, Dragonfly, KeyDB) leave the demoted master running, and it keeps
+// already-established connections open. radix only discards pooled
+// connections on IO errors, so those stale connections are reused forever and
+// every write on them keeps failing with READONLY until the process restarts.
+// Discarding the connection instead makes the pool reconnect through the
+// configured address, which reaches the current master.
+type readOnlyClosingConn struct {
+	radix.Conn
+}
+
+func (c readOnlyClosingConn) EncodeDecode(ctx context.Context, toWrite, toRead interface{}) error {
+	err := c.Conn.EncodeDecode(ctx, toWrite, toRead)
+	if isReadOnlyError(err) {
+		logger.Warnf("redis connection to %s returned READONLY (server demoted to replica); discarding connection so the pool reconnects to the current master", c.Addr())
+		// Stripping the resp.ErrConnUsable wrapper tells the pool to discard
+		// this connection; callers still receive the underlying resp error.
+		return resp.ErrConnUnusable(err)
+	}
+	return err
+}
+
+// Do routes the Action through this wrapper (rather than the embedded Conn)
+// so the Action's EncodeDecode calls hit the READONLY detection above.
+func (c readOnlyClosingConn) Do(ctx context.Context, a radix.Action) error {
+	return a.Perform(ctx, c)
+}
+
+func isReadOnlyError(err error) bool {
+	var respErr resp3.SimpleError
+	return errors.As(err, &respErr) && strings.HasPrefix(respErr.S, "READONLY")
+}
+
+// wrapDialerCloseOnReadOnly returns a Dialer whose connections mark themselves
+// unusable when a command fails with a READONLY error reply. It must be built
+// from the fully-configured base Dialer: radix uses CustomConn in place of
+// every other Dialer field, so the base Dialer is captured here to keep TLS,
+// auth, timeouts, and write buffering working.
+func wrapDialerCloseOnReadOnly(base radix.Dialer) radix.Dialer {
+	return radix.Dialer{
+		CustomConn: func(ctx context.Context, network, addr string) (radix.Conn, error) {
+			conn, err := base.Dial(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			return readOnlyClosingConn{Conn: conn}, nil
+		},
+	}
+}

--- a/src/redis/readonly_conn_test.go
+++ b/src/redis/readonly_conn_test.go
@@ -1,0 +1,138 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mediocregopher/radix/v4"
+	"github.com/mediocregopher/radix/v4/resp"
+	"github.com/mediocregopher/radix/v4/resp/resp3"
+	"github.com/mediocregopher/radix/v4/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const readOnlyErrMsg = "READONLY You can't write against a read only replica."
+
+// readOnlyReply is what a real connection returns for a READONLY error reply:
+// the resp error wrapped in ErrConnUsable (see resp3's unmarshaling).
+func readOnlyReply() error {
+	return resp.ErrConnUsable{Err: resp3.SimpleError{S: readOnlyErrMsg}}
+}
+
+func TestIsReadOnlyError(t *testing.T) {
+	assert.True(t, isReadOnlyError(readOnlyReply()))
+	assert.True(t, isReadOnlyError(resp3.SimpleError{S: readOnlyErrMsg}))
+	assert.False(t, isReadOnlyError(nil))
+	assert.False(t, isReadOnlyError(resp.ErrConnUsable{Err: resp3.SimpleError{S: "ERR unknown command"}}))
+	assert.False(t, isReadOnlyError(errors.New("READONLY-looking plain error is not a resp error")))
+	assert.False(t, isReadOnlyError(&net.OpError{Op: "read", Err: errors.New("connection reset")}))
+}
+
+// stubConn returns a radix.Conn whose replies are driven by fn, wrapped the
+// same way newClientImpl wraps real connections.
+func wrappedStubConn(fn func(ctx context.Context, args []string) interface{}) radix.Conn {
+	return readOnlyClosingConn{Conn: radix.NewStubConn("tcp", "127.0.0.1:6379", fn)}
+}
+
+func TestReadOnlyClosingConnUnwrapsReadOnlyErrors(t *testing.T) {
+	conn := wrappedStubConn(func(ctx context.Context, args []string) interface{} {
+		return readOnlyReply()
+	})
+	defer conn.Close()
+
+	err := conn.Do(context.Background(), radix.Cmd(nil, "SET", "foo", "bar"))
+	require.Error(t, err)
+
+	// The caller still sees the resp error...
+	var respErr resp3.SimpleError
+	assert.True(t, errors.As(err, &respErr))
+	assert.Equal(t, readOnlyErrMsg, respErr.S)
+
+	// ...but the ErrConnUsable wrapper is gone, which is what tells the pool
+	// to discard this connection.
+	assert.False(t, errors.As(err, new(resp.ErrConnUsable)))
+}
+
+func TestReadOnlyClosingConnKeepsOtherErrorsUsable(t *testing.T) {
+	conn := wrappedStubConn(func(ctx context.Context, args []string) interface{} {
+		return resp.ErrConnUsable{Err: resp3.SimpleError{S: "ERR value is not an integer or out of range"}}
+	})
+	defer conn.Close()
+
+	err := conn.Do(context.Background(), radix.Cmd(nil, "INCRBY", "foo", "bar"))
+	require.Error(t, err)
+
+	// Ordinary application errors keep the ErrConnUsable wrapper so the pool
+	// keeps the connection.
+	assert.True(t, errors.As(err, new(resp.ErrConnUsable)))
+}
+
+func TestReadOnlyClosingConnPassesSuccessThrough(t *testing.T) {
+	conn := wrappedStubConn(func(ctx context.Context, args []string) interface{} {
+		return "OK"
+	})
+	defer conn.Close()
+
+	var res string
+	require.NoError(t, conn.Do(context.Background(), radix.Cmd(&res, "SET", "foo", "bar")))
+	assert.Equal(t, "OK", res)
+}
+
+// TestPoolDiscardsConnOnReadOnly proves the end-to-end mechanism: a READONLY
+// reply on a pooled connection makes the pool discard it and dial a fresh one,
+// after which commands succeed (as they would against the newly promoted
+// master).
+func TestPoolDiscardsConnOnReadOnly(t *testing.T) {
+	var dials, closes int64
+
+	// The first dialed "server" answers writes with READONLY (a demoted
+	// master); every later dial reaches a healthy master.
+	dialer := wrapDialerCloseOnReadOnly(radix.Dialer{
+		CustomConn: func(ctx context.Context, network, addr string) (radix.Conn, error) {
+			demoted := atomic.AddInt64(&dials, 1) == 1
+			return radix.NewStubConn(network, addr, func(ctx context.Context, args []string) interface{} {
+				if args[0] == "PING" {
+					return "PONG"
+				}
+				if demoted {
+					return readOnlyReply()
+				}
+				return "OK"
+			}), nil
+		},
+	})
+
+	pool, err := (radix.PoolConfig{
+		Dialer: dialer,
+		Size:   1,
+		Trace: trace.PoolTrace{
+			ConnClosed: func(trace.PoolConnClosed) { atomic.AddInt64(&closes, 1) },
+		},
+	}).New(context.Background(), "tcp", "127.0.0.1:6379")
+	require.NoError(t, err)
+	defer pool.Close()
+
+	// First write hits the demoted master and fails with READONLY.
+	err = pool.Do(context.Background(), radix.Cmd(nil, "SET", "foo", "bar"))
+	require.Error(t, err)
+	var respErr resp3.SimpleError
+	assert.True(t, errors.As(err, &respErr))
+
+	// The pool discards the stale connection and reconnects; the retried
+	// write reaches the new master.
+	assert.Eventually(t, func() bool {
+		var res string
+		if err := pool.Do(context.Background(), radix.Cmd(&res, "SET", "foo", "bar")); err != nil {
+			return false
+		}
+		return res == "OK"
+	}, 5*time.Second, 10*time.Millisecond)
+
+	assert.GreaterOrEqual(t, atomic.LoadInt64(&dials), int64(2))
+	assert.GreaterOrEqual(t, atomic.LoadInt64(&closes), int64(1))
+}

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -183,6 +183,14 @@ type Settings struct {
 	RedisPerSecondClusterPipelineParallelism int `envconfig:"REDIS_PERSECOND_CLUSTER_PIPELINE_PARALLELISM" default:"1"`
 	// Enable healthcheck to check Redis Connection. If there is no active connection, healthcheck failed.
 	RedisHealthCheckActiveConnection bool `envconfig:"REDIS_HEALTH_CHECK_ACTIVE_CONNECTION" default:"false"`
+	// RedisCloseConnectionOnReadOnlyError closes a pooled Redis connection when a command
+	// on it fails with a READONLY error reply, so the pool re-dials through the configured
+	// address. After a master->replica failover in deployments that fail over by repointing
+	// an address at the new master (a Kubernetes Service, DNS, or a proxy), the demoted
+	// master keeps established connections open and every write on them fails with READONLY
+	// until they reconnect; enabling this makes the pool recover automatically. Applies to
+	// both the main and the per-second Redis clients.
+	RedisCloseConnectionOnReadOnlyError bool `envconfig:"REDIS_CLOSE_CONNECTION_ON_READONLY_ERROR" default:"false"`
 	// RedisTimeout sets the timeout for Redis connection and I/O operations.
 	RedisTimeout time.Duration `envconfig:"REDIS_TIMEOUT" default:"10s"`
 	// RedisPerSecondTimeout sets the timeout for per-second Redis connection and I/O operations.

--- a/test/redis/bench_test.go
+++ b/test/redis/bench_test.go
@@ -44,7 +44,7 @@ func BenchmarkParallelDoLimit(b *testing.B) {
 		return func(b *testing.B) {
 			statsStore := gostats.NewStore(gostats.NewNullSink(), false)
 			sm := stats.NewMockStatManager(statsStore)
-			client := redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", "127.0.0.1:6379", poolSize, pipelineWindow, pipelineLimit, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 0)
+			client := redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", "127.0.0.1:6379", poolSize, pipelineWindow, pipelineLimit, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 0, false)
 			defer client.Close()
 
 			cache := redis.NewFixedRateLimitCacheImpl(client, nil, utils.NewTimeSourceImpl(), rand.New(utils.NewLockedSource(time.Now().Unix())), 10, nil, 0.8, "", sm, true)

--- a/test/redis/driver_impl_test.go
+++ b/test/redis/driver_impl_test.go
@@ -41,7 +41,7 @@ func testNewClientImpl(t *testing.T, pipelineWindow time.Duration, pipelineLimit
 
 		// Use a short maxElapsedTime so failing connection tests don't hang in retry loops.
 		mkRedisClient := func(auth, addr string) redis.Client {
-			return redis.NewClientImpl(context.Background(), statsStore, false, auth, "tcp", "single", addr, 1, pipelineWindow, pipelineLimit, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 100*time.Millisecond)
+			return redis.NewClientImpl(context.Background(), statsStore, false, auth, "tcp", "single", addr, 1, pipelineWindow, pipelineLimit, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 100*time.Millisecond, false)
 		}
 
 		t.Run("connection refused", func(t *testing.T) {
@@ -115,11 +115,27 @@ func TestNewClientImpl(t *testing.T) {
 	t.Run("WithoutPipelineWindow", testNewClientImpl(t, 0, 0))
 }
 
+func TestNewClientImplCloseConnectionOnReadOnlyError(t *testing.T) {
+	statsStore := stats.NewStore(stats.NewNullSink(), false)
+	redisSrv := mustNewRedisServer()
+	defer redisSrv.Close()
+
+	// Normal operation is unaffected by the READONLY-handling connection wrapper.
+	client := redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", redisSrv.Addr(), 1, 0, 0, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 0, true)
+	defer client.Close()
+
+	var res string
+	assert.NoError(t, client.DoCmd(&res, "SET", "foo", "bar"))
+	assert.Equal(t, "OK", res)
+	assert.NoError(t, client.DoCmd(&res, "GET", "foo"))
+	assert.Equal(t, "bar", res)
+}
+
 func TestDoCmd(t *testing.T) {
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 	mkRedisClient := func(addr string) redis.Client {
-		return redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", addr, 1, 0, 0, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 0)
+		return redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", addr, 1, 0, 0, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 0, false)
 	}
 
 	t.Run("SETGET ok", func(t *testing.T) {
@@ -164,7 +180,7 @@ func testPipeDo(t *testing.T, pipelineWindow time.Duration, pipelineLimit int) f
 		statsStore := stats.NewStore(stats.NewNullSink(), false)
 
 		mkRedisClient := func(addr string) redis.Client {
-			return redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", addr, 1, pipelineWindow, pipelineLimit, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 0)
+			return redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", addr, 1, pipelineWindow, pipelineLimit, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 0, false)
 		}
 
 		t.Run("SETGET ok", func(t *testing.T) {
@@ -232,7 +248,7 @@ func TestPoolOnEmptyBehavior(t *testing.T) {
 
 	// Helper to create client with specific on-empty behavior
 	mkRedisClientWithBehavior := func(addr, behavior string) redis.Client {
-		return redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", addr, 1, 0, 0, nil, false, nil, 10*time.Second, behavior, "", time.Second, 30*time.Second, 0)
+		return redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", addr, 1, 0, 0, nil, false, nil, 10*time.Second, behavior, "", time.Second, 30*time.Second, 0, false)
 	}
 
 	t.Run("default behavior (empty string)", func(t *testing.T) {
@@ -357,7 +373,7 @@ func TestNewClientImplSentinel(t *testing.T) {
 		// Pass nil for tlsConfig - we can't test TLS without a real TLS server,
 		// but we can verify the code path is executed (logs will show TLS is enabled)
 		// Use a short maxElapsedTime so failing connection tests don't hang in retry loops.
-		return redis.NewClientImpl(context.Background(), statsStore, useTls, auth, "tcp", "sentinel", url, 1, 0, 0, nil, false, nil, timeout, "", sentinelAuth, time.Second, 30*time.Second, 100*time.Millisecond)
+		return redis.NewClientImpl(context.Background(), statsStore, useTls, auth, "tcp", "sentinel", url, 1, 0, 0, nil, false, nil, timeout, "", sentinelAuth, time.Second, 30*time.Second, 100*time.Millisecond, false)
 	}
 
 	t.Run("invalid url format - missing sentinel addresses", func(t *testing.T) {


### PR DESCRIPTION
## Problem

After a master→replica failover in deployments that fail over by repointing an address at the new master (a Kubernetes Service, DNS, or a proxy — e.g. Redis without Sentinel, Dragonfly, KeyDB), the demoted master keeps already-established connections open. radix only discards pooled connections on IO errors, so those stale connections are reused forever and every write on them keeps failing with:

```
READONLY You can't write against a read only replica.
```

until the process restarts — turning a routine failover into a permanent rate limiting outage. We hit this in production running ratelimit against Dragonfly managed by dragonfly-operator (Dragonfly declined to drop client connections on demotion: dragonflydb/dragonfly#5160), but the failure mode applies to any proxy/DNS-based Redis failover.

## Change

Adds an opt-in setting `REDIS_CLOSE_CONNECTION_ON_READONLY_ERROR` (default `false`). When enabled, pooled connections are wrapped so that a READONLY error reply strips radix's `resp.ErrConnUsable` wrapper from the returned error. That is radix v4's native signal that a connection is no longer usable: the pool discards it and re-dials through the configured address, which reaches the current master.

- The failing command still returns its error to the caller — only the connection handling changes.
- Ordinary application errors (`ERR ...`, `WRONGTYPE ...`) keep the `ErrConnUsable` wrapper and do not affect the connection.
- The wrapper is installed via `Dialer.CustomConn` after all other dialer fields are final (TLS, auth, write buffering), since `CustomConn` replaces radix's own dialing.
- Applies to the main and per-second clients across single, cluster, and sentinel modes.

## Testing

- Unit tests for the READONLY detection and the error-unwrap behavior using `radix.NewStubConn`.
- A pool-level test proving the end-to-end mechanism: a READONLY reply on a pooled connection causes the pool to discard it, re-dial, and succeed on the next command.
- A driver-level test against miniredis showing normal operation is unaffected with the flag enabled.
- `go build ./...`, `gofmt`, and `go vet` clean; existing `test/redis` driver tests pass with the new parameter.

## Notes for reviewers

- Default is `false` to keep existing behavior; happy to flip the default if maintainers prefer, since continuing to use a connection that answers READONLY is never useful for ratelimit's write-heavy workload.
- Naming of the env var is open to bikeshedding.

## Local reproduction (before/after)

Reproduced the failure mode locally with two Redis 7 containers (A = master, B = standby) and a small TCP proxy standing in for the Kubernetes Service. Like real conntrack, the proxy keeps *established* connections piped to the old backend and only routes *new* connections to the new one. A driver-level loop ran `INCRBY` through `redis.NewClientImpl`; mid-run, A was demoted (`REPLICAOF B`) and the proxy repointed at B — the same sequence a Service-based failover performs.

**Without this change** — permanent outage; the pool reuses its healthy-looking TCP connections to the demoted master forever:

```
14:14:06.665 INCRBY -> 4      OK
14:14:07.276 >>> FAILOVER: redis A demoted to replica, service now points at B
14:14:07.278 INCRBY -> 0      ERR response returned from Conn: READONLY You can't write against a read only replica.
14:14:07.782 INCRBY -> 0      ERR response returned from Conn: READONLY You can't write against a read only replica.
... (every subsequent command fails identically)
=== after failover: 0 ok, 16 errors -> NEVER RECOVERED ===
```

**With `REDIS_CLOSE_CONNECTION_ON_READONLY_ERROR=true`** — exactly one error on the stale connection, then the pool discards it, re-dials through the service address, and reaches the new master:

```
14:14:39.277 INCRBY -> 4      OK
14:14:39.893 >>> FAILOVER: redis A demoted to replica, service now points at B
14:14:39.894 INCRBY -> 0      ERR READONLY You can't write against a read only replica.
14:14:40.397 INCRBY -> 1      OK
14:14:40.899 INCRBY -> 2      OK
... (all subsequent commands succeed against the new master)
=== after failover: 15 ok, 1 errors -> RECOVERED ===
```
