### PR TITLE
fix: prevent crash when client sends undefined rate limit unit

### DIFF
--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -457,21 +457,25 @@ func (this *rateLimitConfigImpl) GetLimit(
 	}
 
 	if descriptor.GetLimit() != nil {
-		rateLimitKey := descriptorKey(domain, descriptor)
 		rateLimitOverrideUnit := pb.RateLimitResponse_RateLimit_Unit(descriptor.GetLimit().GetUnit())
-		// When limit override is provided by envoy config, we don't want to enable shadow_mode
-		rateLimit = NewRateLimit(
-			descriptor.GetLimit().GetRequestsPerUnit(),
-			rateLimitOverrideUnit,
-			this.statsManager.NewStats(rateLimitKey),
-			false,
-			false,
-			false,
-			"",
-			[]string{},
-			false,
-		)
-		return rateLimit
+		if rateLimitOverrideUnit != pb.RateLimitResponse_RateLimit_UNKNOWN {
+			rateLimitKey := descriptorKey(domain, descriptor)
+			// When limit override is provided by envoy config, we don't want to enable shadow_mode
+			rateLimit = NewRateLimit(
+				descriptor.GetLimit().GetRequestsPerUnit(),
+				rateLimitOverrideUnit,
+				this.statsManager.NewStats(rateLimitKey),
+				false,
+				false,
+				false,
+				"",
+				[]string{},
+				false,
+			)
+			return rateLimit
+		} else {
+			logger.Warnf("ignoring rate limit override with undefined or unknown unit")
+		}
 	}
 
 	descriptorsMap := value.descriptors

--- a/src/utils/utilities.go
+++ b/src/utils/utilities.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	logger "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -35,7 +36,8 @@ func UnitToDivider(unit pb.RateLimitResponse_RateLimit_Unit) int64 {
 		return 60 * 60 * 24 * 365
 	}
 
-	panic("should not get here")
+	logger.Errorf("unknown rate limit unit: %v, defaulting to 1 second divider", unit)
+	return 1
 }
 
 func CalculateReset(unit *pb.RateLimitResponse_RateLimit_Unit, timeSource TimeSource) *durationpb.Duration {

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -286,6 +286,18 @@ func TestConfigLimitOverride(t *testing.T) {
 	assert.EqualValues(1, stats.NewCounter("test-domain.key1_value1.subkey1_something.near_limit").Value())
 	assert.EqualValues(1, stats.NewCounter("test-domain.key1_value1.subkey1_something.within_limit").Value())
 
+	// Undefined or unknown unit override is ignored and falls back to config
+	rl = rlConfig.GetLimit(
+		context.Background(), "test-domain",
+		&pb_struct.RateLimitDescriptor{
+			Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "key1", Value: "value1"}, {Key: "subkey1", Value: "something"}},
+			Limit: &pb_struct.RateLimitDescriptor_RateLimitOverride{
+				RequestsPerUnit: 10, Unit: pb_type.RateLimitUnit_UNKNOWN,
+			},
+		})
+	assert.NotNil(rl)
+	assert.Equal(pb.RateLimitResponse_RateLimit_SECOND, rl.Limit.Unit)
+
 	// Change in override value doesn't erase stats
 	rl = rlConfig.GetLimit(
 		context.TODO(), "test-domain",


### PR DESCRIPTION
## Description

When a client sends a gRPC `RateLimitRequest` with a descriptor limit override (`RateLimitOverride`) whose `unit` field is omitted or set to `UNKNOWN` (0), the server crashes with `panic: should not get here`.

The panic originates in `UnitToDivider()` (`src/utils/utilities.go`), which had no default case. The `UNKNOWN` unit flows from `GetLimit()` (`src/config/config_impl.go`), where the client-supplied override unit was trusted blindly and wrapped into a `RateLimit` without validation.

This is a denial-of-service vector: any caller of the rate limit service (e.g. Envoy, or a direct gRPC client) can crash the whole process with a single malformed request.

## Changes

- `src/config/config_impl.go`: `GetLimit()` now validates the override unit. If it is `UNKNOWN` (undefined), the invalid override is ignored with a warning and lookup falls back to the configured rate limit rules.
- `src/utils/utilities.go`: `UnitToDivider()` no longer panics on unknown units; it logs an error and returns a safe default (1 second) as defense in depth.
- `test/config/config_test.go`: regression test verifying an override with `UNKNOWN` unit is ignored and the configured limit is returned instead of panicking.

## Test Plan

- `go test ./src/...` passes.
- `go vet ./src/...` passes.
- `gofmt` clean.
- Manual reproduction confirmed the server previously crashed (`panic: should not get here`) and now continues serving when an undefined unit is sent.