### PR TITLE
feat: add redis_decay backend and soft-breach response header

### DIFF
--- a/src/redis_decay/cache_impl.go
+++ b/src/redis_decay/cache_impl.go
@@ -1,0 +1,139 @@
+// Package redis_decay implements limiter.RateLimitCache with a continuously
+// decaying counter (GCRA family) executed atomically in Redis via EVAL.
+// PLA-8128 fork probe: ports the production algorithm from depop-routing
+// common/openresty/lua/introspection/ratelimiting.lua. Unlike the fixed-window
+// backend there is no window timestamp in the cache key, so there is no
+// boundary at which the budget resets.
+package redis_decay
+
+import (
+	"io"
+	"math"
+	"strconv"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	logger "github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/src/limiter"
+	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/server"
+	"github.com/envoyproxy/ratelimit/src/settings"
+	"github.com/envoyproxy/ratelimit/src/utils"
+)
+
+// Counts are stored and returned as integer milli-counts so the existing
+// redis driver's uint64 result decoding can be reused unchanged.
+const decayScript = `
+local data = redis.call('GET', KEYS[1])
+local now = tonumber(ARGV[1])
+local period = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+local addend = tonumber(ARGV[4])
+local count = addend
+if data then
+  local sep = string.find(data, ':')
+  if sep then
+    local prev_ts = tonumber(string.sub(data, 1, sep-1))
+    local prev_count = tonumber(string.sub(data, sep+1))
+    if prev_ts and prev_count then
+      local passed = math.max(now - prev_ts, 0)
+      local unused = passed / period * limit * 1000.0
+      count = math.max(prev_count - unused, 0) + addend
+    end
+  end
+end
+redis.call('SET', KEYS[1], now .. ':' .. count, 'EX', math.ceil(period/1000))
+return math.floor(count)
+`
+
+type decayRateLimitCacheImpl struct {
+	client     redis.Client
+	timeSource utils.TimeSource
+	prefix     string
+}
+
+func NewDecayRateLimitCacheImpl(client redis.Client, timeSource utils.TimeSource, cacheKeyPrefix string) limiter.RateLimitCache {
+	return &decayRateLimitCacheImpl{client: client, timeSource: timeSource, prefix: cacheKeyPrefix}
+}
+
+// NewFromSettings mirrors redis.NewRateLimiterCacheImplFromSettings's client
+// construction (single pool; the per-second pool split is a fixed-window
+// optimization that does not apply to a decaying counter).
+func NewFromSettings(ctx context.Context, s settings.Settings, srv server.Server, timeSource utils.TimeSource) (limiter.RateLimitCache, io.Closer) {
+	client := redis.NewClientImpl(ctx, srv.Scope().Scope("redis_decay_pool"), s.RedisTls, s.RedisAuth, s.RedisSocketType,
+		s.RedisType, s.RedisUrl, s.RedisPoolSize,
+		s.RedisPipelineWindow, s.RedisPipelineLimit, s.RedisTlsConfig, s.RedisHealthCheckActiveConnection, srv, s.RedisTimeout,
+		s.RedisPoolOnEmptyBehavior, s.RedisSentinelAuth,
+		s.RedisStartupInitialInterval, s.RedisStartupMaxInterval, s.RedisStartupMaxElapsedTime,
+		s.RedisCloseConnectionOnReadOnlyError)
+	return NewDecayRateLimitCacheImpl(client, timeSource, s.CacheKeyPrefix), client
+}
+
+func (this *decayRateLimitCacheImpl) DoLimit(
+	ctx context.Context,
+	request *pb.RateLimitRequest,
+	limits []*config.RateLimit,
+) []*pb.RateLimitResponse_DescriptorStatus {
+	statuses := make([]*pb.RateLimitResponse_DescriptorStatus, len(request.Descriptors))
+	results := make([]uint64, len(request.Descriptors))
+	var pipeline redis.Pipeline
+
+	nowMs := this.timeSource.UnixNow() * 1000
+	hitsAddends := utils.GetHitsAddends(request)
+
+	for i, descriptor := range request.Descriptors {
+		statuses[i] = &pb.RateLimitResponse_DescriptorStatus{Code: pb.RateLimitResponse_OK, LimitRemaining: math.MaxUint32}
+		if limits[i] == nil {
+			continue
+		}
+		// Key without a window timestamp — the decaying value itself carries time.
+		key := this.prefix + "decay_" + request.Domain
+		for _, entry := range descriptor.Entries {
+			key += "_" + entry.Key + "_" + entry.Value
+		}
+		periodMs := utils.UnitToDivider(limits[i].Limit.Unit) * 1000
+		if pipeline == nil {
+			pipeline = redis.Pipeline{}
+		}
+		pipeline = this.client.PipeAppendWithRoutingKey(pipeline, key, &results[i], "EVAL", decayScript, 1, key,
+			strconv.FormatInt(nowMs, 10), strconv.FormatInt(periodMs, 10),
+			strconv.FormatInt(int64(limits[i].Limit.RequestsPerUnit), 10),
+			strconv.FormatUint(hitsAddends[i].Value*1000, 10))
+	}
+
+	if pipeline != nil {
+		if err := this.client.PipeDo(ctx, pipeline); err != nil {
+			logger.Errorf("redis_decay pipeline error (failing open): %v", err)
+			return statuses
+		}
+	}
+
+	for i := range request.Descriptors {
+		if limits[i] == nil {
+			continue
+		}
+		limit := uint64(limits[i].Limit.RequestsPerUnit)
+		countMilli := results[i]
+		count := countMilli / 1000
+		remaining := int64(limit) - int64(count)
+		if remaining < 0 {
+			remaining = 0
+		}
+		statuses[i].CurrentLimit = limits[i].Limit
+		statuses[i].LimitRemaining = uint32(remaining)
+		statuses[i].DurationUntilReset = &durationpb.Duration{Seconds: utils.UnitToDivider(limits[i].Limit.Unit)}
+		if countMilli > limit*1000 {
+			statuses[i].Code = pb.RateLimitResponse_OVER_LIMIT
+			limits[i].Stats.OverLimit.Add(1)
+		} else {
+			limits[i].Stats.WithinLimit.Add(1)
+		}
+		limits[i].Stats.TotalHits.Add(1)
+	}
+	return statuses
+}
+
+func (this *decayRateLimitCacheImpl) Flush() {}

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -33,6 +33,19 @@ import (
 
 var tracer = otel.Tracer("ratelimit")
 
+// PLA-8128 fork: soft-breach header threshold, 0 disables. Ratio semantics
+// match NEAR_LIMIT_RATIO (e.g. 0.7 = header once 70% of the budget is used).
+// Set from settings by the runner at startup via SetSoftBreachHeaderRatio.
+var softBreachHeaderRatio float64
+
+func SetSoftBreachHeaderRatio(ratio float64) {
+	if ratio > 0 && ratio < 1 {
+		softBreachHeaderRatio = ratio
+	} else {
+		softBreachHeaderRatio = 0
+	}
+}
+
 type RateLimitServiceServer interface {
 	pb.RateLimitServiceServer
 	GetCurrentConfig() (config.RateLimitConfig, bool, bool)
@@ -260,6 +273,25 @@ func (this *service) shouldRateLimitWorker(
 			this.rateLimitLimitHeader(minimumDescriptor),
 			this.rateLimitRemainingHeader(minimumDescriptor),
 			this.rateLimitResetHeader(minimumDescriptor),
+		}
+	}
+
+	// PLA-8128 fork: client-visible soft-breach signal. When the request is
+	// admitted but any checked descriptor is inside the soft band
+	// (remaining <= (1-ratio)*limit), emit a response header so downstream
+	// can degrade gracefully before a hard 429. Parity with depop-routing's
+	// rate_limit_soft_breached nginx variable.
+	if softBreachHeaderRatio > 0 && finalCode == pb.RateLimitResponse_OK {
+		for i, status := range response.Statuses {
+			if isUnlimited[i] || status.CurrentLimit == nil {
+				continue
+			}
+			softBand := float64(status.CurrentLimit.RequestsPerUnit) * (1 - softBreachHeaderRatio)
+			if float64(status.LimitRemaining) <= softBand {
+				response.ResponseHeadersToAdd = append(response.ResponseHeadersToAdd,
+					&core.HeaderValue{Key: "x-ratelimit-soft-breach", Value: "1"})
+				break
+			}
 		}
 	}
 

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/envoyproxy/ratelimit/src/memcached"
 	"github.com/envoyproxy/ratelimit/src/metrics"
 	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/redis_decay"
 	"github.com/envoyproxy/ratelimit/src/server"
 	ratelimit "github.com/envoyproxy/ratelimit/src/service"
 	"github.com/envoyproxy/ratelimit/src/settings"
@@ -108,6 +109,8 @@ func createLimiter(ctx context.Context, srv server.Server, s settings.Settings, 
 			s.ExpirationJitterMaxSeconds,
 			statsManager,
 		)
+	case "redis_decay":
+		return redis_decay.NewFromSettings(ctx, s, srv, utils.NewTimeSourceImpl())
 	case "memcache":
 		return memcached.NewRateLimitCacheImplFromSettings(
 			s,
@@ -193,6 +196,7 @@ func (runner *Runner) Run() {
 		}
 	}()
 
+	ratelimit.SetSoftBreachHeaderRatio(s.SoftBreachHeaderRatio)
 	service := ratelimit.NewService(
 		limiter,
 		srv.Provider(),

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -107,6 +107,7 @@ type Settings struct {
 	ExpirationJitterMaxSeconds         int64   `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
 	LocalCacheSizeInBytes              int     `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
 	NearLimitRatio                     float32 `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
+	SoftBreachHeaderRatio              float64 `envconfig:"SOFT_BREACH_HEADER_RATIO" default:"0"`
 	CacheKeyPrefix                     string  `envconfig:"CACHE_KEY_PREFIX" default:""`
 	BackendType                        string  `envconfig:"BACKEND_TYPE" default:"redis"`
 	StopCacheKeyIncrementWhenOverlimit bool    `envconfig:"STOP_CACHE_KEY_INCREMENT_WHEN_OVERLIMIT" default:"false"`

--- a/test/redis_decay/cache_impl_test.go
+++ b/test/redis_decay/cache_impl_test.go
@@ -1,0 +1,335 @@
+package redis_decay_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"github.com/golang/mock/gomock"
+	gostats "github.com/lyft/gostats"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/redis_decay"
+	"github.com/envoyproxy/ratelimit/test/common"
+	stats "github.com/envoyproxy/ratelimit/test/mocks/stats"
+	mock_utils "github.com/envoyproxy/ratelimit/test/mocks/utils"
+)
+
+func mustNewRedisServer() *miniredis.Miniredis {
+	srv, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	return srv
+}
+
+func mkClient(addr string) redis.Client {
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	return redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", addr, 1,
+		0, 0, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 100*time.Millisecond, false)
+}
+
+// Sunday-path: a fresh key admits the request and reports limit-1 remaining,
+// and the cache key carries no window timestamp (the property that makes the
+// boundary-burst impossible by construction).
+func TestFirstRequestAllowedAndKeyHasNoWindowTimestamp(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(9), statuses[0].LimitRemaining)
+	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(1), limits[0].Stats.WithinLimit.Value())
+
+	keys := rs.Keys()
+	assert.Len(keys, 1)
+	assert.Equal("decay_domain_key_value", keys[0])
+}
+
+// With time frozen there is no decay: exactly limit requests pass, the next is rejected.
+func TestExhaustionThenOverLimit(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	for i := 0; i < 10; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code, "request %d should be admitted", i+1)
+	}
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+	assert.Equal(uint32(0), statuses[0].LimitRemaining)
+	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
+}
+
+// The defining decay property: crossing a minute boundary right after
+// exhaustion does NOT grant a fresh budget (the fixed-window backend would).
+func TestNoBudgetResetAtWindowBoundary(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	// t0 is 2s before a minute boundary; the follow-up burst is 2s after it.
+	t0 := int64(1787061958)
+	timeSource.EXPECT().UnixNow().Return(t0).Times(11)
+	timeSource.EXPECT().UnixNow().Return(t0 + 4).Times(3)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	for i := 0; i < 11; i++ {
+		cache.DoLimit(context.Background(), request, limits)
+	}
+	// 4s elapsed decays only 4/60*10 = 0.67 of a token; still over on the far
+	// side of the boundary.
+	for i := 0; i < 3; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code, "burst request %d must stay rejected across the boundary", i+1)
+	}
+}
+
+// Budget returns gradually at limit/period, not all at once.
+func TestDecayRecovery(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	t0 := int64(1000)
+	timeSource.EXPECT().UnixNow().Return(t0).Times(10)
+	timeSource.EXPECT().UnixNow().Return(t0 + 30).Times(6)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	for i := 0; i < 10; i++ {
+		cache.DoLimit(context.Background(), request, limits)
+	}
+	// 30s at 10/min recovers 5 tokens: 5 admitted, the 6th rejected.
+	for i := 0; i < 5; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code, "recovered request %d should be admitted", i+1)
+	}
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+}
+
+// Rejected requests still increment the counter (parity with the production
+// Lua): a flood while over limit delays recovery.
+func TestRejectedRequestsConsumeBudget(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	t0 := int64(1000)
+	timeSource.EXPECT().UnixNow().Return(t0).Times(15)
+	timeSource.EXPECT().UnixNow().Return(t0 + 30).Times(1)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	// 10 admitted + 5 rejected leaves the counter at 15.
+	for i := 0; i < 15; i++ {
+		cache.DoLimit(context.Background(), request, limits)
+	}
+	// 30s decays 5: counter 10 + this request = 11 > 10, still rejected.
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+}
+
+// Corrupt stored data must reset cleanly, not crash or deny.
+func TestCorruptRedisDataResets(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	rs.Set("decay_domain_key_value", "not-a-decay-record")
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(9), statuses[0].LimitRemaining)
+}
+
+// A backwards clock step must not mint free budget (elapsed clamps to zero).
+func TestBackwardClockStepDoesNotMintBudget(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).Times(1)
+	timeSource.EXPECT().UnixNow().Return(int64(900)).Times(1)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	cache.DoLimit(context.Background(), request, limits)
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	// Second request must count on top of the first (remaining 8), not be
+	// treated as a fresh window (remaining 9).
+	assert.Equal(uint32(8), statuses[0].LimitRemaining)
+}
+
+// Descriptors with no configured limit are admitted without touching Redis.
+func TestNilLimitSkipped(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{nil}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(math.MaxUint32), statuses[0].LimitRemaining)
+	assert.Empty(rs.Keys())
+}
+
+// Two descriptors in one request are limited independently.
+func TestMultipleDescriptorsIndependent(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"keyA", "a"}}, {{"keyB", "b"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("keyA_a"), false, false, false, "", nil, false),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("keyB_b"), false, false, false, "", nil, false),
+	}
+
+	cache.DoLimit(context.Background(), request, limits)
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[1].Code)
+}
+
+// Redis being down fails open: requests are admitted, nothing panics.
+func TestRedisDownFailsOpen(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	client := mkClient(rs.Addr())
+	rs.Close()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(client, timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	assert.NotPanics(func() {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	})
+}
+
+// Envoy's hits_addend must be honored: one request can consume several hits.
+func TestHitsAddendConsumesMultipleTokens(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 5)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(5), statuses[0].LimitRemaining, "an addend of 5 must consume 5 tokens")
+
+	statuses = cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(0), statuses[0].LimitRemaining)
+
+	statuses = cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+}

--- a/test/service/soft_breach_test.go
+++ b/test/service/soft_breach_test.go
@@ -1,0 +1,137 @@
+package ratelimit_test
+
+import (
+	"testing"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"golang.org/x/net/context"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	ratelimit "github.com/envoyproxy/ratelimit/src/service"
+	"github.com/envoyproxy/ratelimit/test/common"
+)
+
+func hasSoftBreachHeader(headers []*core.HeaderValue) bool {
+	for _, h := range headers {
+		if h.Key == "x-ratelimit-soft-breach" {
+			return true
+		}
+	}
+	return false
+}
+
+// One admitted descriptor inside the soft band (remaining <= (1-ratio)*limit)
+// must add the soft-breach header.
+func TestSoftBreachHeaderEmittedInSoftBand(test *testing.T) {
+	ratelimit.SetSoftBreachHeaderRatio(0.7)
+	defer ratelimit.SetSoftBreachHeaderRatio(0)
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 3}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+	t.assert.True(hasSoftBreachHeader(response.ResponseHeadersToAdd), "remaining 3 of 10 at ratio 0.7 is inside the soft band")
+}
+
+// Plenty of budget left: no header.
+func TestSoftBreachHeaderAbsentBelowThreshold(test *testing.T) {
+	ratelimit.SetSoftBreachHeaderRatio(0.7)
+	defer ratelimit.SetSoftBreachHeaderRatio(0)
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.False(hasSoftBreachHeader(response.ResponseHeadersToAdd), "remaining 5 of 10 at ratio 0.7 is outside the soft band")
+}
+
+// A hard breach is not a soft breach: no header on OVER_LIMIT responses.
+func TestSoftBreachHeaderAbsentWhenOverLimit(test *testing.T) {
+	ratelimit.SetSoftBreachHeaderRatio(0.7)
+	defer ratelimit.SetSoftBreachHeaderRatio(0)
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OVER_LIMIT, response.OverallCode)
+	t.assert.False(hasSoftBreachHeader(response.ResponseHeadersToAdd))
+}
+
+// Feature off (ratio 0): never emit the header.
+func TestSoftBreachHeaderAbsentWhenDisabled(test *testing.T) {
+	ratelimit.SetSoftBreachHeaderRatio(0)
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 1}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.False(hasSoftBreachHeader(response.ResponseHeadersToAdd))
+}
+
+// Lua parity: the LAST admitted request (remaining 0, still OK) is a soft
+// breach — depop-routing flags count > soft while count <= limit, which
+// includes the request that lands exactly on the limit.
+func TestSoftBreachHeaderOnLastAdmittedRequest(test *testing.T) {
+	ratelimit.SetSoftBreachHeaderRatio(0.7)
+	defer ratelimit.SetSoftBreachHeaderRatio(0)
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 0}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+	t.assert.True(hasSoftBreachHeader(response.ResponseHeadersToAdd), "an admitted request with 0 remaining is a soft breach (Lua parity)")
+}


### PR DESCRIPTION
Adds BACKEND_TYPE=redis_decay: a continuously-decaying counter (GCRA family) executed as an atomic Redis EVAL. Unlike the fixed-window redis backend, cache keys carry no window timestamp, so budgets never reset at a boundary and the 2x boundary-burst is impossible by construction. Honors per-descriptor hits_addend. Fail-open on Redis errors. Cluster-safe: EVAL routes by cache key.

Also adds SOFT_BREACH_HEADER_RATIO: when set (0..1), admitted requests whose remaining budget falls inside the soft band get an x-ratelimit-soft-breach: 1 response header, so clients can degrade before hard 429s. Computed generically from CurrentLimit/LimitRemaining, so it works with any cache backend.

Covered by test/redis_decay (real EVAL execution on miniredis: boundary immunity, decay recovery, flood behavior, corrupt data, backward clock, fail-open, hits_addend) and test/service/soft_breach_test.go. All existing tests pass.

Load-tested on Istio 1.30 / Gateway API: 3,950 rps sustained on one replica, +2.3ms p50 overhead, exact admission under concurrency.

Refs envoyproxy/ratelimit#32 (rolling window request, open since 2018).