### PR TITLE
fix: apply log level/format before NewRunner() emits startup logs

### DIFF
--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -42,6 +42,8 @@ type Runner struct {
 }
 
 func NewRunner(s settings.Settings) Runner {
+	configureLogger(s)
+
 	var store gostats.Store
 
 	switch {
@@ -88,6 +90,24 @@ func NewRunner(s settings.Settings) Runner {
 		statsManager: stats.NewStatManager(store, s),
 		settings:     s,
 		done:         make(chan struct{}),
+	}
+}
+
+func configureLogger(s settings.Settings) {
+	logLevel, err := logger.ParseLevel(s.LogLevel)
+	if err != nil {
+		logger.Fatalf("Could not parse log level. %v\n", err)
+	}
+	logger.SetLevel(logLevel)
+
+	if strings.ToLower(s.LogFormat) == "json" {
+		logger.SetFormatter(&logger.JSONFormatter{
+			TimestampFormat: time.RFC3339Nano,
+			FieldMap: logger.FieldMap{
+				logger.FieldKeyTime: "@timestamp",
+				logger.FieldKeyMsg:  "@message",
+			},
+		})
 	}
 }
 
@@ -155,22 +175,6 @@ func (runner *Runner) Run() {
 		}()
 	} else {
 		logger.Infof("Tracing disabled")
-	}
-
-	logLevel, err := logger.ParseLevel(s.LogLevel)
-	if err != nil {
-		logger.Fatalf("Could not parse log level. %v\n", err)
-	} else {
-		logger.SetLevel(logLevel)
-	}
-	if strings.ToLower(s.LogFormat) == "json" {
-		logger.SetFormatter(&logger.JSONFormatter{
-			TimestampFormat: time.RFC3339Nano,
-			FieldMap: logger.FieldMap{
-				logger.FieldKeyTime: "@timestamp",
-				logger.FieldKeyMsg:  "@message",
-			},
-		})
 	}
 
 	var localCache *freecache.Cache


### PR DESCRIPTION
## Summary

When LOG_FORMAT=json was set, startup logs emitted before the logger configuration was applied used logrus’s default text formatter.

This affected Stats-related logs emitted from NewRunner() and tracing initialization logs emitted early in Run(). Logs emitted later, such as the Redis connection log, used the configured JSON formatter. As a result, a single process produced logs in inconsistent formats.

```
time="2026-07-16T03:20:52Z" level=info msg="Stats initialized for Prometheus"
time="2026-07-16T03:20:52Z" level=info msg="Starting prometheus sink on :9090/rate-limit-metrics"
time="2026-07-16T03:20:52Z" level=info msg="Stats flush interval: 30s"
time="2026-07-16T03:20:52Z" level=info msg="TracerProvider initialized with following parameters: ..."
{"@message":"connecting to redis on 127.0.0.1:6379 with pool size 64","@timestamp":"...","level":"warning"}
```

## Fix

Extracted the logger level/format configuration into `configureLogger()` and call it at the top of `NewRunner()`, so it's applied before any log line is emitted, including those inside `NewRunner()` itself. Removed the now-duplicated configuration code from `Run()`.

Note: #428 was a prior attempt at the same root cause, but it only reordered the `TracerProvider initialized` log inside `Run()` and didn't address the Stats-related logs emitted from `NewRunner()`. It went unreviewed and was stale-closed. This PR covers both.

