### PR TITLE
feat: add redis_decay backend and soft-breach response header

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -18,15 +18,19 @@ func (e RateLimitConfigError) Error() string {
 
 // Wrapper for an individual rate limit config entry which includes the defined limit and stats.
 type RateLimit struct {
-	FullKey        string
-	Stats          stats.RateLimitStats
-	Limit          *pb.RateLimitResponse_RateLimit
-	Unlimited      bool
-	ShadowMode     bool
-	QuotaMode      bool
-	Name           string
-	Replaces       []string
-	DetailedMetric bool
+	FullKey string
+	Stats   stats.RateLimitStats
+	Limit   *pb.RateLimitResponse_RateLimit
+	// SoftRequestsPerUnit is a threshold below Limit.RequestsPerUnit. Requests
+	// above it are admitted but flagged upstream via a soft-breach header.
+	// Zero means no soft threshold for this descriptor.
+	SoftRequestsPerUnit uint32
+	Unlimited           bool
+	ShadowMode          bool
+	QuotaMode           bool
+	Name                string
+	Replaces            []string
+	DetailedMetric      bool
 	// ShareThresholdKeyPattern is a slice of wildcard patterns for descriptor entries
 	// The slice index corresponds to the descriptor entry index.
 	ShareThresholdKeyPattern []string

--- a/src/config/config_impl.go
+++ b/src/config/config_impl.go
@@ -20,10 +20,14 @@ type yamlReplaces struct {
 
 type YamlRateLimit struct {
 	RequestsPerUnit uint32 `yaml:"requests_per_unit"`
-	Unit            string
-	Unlimited       bool `yaml:"unlimited"`
-	Name            string
-	Replaces        []yamlReplaces
+	// SoftRequestsPerUnit, when non-zero, marks a threshold below the hard limit.
+	// Requests above it are still admitted but carry a soft-breach header upstream
+	// so the backend can degrade before clients start seeing 429s. Zero disables it.
+	SoftRequestsPerUnit uint32 `yaml:"soft_requests_per_unit"`
+	Unit                string
+	Unlimited           bool `yaml:"unlimited"`
+	Name                string
+	Replaces            []yamlReplaces
 }
 
 type YamlDescriptor struct {
@@ -72,22 +76,23 @@ type rateLimitConfigImpl struct {
 }
 
 var validKeys = map[string]bool{
-	"domain":            true,
-	"key":               true,
-	"value":             true,
-	"descriptors":       true,
-	"rate_limit":        true,
-	"unit":              true,
-	"requests_per_unit": true,
-	"unlimited":         true,
-	"shadow_mode":       true,
-	"quota_mode":        true,
-	"name":              true,
-	"replaces":          true,
-	"detailed_metric":   true,
-	"value_to_metric":   true,
-	"share_threshold":   true,
-	"metadata":          true,
+	"domain":                 true,
+	"key":                    true,
+	"value":                  true,
+	"descriptors":            true,
+	"rate_limit":             true,
+	"unit":                   true,
+	"requests_per_unit":      true,
+	"soft_requests_per_unit": true,
+	"unlimited":              true,
+	"shadow_mode":            true,
+	"quota_mode":             true,
+	"name":                   true,
+	"replaces":               true,
+	"detailed_metric":        true,
+	"value_to_metric":        true,
+	"share_threshold":        true,
+	"metadata":               true,
 }
 
 // Create a new rate limit config entry.
@@ -290,9 +295,15 @@ func (this *rateLimitDescriptor) loadDescriptors(config RateLimitConfigToLoad, p
 				statsManager.NewStats(newParentKey), unlimited, descriptorConfig.ShadowMode, descriptorConfig.QuotaMode,
 				descriptorConfig.RateLimit.Name, replaces, descriptorConfig.DetailedMetric,
 			)
+			rateLimit.SoftRequestsPerUnit = descriptorConfig.RateLimit.SoftRequestsPerUnit
+			if rateLimit.SoftRequestsPerUnit >= rateLimit.Limit.RequestsPerUnit && rateLimit.SoftRequestsPerUnit != 0 {
+				panic(newRateLimitConfigError(
+					config.Name,
+					"soft_requests_per_unit must be below requests_per_unit"))
+			}
 			rateLimitDebugString = fmt.Sprintf(
-				" ratelimit={requests_per_unit=%d, unit=%s, unlimited=%t, shadow_mode=%t, quota_mode=%t}", rateLimit.Limit.RequestsPerUnit,
-				rateLimit.Limit.Unit.String(), rateLimit.Unlimited, rateLimit.ShadowMode, rateLimit.QuotaMode)
+				" ratelimit={requests_per_unit=%d, soft_requests_per_unit=%d, unit=%s, unlimited=%t, shadow_mode=%t, quota_mode=%t}", rateLimit.Limit.RequestsPerUnit,
+				rateLimit.SoftRequestsPerUnit, rateLimit.Limit.Unit.String(), rateLimit.Unlimited, rateLimit.ShadowMode, rateLimit.QuotaMode)
 
 			for _, replaces := range descriptorConfig.RateLimit.Replaces {
 				if replaces.Name == "" {
@@ -578,15 +589,16 @@ func (this *rateLimitConfigImpl) GetLimit(
 				// Create a copy of the rate limit to avoid modifying the shared object
 				originalLimit := nextDescriptor.limit
 				rateLimit = &RateLimit{
-					FullKey:        originalLimit.FullKey,
-					Stats:          originalLimit.Stats,
-					Limit:          originalLimit.Limit,
-					Unlimited:      originalLimit.Unlimited,
-					ShadowMode:     originalLimit.ShadowMode,
-					QuotaMode:      originalLimit.QuotaMode,
-					Name:           originalLimit.Name,
-					Replaces:       originalLimit.Replaces,
-					DetailedMetric: originalLimit.DetailedMetric,
+					FullKey:             originalLimit.FullKey,
+					Stats:               originalLimit.Stats,
+					Limit:               originalLimit.Limit,
+					SoftRequestsPerUnit: originalLimit.SoftRequestsPerUnit,
+					Unlimited:           originalLimit.Unlimited,
+					ShadowMode:          originalLimit.ShadowMode,
+					QuotaMode:           originalLimit.QuotaMode,
+					Name:                originalLimit.Name,
+					Replaces:            originalLimit.Replaces,
+					DetailedMetric:      originalLimit.DetailedMetric,
 					// Initialize ShareThresholdKeyPattern with correct length, empty strings for entries without share_threshold
 					ShareThresholdKeyPattern: nil,
 					Metadata:                 nextDescriptor.metadata,
@@ -614,7 +626,9 @@ func (this *rateLimitConfigImpl) GetLimit(
 			if rateLimit != nil && rateLimit.DetailedMetric {
 				// Preserve ShareThresholdKeyPattern when recreating rate limit
 				originalShareThresholdKeyPattern := rateLimit.ShareThresholdKeyPattern
+				soft := rateLimit.SoftRequestsPerUnit
 				rateLimit = NewRateLimit(rateLimit.Limit.RequestsPerUnit, rateLimit.Limit.Unit, this.statsManager.NewStats(rateLimit.FullKey), rateLimit.Unlimited, rateLimit.ShadowMode, rateLimit.QuotaMode, rateLimit.Name, rateLimit.Replaces, rateLimit.DetailedMetric)
+				rateLimit.SoftRequestsPerUnit = soft
 				rateLimit.ShareThresholdKeyPattern = originalShareThresholdKeyPattern
 			}
 
@@ -664,7 +678,9 @@ func (this *rateLimitConfigImpl) GetLimit(
 		if enhancedKey != rateLimit.FullKey {
 			// Recreate to ensure a clean stats struct, then set to enhanced stats
 			originalShareThresholdKeyPattern := rateLimit.ShareThresholdKeyPattern
+			soft := rateLimit.SoftRequestsPerUnit
 			rateLimit = NewRateLimit(rateLimit.Limit.RequestsPerUnit, rateLimit.Limit.Unit, this.statsManager.NewStats(enhancedKey), rateLimit.Unlimited, rateLimit.ShadowMode, rateLimit.QuotaMode, rateLimit.Name, rateLimit.Replaces, rateLimit.DetailedMetric)
+			rateLimit.SoftRequestsPerUnit = soft
 			rateLimit.ShareThresholdKeyPattern = originalShareThresholdKeyPattern
 		}
 	}

--- a/src/redis_decay/cache_impl.go
+++ b/src/redis_decay/cache_impl.go
@@ -70,6 +70,13 @@ func NewFromSettings(ctx context.Context, s settings.Settings, srv server.Server
 	return NewDecayRateLimitCacheImpl(client, timeSource, s.CacheKeyPrefix), client
 }
 
+// allowlistKeys names the descriptor-entry keys PLA-8129 lets an operator
+// exempt at runtime, one Redis SET per key: SADD allowlist:<name> <value>
+// takes effect on the very next request — no deploy, no EnvoyFilter apply.
+// This replaces the compiled-in Lua tables (IP_ALLOWLIST / USER_ID_ALLOWLIST)
+// that were the PLA-8129 gap: a config change was still a deploy.
+var allowlistKeys = map[string]bool{"rl_ip": true, "rl_ua": true, "rl_subject": true}
+
 func (this *decayRateLimitCacheImpl) DoLimit(
 	ctx context.Context,
 	request *pb.RateLimitRequest,
@@ -77,14 +84,79 @@ func (this *decayRateLimitCacheImpl) DoLimit(
 ) []*pb.RateLimitResponse_DescriptorStatus {
 	statuses := make([]*pb.RateLimitResponse_DescriptorStatus, len(request.Descriptors))
 	results := make([]uint64, len(request.Descriptors))
-	var pipeline redis.Pipeline
+	allowlisted := make([]bool, len(request.Descriptors))
 
 	nowMs := this.timeSource.UnixNow() * 1000
 	hitsAddends := utils.GetHitsAddends(request)
 
+	// Phase 1: one round trip checking every allowlist-eligible VALUE seen
+	// anywhere in the request against its own live Redis SET. Runs before any
+	// decay counter is touched, so an allowlisted caller never increments a
+	// bucket it will be exempted from.
+	//
+	// The three allowlists are NOT symmetric — matching ratelimiting.lua
+	// exactly (ip_rate_limit_with_pooling / user_agent_rate_limit_with_pooling
+	// / auth_rate_limit_with_pooling, :204-253):
+	//   - an allowlisted IP exempts ip, ua AND subject together
+	//   - an allowlisted user-agent or user-id exempts only its own bucket
+	//   - client_id is never exempted by any allowlist
+	// A per-descriptor-only check (allowlist this descriptor iff its own key
+	// is allowlisted) reproduces the second and third rules but silently
+	// drops the first — the cross-bucket IP exemption is a request-level
+	// correlation, not a per-descriptor one. So this collects each key's
+	// VALUE from wherever it appears in the request first, then applies the
+	// exemption rule per descriptor type afterward.
+	values := map[string]string{}
+	for i, descriptor := range request.Descriptors {
+		if limits[i] == nil {
+			continue
+		}
+		for _, entry := range descriptor.Entries {
+			if allowlistKeys[entry.Key] {
+				values[entry.Key] = entry.Value
+			}
+		}
+	}
+	membership := map[string]*uint64{}
+	var checkPipeline redis.Pipeline
+	for key, value := range values {
+		var res uint64
+		membership[key] = &res
+		if checkPipeline == nil {
+			checkPipeline = redis.Pipeline{}
+		}
+		checkPipeline = this.client.PipeAppend(checkPipeline, &res, "SISMEMBER",
+			this.prefix+"allowlist:"+key, value)
+	}
+	if checkPipeline != nil {
+		if err := this.client.PipeDo(ctx, checkPipeline); err != nil {
+			// Same policy as a decay-pipeline failure: surface it rather than
+			// silently treating everyone as allowlisted or as not allowlisted.
+			panic(redis.RedisError(err.Error()))
+		}
+	}
+	ipAllowed := membership["rl_ip"] != nil && *membership["rl_ip"] == 1
+	for i, descriptor := range request.Descriptors {
+		if limits[i] == nil {
+			continue
+		}
+		for _, entry := range descriptor.Entries {
+			switch entry.Key {
+			case "rl_ip":
+				allowlisted[i] = ipAllowed
+			case "rl_ua":
+				allowlisted[i] = ipAllowed || (membership["rl_ua"] != nil && *membership["rl_ua"] == 1)
+			case "rl_subject":
+				allowlisted[i] = ipAllowed || (membership["rl_subject"] != nil && *membership["rl_subject"] == 1)
+			}
+		}
+	}
+
+	var pipeline redis.Pipeline
+
 	for i, descriptor := range request.Descriptors {
 		statuses[i] = &pb.RateLimitResponse_DescriptorStatus{Code: pb.RateLimitResponse_OK, LimitRemaining: math.MaxUint32}
-		if limits[i] == nil {
+		if limits[i] == nil || allowlisted[i] {
 			continue
 		}
 		// Key without a window timestamp — the decaying value itself carries time.
@@ -113,7 +185,7 @@ func (this *decayRateLimitCacheImpl) DoLimit(
 	}
 
 	for i := range request.Descriptors {
-		if limits[i] == nil {
+		if limits[i] == nil || allowlisted[i] {
 			continue
 		}
 		limit := uint64(limits[i].Limit.RequestsPerUnit)

--- a/src/redis_decay/cache_impl.go
+++ b/src/redis_decay/cache_impl.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
-	logger "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -105,8 +104,11 @@ func (this *decayRateLimitCacheImpl) DoLimit(
 
 	if pipeline != nil {
 		if err := this.client.PipeDo(ctx, pipeline); err != nil {
-			logger.Errorf("redis_decay pipeline error (failing open): %v", err)
-			return statuses
+			// Surface the failure exactly as the fixed-window backend does: the
+			// service layer recovers it, increments the RedisError stat, and the
+			// caller's configured failure-mode policy decides whether to admit.
+			// Returning OK here would hide the outage and override that policy.
+			panic(redis.RedisError(err.Error()))
 		}
 	}
 

--- a/src/redis_decay/cache_impl.go
+++ b/src/redis_decay/cache_impl.go
@@ -1,0 +1,140 @@
+// Package redis_decay implements limiter.RateLimitCache with a continuously
+// decaying counter (GCRA family) executed atomically in Redis via EVAL.
+// Unlike the fixed-window backend there is no window timestamp in the cache
+// key, so there is no boundary at which the budget resets and the classic
+// 2x boundary-burst cannot occur (see issue #32).
+package redis_decay
+
+import (
+	"io"
+	"math"
+	"strconv"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"golang.org/x/net/context"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/src/limiter"
+	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/server"
+	"github.com/envoyproxy/ratelimit/src/settings"
+	"github.com/envoyproxy/ratelimit/src/utils"
+)
+
+// Counts are stored and returned as integer milli-counts so the existing
+// redis driver's uint64 result decoding can be reused unchanged.
+const decayScript = `
+local data = redis.call('GET', KEYS[1])
+local now = tonumber(ARGV[1])
+local period = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+local addend = tonumber(ARGV[4])
+local count = addend
+if data then
+  local sep = string.find(data, ':')
+  if sep then
+    local prev_ts = tonumber(string.sub(data, 1, sep-1))
+    local prev_count = tonumber(string.sub(data, sep+1))
+    if prev_ts and prev_count then
+      local passed = math.max(now - prev_ts, 0)
+      local unused = passed / period * limit * 1000.0
+      count = math.max(prev_count - unused, 0) + addend
+    end
+  end
+end
+redis.call('SET', KEYS[1], now .. ':' .. count, 'EX', math.ceil(period/1000))
+return math.floor(count)
+`
+
+type decayRateLimitCacheImpl struct {
+	client     redis.Client
+	timeSource utils.TimeSource
+	prefix     string
+}
+
+func NewDecayRateLimitCacheImpl(client redis.Client, timeSource utils.TimeSource, cacheKeyPrefix string) limiter.RateLimitCache {
+	return &decayRateLimitCacheImpl{client: client, timeSource: timeSource, prefix: cacheKeyPrefix}
+}
+
+// NewFromSettings mirrors redis.NewRateLimiterCacheImplFromSettings's client
+// construction (single pool; the per-second pool split is a fixed-window
+// optimization that does not apply to a decaying counter).
+func NewFromSettings(ctx context.Context, s settings.Settings, srv server.Server, timeSource utils.TimeSource) (limiter.RateLimitCache, io.Closer) {
+	client := redis.NewClientImpl(ctx, srv.Scope().Scope("redis_decay_pool"), s.RedisTls, s.RedisAuth, s.RedisSocketType,
+		s.RedisType, s.RedisUrl, s.RedisPoolSize,
+		s.RedisPipelineWindow, s.RedisPipelineLimit, s.RedisTlsConfig, s.RedisHealthCheckActiveConnection, srv, s.RedisTimeout,
+		s.RedisPoolOnEmptyBehavior, s.RedisSentinelAuth,
+		s.RedisStartupInitialInterval, s.RedisStartupMaxInterval, s.RedisStartupMaxElapsedTime,
+		s.RedisCloseConnectionOnReadOnlyError)
+	return NewDecayRateLimitCacheImpl(client, timeSource, s.CacheKeyPrefix), client
+}
+
+func (this *decayRateLimitCacheImpl) DoLimit(
+	ctx context.Context,
+	request *pb.RateLimitRequest,
+	limits []*config.RateLimit,
+) []*pb.RateLimitResponse_DescriptorStatus {
+	statuses := make([]*pb.RateLimitResponse_DescriptorStatus, len(request.Descriptors))
+	results := make([]uint64, len(request.Descriptors))
+	var pipeline redis.Pipeline
+
+	nowMs := this.timeSource.UnixNow() * 1000
+	hitsAddends := utils.GetHitsAddends(request)
+
+	for i, descriptor := range request.Descriptors {
+		statuses[i] = &pb.RateLimitResponse_DescriptorStatus{Code: pb.RateLimitResponse_OK, LimitRemaining: math.MaxUint32}
+		if limits[i] == nil {
+			continue
+		}
+		// Key without a window timestamp — the decaying value itself carries time.
+		key := this.prefix + "decay_" + request.Domain
+		for _, entry := range descriptor.Entries {
+			key += "_" + entry.Key + "_" + entry.Value
+		}
+		periodMs := utils.UnitToDivider(limits[i].Limit.Unit) * 1000
+		if pipeline == nil {
+			pipeline = redis.Pipeline{}
+		}
+		pipeline = this.client.PipeAppendWithRoutingKey(pipeline, key, &results[i], "EVAL", decayScript, 1, key,
+			strconv.FormatInt(nowMs, 10), strconv.FormatInt(periodMs, 10),
+			strconv.FormatInt(int64(limits[i].Limit.RequestsPerUnit), 10),
+			strconv.FormatUint(hitsAddends[i].Value*1000, 10))
+	}
+
+	if pipeline != nil {
+		if err := this.client.PipeDo(ctx, pipeline); err != nil {
+			// Surface the failure exactly as the fixed-window backend does: the
+			// service layer recovers it, increments the RedisError stat, and the
+			// caller's configured failure-mode policy decides whether to admit.
+			// Returning OK here would hide the outage and override that policy.
+			panic(redis.RedisError(err.Error()))
+		}
+	}
+
+	for i := range request.Descriptors {
+		if limits[i] == nil {
+			continue
+		}
+		limit := uint64(limits[i].Limit.RequestsPerUnit)
+		countMilli := results[i]
+		count := countMilli / 1000
+		remaining := int64(limit) - int64(count)
+		if remaining < 0 {
+			remaining = 0
+		}
+		statuses[i].CurrentLimit = limits[i].Limit
+		statuses[i].LimitRemaining = uint32(remaining)
+		statuses[i].DurationUntilReset = &durationpb.Duration{Seconds: utils.UnitToDivider(limits[i].Limit.Unit)}
+		if countMilli > limit*1000 {
+			statuses[i].Code = pb.RateLimitResponse_OVER_LIMIT
+			limits[i].Stats.OverLimit.Add(1)
+		} else {
+			limits[i].Stats.WithinLimit.Add(1)
+		}
+		limits[i].Stats.TotalHits.Add(1)
+	}
+	return statuses
+}
+
+func (this *decayRateLimitCacheImpl) Flush() {}

--- a/src/redis_decay/cache_impl.go
+++ b/src/redis_decay/cache_impl.go
@@ -1,0 +1,138 @@
+// Package redis_decay implements limiter.RateLimitCache with a continuously
+// decaying counter (GCRA family) executed atomically in Redis via EVAL.
+// Unlike the fixed-window backend there is no window timestamp in the cache
+// key, so there is no boundary at which the budget resets and the classic
+// 2x boundary-burst cannot occur (see issue #32).
+package redis_decay
+
+import (
+	"io"
+	"math"
+	"strconv"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	logger "github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/src/limiter"
+	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/server"
+	"github.com/envoyproxy/ratelimit/src/settings"
+	"github.com/envoyproxy/ratelimit/src/utils"
+)
+
+// Counts are stored and returned as integer milli-counts so the existing
+// redis driver's uint64 result decoding can be reused unchanged.
+const decayScript = `
+local data = redis.call('GET', KEYS[1])
+local now = tonumber(ARGV[1])
+local period = tonumber(ARGV[2])
+local limit = tonumber(ARGV[3])
+local addend = tonumber(ARGV[4])
+local count = addend
+if data then
+  local sep = string.find(data, ':')
+  if sep then
+    local prev_ts = tonumber(string.sub(data, 1, sep-1))
+    local prev_count = tonumber(string.sub(data, sep+1))
+    if prev_ts and prev_count then
+      local passed = math.max(now - prev_ts, 0)
+      local unused = passed / period * limit * 1000.0
+      count = math.max(prev_count - unused, 0) + addend
+    end
+  end
+end
+redis.call('SET', KEYS[1], now .. ':' .. count, 'EX', math.ceil(period/1000))
+return math.floor(count)
+`
+
+type decayRateLimitCacheImpl struct {
+	client     redis.Client
+	timeSource utils.TimeSource
+	prefix     string
+}
+
+func NewDecayRateLimitCacheImpl(client redis.Client, timeSource utils.TimeSource, cacheKeyPrefix string) limiter.RateLimitCache {
+	return &decayRateLimitCacheImpl{client: client, timeSource: timeSource, prefix: cacheKeyPrefix}
+}
+
+// NewFromSettings mirrors redis.NewRateLimiterCacheImplFromSettings's client
+// construction (single pool; the per-second pool split is a fixed-window
+// optimization that does not apply to a decaying counter).
+func NewFromSettings(ctx context.Context, s settings.Settings, srv server.Server, timeSource utils.TimeSource) (limiter.RateLimitCache, io.Closer) {
+	client := redis.NewClientImpl(ctx, srv.Scope().Scope("redis_decay_pool"), s.RedisTls, s.RedisAuth, s.RedisSocketType,
+		s.RedisType, s.RedisUrl, s.RedisPoolSize,
+		s.RedisPipelineWindow, s.RedisPipelineLimit, s.RedisTlsConfig, s.RedisHealthCheckActiveConnection, srv, s.RedisTimeout,
+		s.RedisPoolOnEmptyBehavior, s.RedisSentinelAuth,
+		s.RedisStartupInitialInterval, s.RedisStartupMaxInterval, s.RedisStartupMaxElapsedTime,
+		s.RedisCloseConnectionOnReadOnlyError)
+	return NewDecayRateLimitCacheImpl(client, timeSource, s.CacheKeyPrefix), client
+}
+
+func (this *decayRateLimitCacheImpl) DoLimit(
+	ctx context.Context,
+	request *pb.RateLimitRequest,
+	limits []*config.RateLimit,
+) []*pb.RateLimitResponse_DescriptorStatus {
+	statuses := make([]*pb.RateLimitResponse_DescriptorStatus, len(request.Descriptors))
+	results := make([]uint64, len(request.Descriptors))
+	var pipeline redis.Pipeline
+
+	nowMs := this.timeSource.UnixNow() * 1000
+	hitsAddends := utils.GetHitsAddends(request)
+
+	for i, descriptor := range request.Descriptors {
+		statuses[i] = &pb.RateLimitResponse_DescriptorStatus{Code: pb.RateLimitResponse_OK, LimitRemaining: math.MaxUint32}
+		if limits[i] == nil {
+			continue
+		}
+		// Key without a window timestamp — the decaying value itself carries time.
+		key := this.prefix + "decay_" + request.Domain
+		for _, entry := range descriptor.Entries {
+			key += "_" + entry.Key + "_" + entry.Value
+		}
+		periodMs := utils.UnitToDivider(limits[i].Limit.Unit) * 1000
+		if pipeline == nil {
+			pipeline = redis.Pipeline{}
+		}
+		pipeline = this.client.PipeAppendWithRoutingKey(pipeline, key, &results[i], "EVAL", decayScript, 1, key,
+			strconv.FormatInt(nowMs, 10), strconv.FormatInt(periodMs, 10),
+			strconv.FormatInt(int64(limits[i].Limit.RequestsPerUnit), 10),
+			strconv.FormatUint(hitsAddends[i].Value*1000, 10))
+	}
+
+	if pipeline != nil {
+		if err := this.client.PipeDo(ctx, pipeline); err != nil {
+			logger.Errorf("redis_decay pipeline error (failing open): %v", err)
+			return statuses
+		}
+	}
+
+	for i := range request.Descriptors {
+		if limits[i] == nil {
+			continue
+		}
+		limit := uint64(limits[i].Limit.RequestsPerUnit)
+		countMilli := results[i]
+		count := countMilli / 1000
+		remaining := int64(limit) - int64(count)
+		if remaining < 0 {
+			remaining = 0
+		}
+		statuses[i].CurrentLimit = limits[i].Limit
+		statuses[i].LimitRemaining = uint32(remaining)
+		statuses[i].DurationUntilReset = &durationpb.Duration{Seconds: utils.UnitToDivider(limits[i].Limit.Unit)}
+		if countMilli > limit*1000 {
+			statuses[i].Code = pb.RateLimitResponse_OVER_LIMIT
+			limits[i].Stats.OverLimit.Add(1)
+		} else {
+			limits[i].Stats.WithinLimit.Add(1)
+		}
+		limits[i].Stats.TotalHits.Add(1)
+	}
+	return statuses
+}
+
+func (this *decayRateLimitCacheImpl) Flush() {}

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -38,6 +38,9 @@ var tracer = otel.Tracer("ratelimit")
 // before clients start seeing 429s.
 const softBreachHeaderName = "x-ratelimit-soft-breached"
 
+// Standard back-off header returned to the client on a hard breach.
+const retryAfterHeaderName = "retry-after"
+
 type RateLimitServiceServer interface {
 	pb.RateLimitServiceServer
 	GetCurrentConfig() (config.RateLimitConfig, bool, bool)
@@ -52,6 +55,7 @@ type service struct {
 	stats                          stats.ServiceStats
 	health                         *server.HealthChecker
 	customHeadersEnabled           bool
+	retryAfterEnabled              bool
 	customHeaderLimitHeader        string
 	customHeaderRemainingHeader    string
 	customHeaderResetHeader        string
@@ -95,6 +99,7 @@ func (this *service) SetConfig(updateEvent provider.ConfigUpdateEvent, healthyWi
 	this.globalShadowMode = rlSettings.GlobalShadowMode
 	this.globalQuotaMode = rlSettings.GlobalQuotaMode
 	this.responseDynamicMetadataEnabled = rlSettings.ResponseDynamicMetadata
+	this.retryAfterEnabled = rlSettings.RetryAfterHeaderEnabled
 
 	if rlSettings.RateLimitResponseHeadersEnabled {
 		this.customHeadersEnabled = true
@@ -295,6 +300,27 @@ func (this *service) shouldRateLimitWorker(
 	if finalCode == pb.RateLimitResponse_OVER_LIMIT && globalShadowMode {
 		finalCode = pb.RateLimitResponse_OK
 		this.stats.GlobalShadowMode.Inc()
+	}
+
+	// Retry-After on a hard breach, carrying the breaching descriptor's own
+	// period in seconds. Placed after the global shadow-mode conversion above:
+	// a shadowed breach is admitted, so telling the client to back off would be
+	// wrong. Opt-in, so existing deployments see no response-shape change.
+	if this.retryAfterEnabled && finalCode == pb.RateLimitResponse_OVER_LIMIT {
+		for i, status := range response.Statuses {
+			if status.Code != pb.RateLimitResponse_OVER_LIMIT || status.CurrentLimit == nil {
+				continue
+			}
+			if limitsToCheck[i] != nil && limitsToCheck[i].ShadowMode {
+				continue
+			}
+			response.ResponseHeadersToAdd = append(response.ResponseHeadersToAdd,
+				&core.HeaderValue{
+					Key:   retryAfterHeaderName,
+					Value: strconv.FormatInt(utils.UnitToDivider(status.CurrentLimit.Unit), 10),
+				})
+			break
+		}
 	}
 
 	// If response dynamic data enabled, set dynamic data on response.

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -33,18 +33,10 @@ import (
 
 var tracer = otel.Tracer("ratelimit")
 
-// Soft-breach header threshold, 0 disables. Ratio semantics
-// match NEAR_LIMIT_RATIO (e.g. 0.7 = header once 70% of the budget is used).
-// Set from settings by the runner at startup via SetSoftBreachHeaderRatio.
-var softBreachHeaderRatio float64
-
-func SetSoftBreachHeaderRatio(ratio float64) {
-	if ratio > 0 && ratio < 1 {
-		softBreachHeaderRatio = ratio
-	} else {
-		softBreachHeaderRatio = 0
-	}
-}
+// Header added to the UPSTREAM request when an admitted request is above a
+// descriptor's soft_requests_per_unit threshold, so the backend can degrade
+// before clients start seeing 429s.
+const softBreachHeaderName = "x-ratelimit-soft-breached"
 
 type RateLimitServiceServer interface {
 	pb.RateLimitServiceServer
@@ -276,19 +268,24 @@ func (this *service) shouldRateLimitWorker(
 		}
 	}
 
-	// Client-visible soft-breach signal. When the request is admitted but
-	// any checked descriptor is inside the soft band
-	// (remaining <= (1-ratio)*limit), emit a response header so downstream
-	// can degrade gracefully before a hard 429.
-	if softBreachHeaderRatio > 0 && finalCode == pb.RateLimitResponse_OK {
+	// Soft-breach signal. When the request is admitted but a descriptor that
+	// configures soft_requests_per_unit is above that threshold, flag it to the
+	// UPSTREAM service so it can degrade before clients start seeing 429s.
+	// Only descriptors carrying a soft threshold participate; the rest can
+	// never soft-breach.
+	if finalCode == pb.RateLimitResponse_OK {
 		for i, status := range response.Statuses {
-			if isUnlimited[i] || status.CurrentLimit == nil {
+			if isUnlimited[i] || status.CurrentLimit == nil || limitsToCheck[i] == nil {
 				continue
 			}
-			softBand := float64(status.CurrentLimit.RequestsPerUnit) * (1 - softBreachHeaderRatio)
-			if float64(status.LimitRemaining) <= softBand {
-				response.ResponseHeadersToAdd = append(response.ResponseHeadersToAdd,
-					&core.HeaderValue{Key: "x-ratelimit-soft-breach", Value: "1"})
+			soft := limitsToCheck[i].SoftRequestsPerUnit
+			if soft == 0 {
+				continue
+			}
+			used := status.CurrentLimit.RequestsPerUnit - status.LimitRemaining
+			if used > soft {
+				response.RequestHeadersToAdd = append(response.RequestHeadersToAdd,
+					&core.HeaderValue{Key: softBreachHeaderName, Value: "1"})
 				break
 			}
 		}

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -33,6 +33,19 @@ import (
 
 var tracer = otel.Tracer("ratelimit")
 
+// Soft-breach header threshold, 0 disables. Ratio semantics
+// match NEAR_LIMIT_RATIO (e.g. 0.7 = header once 70% of the budget is used).
+// Set from settings by the runner at startup via SetSoftBreachHeaderRatio.
+var softBreachHeaderRatio float64
+
+func SetSoftBreachHeaderRatio(ratio float64) {
+	if ratio > 0 && ratio < 1 {
+		softBreachHeaderRatio = ratio
+	} else {
+		softBreachHeaderRatio = 0
+	}
+}
+
 type RateLimitServiceServer interface {
 	pb.RateLimitServiceServer
 	GetCurrentConfig() (config.RateLimitConfig, bool, bool)
@@ -260,6 +273,24 @@ func (this *service) shouldRateLimitWorker(
 			this.rateLimitLimitHeader(minimumDescriptor),
 			this.rateLimitRemainingHeader(minimumDescriptor),
 			this.rateLimitResetHeader(minimumDescriptor),
+		}
+	}
+
+	// Client-visible soft-breach signal. When the request is admitted but
+	// any checked descriptor is inside the soft band
+	// (remaining <= (1-ratio)*limit), emit a response header so downstream
+	// can degrade gracefully before a hard 429.
+	if softBreachHeaderRatio > 0 && finalCode == pb.RateLimitResponse_OK {
+		for i, status := range response.Statuses {
+			if isUnlimited[i] || status.CurrentLimit == nil {
+				continue
+			}
+			softBand := float64(status.CurrentLimit.RequestsPerUnit) * (1 - softBreachHeaderRatio)
+			if float64(status.LimitRemaining) <= softBand {
+				response.ResponseHeadersToAdd = append(response.ResponseHeadersToAdd,
+					&core.HeaderValue{Key: "x-ratelimit-soft-breach", Value: "1"})
+				break
+			}
 		}
 	}
 

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -33,6 +33,14 @@ import (
 
 var tracer = otel.Tracer("ratelimit")
 
+// Header added to the UPSTREAM request when an admitted request is above a
+// descriptor's soft_requests_per_unit threshold, so the backend can degrade
+// before clients start seeing 429s.
+const softBreachHeaderName = "x-ratelimit-soft-breached"
+
+// Standard back-off header returned to the client on a hard breach.
+const retryAfterHeaderName = "retry-after"
+
 type RateLimitServiceServer interface {
 	pb.RateLimitServiceServer
 	GetCurrentConfig() (config.RateLimitConfig, bool, bool)
@@ -47,6 +55,7 @@ type service struct {
 	stats                          stats.ServiceStats
 	health                         *server.HealthChecker
 	customHeadersEnabled           bool
+	retryAfterEnabled              bool
 	customHeaderLimitHeader        string
 	customHeaderRemainingHeader    string
 	customHeaderResetHeader        string
@@ -90,6 +99,7 @@ func (this *service) SetConfig(updateEvent provider.ConfigUpdateEvent, healthyWi
 	this.globalShadowMode = rlSettings.GlobalShadowMode
 	this.globalQuotaMode = rlSettings.GlobalQuotaMode
 	this.responseDynamicMetadataEnabled = rlSettings.ResponseDynamicMetadata
+	this.retryAfterEnabled = rlSettings.RetryAfterHeaderEnabled
 
 	if rlSettings.RateLimitResponseHeadersEnabled {
 		this.customHeadersEnabled = true
@@ -263,10 +273,54 @@ func (this *service) shouldRateLimitWorker(
 		}
 	}
 
+	// Soft-breach signal. When the request is admitted but a descriptor that
+	// configures soft_requests_per_unit is above that threshold, flag it to the
+	// UPSTREAM service so it can degrade before clients start seeing 429s.
+	// Only descriptors carrying a soft threshold participate; the rest can
+	// never soft-breach.
+	if finalCode == pb.RateLimitResponse_OK {
+		for i, status := range response.Statuses {
+			if isUnlimited[i] || status.CurrentLimit == nil || limitsToCheck[i] == nil {
+				continue
+			}
+			soft := limitsToCheck[i].SoftRequestsPerUnit
+			if soft == 0 {
+				continue
+			}
+			used := status.CurrentLimit.RequestsPerUnit - status.LimitRemaining
+			if used > soft {
+				response.RequestHeadersToAdd = append(response.RequestHeadersToAdd,
+					&core.HeaderValue{Key: softBreachHeaderName, Value: "1"})
+				break
+			}
+		}
+	}
+
 	// If there is a global shadow_mode, it should always return OK
 	if finalCode == pb.RateLimitResponse_OVER_LIMIT && globalShadowMode {
 		finalCode = pb.RateLimitResponse_OK
 		this.stats.GlobalShadowMode.Inc()
+	}
+
+	// Retry-After on a hard breach, carrying the breaching descriptor's own
+	// period in seconds. Placed after the global shadow-mode conversion above:
+	// a shadowed breach is admitted, so telling the client to back off would be
+	// wrong. Opt-in, so existing deployments see no response-shape change.
+	if this.retryAfterEnabled && finalCode == pb.RateLimitResponse_OVER_LIMIT {
+		for i, status := range response.Statuses {
+			if status.Code != pb.RateLimitResponse_OVER_LIMIT || status.CurrentLimit == nil {
+				continue
+			}
+			if limitsToCheck[i] != nil && limitsToCheck[i].ShadowMode {
+				continue
+			}
+			response.ResponseHeadersToAdd = append(response.ResponseHeadersToAdd,
+				&core.HeaderValue{
+					Key:   retryAfterHeaderName,
+					Value: strconv.FormatInt(utils.UnitToDivider(status.CurrentLimit.Unit), 10),
+				})
+			break
+		}
 	}
 
 	// If response dynamic data enabled, set dynamic data on response.

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -196,7 +196,6 @@ func (runner *Runner) Run() {
 		}
 	}()
 
-	ratelimit.SetSoftBreachHeaderRatio(s.SoftBreachHeaderRatio)
 	service := ratelimit.NewService(
 		limiter,
 		srv.Provider(),

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/envoyproxy/ratelimit/src/memcached"
 	"github.com/envoyproxy/ratelimit/src/metrics"
 	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/redis_decay"
 	"github.com/envoyproxy/ratelimit/src/server"
 	ratelimit "github.com/envoyproxy/ratelimit/src/service"
 	"github.com/envoyproxy/ratelimit/src/settings"
@@ -108,6 +109,8 @@ func createLimiter(ctx context.Context, srv server.Server, s settings.Settings, 
 			s.ExpirationJitterMaxSeconds,
 			statsManager,
 		)
+	case "redis_decay":
+		return redis_decay.NewFromSettings(ctx, s, srv, utils.NewTimeSourceImpl())
 	case "memcache":
 		return memcached.NewRateLimitCacheImplFromSettings(
 			s,

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -22,6 +22,7 @@ import (
 	"github.com/envoyproxy/ratelimit/src/memcached"
 	"github.com/envoyproxy/ratelimit/src/metrics"
 	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/redis_decay"
 	"github.com/envoyproxy/ratelimit/src/server"
 	ratelimit "github.com/envoyproxy/ratelimit/src/service"
 	"github.com/envoyproxy/ratelimit/src/settings"
@@ -108,6 +109,8 @@ func createLimiter(ctx context.Context, srv server.Server, s settings.Settings, 
 			s.ExpirationJitterMaxSeconds,
 			statsManager,
 		)
+	case "redis_decay":
+		return redis_decay.NewFromSettings(ctx, s, srv, utils.NewTimeSourceImpl())
 	case "memcache":
 		return memcached.NewRateLimitCacheImplFromSettings(
 			s,
@@ -193,6 +196,7 @@ func (runner *Runner) Run() {
 		}
 	}()
 
+	ratelimit.SetSoftBreachHeaderRatio(s.SoftBreachHeaderRatio)
 	service := ratelimit.NewService(
 		limiter,
 		srv.Provider(),

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -113,6 +113,9 @@ type Settings struct {
 
 	// Settings for optional returning of custom headers
 	RateLimitResponseHeadersEnabled bool `envconfig:"LIMIT_RESPONSE_HEADERS_ENABLED" default:"false"`
+	// RetryAfterHeaderEnabled adds a standard Retry-After header on a hard
+	// breach, set to the breaching descriptor's period in seconds.
+	RetryAfterHeaderEnabled bool `envconfig:"RETRY_AFTER_HEADER_ENABLED" default:"false"`
 	// value: the current limit
 	HeaderRatelimitLimit string `envconfig:"LIMIT_LIMIT_HEADER" default:"RateLimit-Limit"`
 	// value: remaining count

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -107,6 +107,7 @@ type Settings struct {
 	ExpirationJitterMaxSeconds         int64   `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
 	LocalCacheSizeInBytes              int     `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
 	NearLimitRatio                     float32 `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
+	SoftBreachHeaderRatio              float64 `envconfig:"SOFT_BREACH_HEADER_RATIO" default:"0"`
 	CacheKeyPrefix                     string  `envconfig:"CACHE_KEY_PREFIX" default:""`
 	BackendType                        string  `envconfig:"BACKEND_TYPE" default:"redis"`
 	StopCacheKeyIncrementWhenOverlimit bool    `envconfig:"STOP_CACHE_KEY_INCREMENT_WHEN_OVERLIMIT" default:"false"`

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -107,7 +107,6 @@ type Settings struct {
 	ExpirationJitterMaxSeconds         int64   `envconfig:"EXPIRATION_JITTER_MAX_SECONDS" default:"300"`
 	LocalCacheSizeInBytes              int     `envconfig:"LOCAL_CACHE_SIZE_IN_BYTES" default:"0"`
 	NearLimitRatio                     float32 `envconfig:"NEAR_LIMIT_RATIO" default:"0.8"`
-	SoftBreachHeaderRatio              float64 `envconfig:"SOFT_BREACH_HEADER_RATIO" default:"0"`
 	CacheKeyPrefix                     string  `envconfig:"CACHE_KEY_PREFIX" default:""`
 	BackendType                        string  `envconfig:"BACKEND_TYPE" default:"redis"`
 	StopCacheKeyIncrementWhenOverlimit bool    `envconfig:"STOP_CACHE_KEY_INCREMENT_WHEN_OVERLIMIT" default:"false"`

--- a/test/config/soft_requests_per_unit_test.go
+++ b/test/config/soft_requests_per_unit_test.go
@@ -1,0 +1,82 @@
+package config_test
+
+import (
+	"testing"
+
+	pb_struct "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	stats "github.com/lyft/gostats"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	mockstats "github.com/envoyproxy/ratelimit/test/mocks/stats"
+)
+
+// soft_requests_per_unit must survive real YAML parsing. Building a RateLimit
+// struct directly does not exercise validateYamlKeys, which keeps its own
+// allowlist of permitted keys — a field added to the struct but not to that
+// list parses fine in unit tests and then panics on a live config load.
+func TestSoftRequestsPerUnitParsesFromYaml(t *testing.T) {
+	assert := assert.New(t)
+	statsStore := stats.NewStore(stats.NewNullSink(), false)
+	sm := mockstats.NewMockStatManager(statsStore)
+
+	rlConfig := config.NewRateLimitConfigImpl([]config.RateLimitConfigToLoad{
+		{
+			Name: "soft.yaml",
+			ConfigYaml: config.ConfigFileContentToYaml("soft.yaml", `
+domain: soft_test
+descriptors:
+  - key: subject
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20
+      soft_requests_per_unit: 14
+  - key: plain
+    rate_limit:
+      unit: minute
+      requests_per_unit: 30
+`),
+		},
+	}, sm, true)
+
+	withSoft := rlConfig.GetLimit(context.Background(), "soft_test",
+		&pb_struct.RateLimitDescriptor{Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "subject", Value: "a"}}})
+	assert.NotNil(withSoft)
+	assert.Equal(uint32(14), withSoft.SoftRequestsPerUnit)
+	assert.Equal(uint32(20), withSoft.Limit.RequestsPerUnit)
+	assert.Equal(pb.RateLimitResponse_RateLimit_MINUTE, withSoft.Limit.Unit)
+
+	// A descriptor that omits it defaults to 0 (feature off), matching the three
+	// depop-routing limiters that pass nil for soft_count.
+	withoutSoft := rlConfig.GetLimit(context.Background(), "soft_test",
+		&pb_struct.RateLimitDescriptor{Entries: []*pb_struct.RateLimitDescriptor_Entry{{Key: "plain", Value: "b"}}})
+	assert.NotNil(withoutSoft)
+	assert.Equal(uint32(0), withoutSoft.SoftRequestsPerUnit)
+}
+
+// A soft threshold at or above the hard limit is meaningless and must be rejected
+// at load time rather than silently never firing.
+func TestSoftRequestsPerUnitAboveHardLimitRejected(t *testing.T) {
+	assert := assert.New(t)
+	statsStore := stats.NewStore(stats.NewNullSink(), false)
+	sm := mockstats.NewMockStatManager(statsStore)
+
+	assert.Panics(func() {
+		config.NewRateLimitConfigImpl([]config.RateLimitConfigToLoad{
+			{
+				Name: "bad.yaml",
+				ConfigYaml: config.ConfigFileContentToYaml("bad.yaml", `
+domain: soft_bad
+descriptors:
+  - key: subject
+    rate_limit:
+      unit: minute
+      requests_per_unit: 20
+      soft_requests_per_unit: 20
+`),
+			},
+		}, sm, true)
+	})
+}

--- a/test/redis_decay/allowlist_test.go
+++ b/test/redis_decay/allowlist_test.go
@@ -1,0 +1,269 @@
+package redis_decay_test
+
+// Tests for the PLA-8129 runtime allowlist added to cache_impl.go: an
+// operator SADDs a value to a Redis SET (allowlist:rl_ip / allowlist:rl_ua /
+// allowlist:rl_subject) and it takes effect on the next request, no deploy.
+// This mirrors ratelimiting.lua's ip_rate_limit_with_pooling /
+// user_agent_rate_limit_with_pooling / auth_rate_limit_with_pooling
+// (:204-253): the three allowlists are NOT symmetric — an allowlisted IP
+// exempts all three buckets for the whole request, but an allowlisted
+// user-agent or user-id exempts only its own bucket. client_id is never
+// exempted by any allowlist.
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"github.com/golang/mock/gomock"
+	gostats "github.com/lyft/gostats"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/src/redis_decay"
+	"github.com/envoyproxy/ratelimit/test/common"
+	stats "github.com/envoyproxy/ratelimit/test/mocks/stats"
+	mock_utils "github.com/envoyproxy/ratelimit/test/mocks/utils"
+)
+
+// An allowlisted IP exempts its own rl_ip descriptor.
+func TestAllowlistedIPExemptsItsOwnBucket(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	rs.SAdd("allowlist:rl_ip", "10.0.0.1")
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"rl_ip", "10.0.0.1"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_ip_value"), false, false, false, "", nil, false)}
+
+	// Limit is 1/min; a non-exempt caller would be OVER_LIMIT by the second
+	// call. An allowlisted IP must stay OK indefinitely.
+	for i := 0; i < 5; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code, "allowlisted IP request %d must be admitted", i+1)
+	}
+	for _, k := range rs.Keys() {
+		assert.NotContains(k, "decay_", "an allowlisted request must never touch its decay counter, found key %q", k)
+	}
+}
+
+// An allowlisted IP exempts rl_ua and rl_subject buckets too, even in a
+// SEPARATE descriptor group within the same request — this is the
+// cross-bucket rule that makes the IP allowlist different from the UA/subject
+// ones, which only ever exempt their own bucket.
+func TestAllowlistedIPExemptsOtherBucketsInSameRequest(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	rs.SAdd("allowlist:rl_ip", "10.0.0.1")
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{
+		{{"rl_ip", "10.0.0.1"}},
+		{{"rl_ua", "curl/8"}},
+		{{"rl_subject", "u_alice"}},
+	}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_ip_value"), false, false, false, "", nil, false),
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_ua_value"), false, false, false, "", nil, false),
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_subject_value"), false, false, false, "", nil, false),
+	}
+
+	for i := 0; i < 3; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code, "rl_ip request %d", i+1)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[1].Code, "rl_ua request %d must be exempted by the IP allowlist", i+1)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[2].Code, "rl_subject request %d must be exempted by the IP allowlist", i+1)
+	}
+}
+
+// An allowlisted user-agent exempts ONLY its own bucket — a co-occurring
+// rl_ip descriptor in the same request must still be rate limited normally.
+func TestAllowlistedUserAgentExemptsOnlyItsOwnBucket(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	rs.SAdd("allowlist:rl_ua", "DepopInternalBot/1.0")
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{
+		{{"rl_ip", "10.0.0.9"}},
+		{{"rl_ua", "DepopInternalBot/1.0"}},
+	}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_ip_value"), false, false, false, "", nil, false),
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_ua_value"), false, false, false, "", nil, false),
+	}
+
+	cache.DoLimit(context.Background(), request, limits)
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code, "the non-allowlisted rl_ip bucket must still enforce its limit")
+	assert.Equal(pb.RateLimitResponse_OK, statuses[1].Code, "the allowlisted rl_ua bucket must stay exempt")
+}
+
+// An allowlisted subject exempts only its own bucket, same as user-agent.
+func TestAllowlistedSubjectExemptsOnlyItsOwnBucket(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	rs.SAdd("allowlist:rl_subject", "86339")
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{
+		{{"rl_ip", "10.0.0.9"}},
+		{{"rl_subject", "86339"}},
+	}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_ip_value"), false, false, false, "", nil, false),
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_subject_value"), false, false, false, "", nil, false),
+	}
+
+	cache.DoLimit(context.Background(), request, limits)
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code, "the non-allowlisted rl_ip bucket must still enforce its limit")
+	assert.Equal(pb.RateLimitResponse_OK, statuses[1].Code, "the allowlisted rl_subject bucket must stay exempt")
+}
+
+// client_id is never exempted by any allowlist, even if an operator SADDs a
+// value under allowlist:client_id by mistake — it is not in allowlistKeys.
+func TestClientIDNeverExempted(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	rs.SAdd("allowlist:client_id", "some-client")
+	rs.SAdd("allowlist:rl_ip", "10.0.0.1") // even a global IP allowlist must not reach client_id
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{
+		{{"rl_ip", "10.0.0.1"}},
+		{{"client_id", "some-client"}},
+	}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_ip_value"), false, false, false, "", nil, false),
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("client_id_value"), false, false, false, "", nil, false),
+	}
+
+	cache.DoLimit(context.Background(), request, limits)
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code, "rl_ip is allowlisted")
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[1].Code, "client_id must never be exempted by any allowlist")
+}
+
+// A value that is not in any allowlist is rate limited normally — the
+// allowlist machinery must be a no-op for the common case.
+func TestNonAllowlistedValueBehavesNormally(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	rs.SAdd("allowlist:rl_ip", "10.0.0.1") // a different IP is allowlisted
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"rl_ip", "10.0.0.99"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_ip_value"), false, false, false, "", nil, false)}
+
+	cache.DoLimit(context.Background(), request, limits)
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code, "a non-allowlisted IP must be rate limited")
+}
+
+// No allowlists configured at all: the membership check pipeline must not
+// run, and behavior must be identical to the pre-allowlist implementation.
+func TestNoAllowlistsConfiguredBehavesLikeBaseline(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(9), statuses[0].LimitRemaining)
+}
+
+// A Redis failure during the allowlist membership check must surface as
+// redis.RedisError, exactly as a failure during the decay pipeline does —
+// the service layer's failure-mode policy must not be bypassed just because
+// the failure happened in the allowlist phase instead of the counter phase.
+func TestRedisDownDuringAllowlistCheckSurfacesRedisError(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	client := mkClient(rs.Addr())
+	rs.Close()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(client, timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"rl_ip", "10.0.0.1"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("rl_ip_value"), false, false, false, "", nil, false)}
+
+	defer func() {
+		r := recover()
+		assert.NotNil(r, "a Redis failure during the allowlist check must panic")
+	}()
+	cache.DoLimit(context.Background(), request, limits)
+	assert.Fail("DoLimit returned normally despite Redis being down")
+}

--- a/test/redis_decay/cache_impl_test.go
+++ b/test/redis_decay/cache_impl_test.go
@@ -1,0 +1,343 @@
+package redis_decay_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"github.com/golang/mock/gomock"
+	gostats "github.com/lyft/gostats"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/redis_decay"
+	"github.com/envoyproxy/ratelimit/test/common"
+	stats "github.com/envoyproxy/ratelimit/test/mocks/stats"
+	mock_utils "github.com/envoyproxy/ratelimit/test/mocks/utils"
+)
+
+func mustNewRedisServer() *miniredis.Miniredis {
+	srv, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	return srv
+}
+
+func mkClient(addr string) redis.Client {
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	return redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", addr, 1,
+		0, 0, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 100*time.Millisecond, false)
+}
+
+// Sunday-path: a fresh key admits the request and reports limit-1 remaining,
+// and the cache key carries no window timestamp (the property that makes the
+// boundary-burst impossible by construction).
+func TestFirstRequestAllowedAndKeyHasNoWindowTimestamp(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(9), statuses[0].LimitRemaining)
+	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(1), limits[0].Stats.WithinLimit.Value())
+
+	keys := rs.Keys()
+	assert.Len(keys, 1)
+	assert.Equal("decay_domain_key_value", keys[0])
+}
+
+// With time frozen there is no decay: exactly limit requests pass, the next is rejected.
+func TestExhaustionThenOverLimit(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	for i := 0; i < 10; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code, "request %d should be admitted", i+1)
+	}
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+	assert.Equal(uint32(0), statuses[0].LimitRemaining)
+	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
+}
+
+// The defining decay property: crossing a minute boundary right after
+// exhaustion does NOT grant a fresh budget (the fixed-window backend would).
+func TestNoBudgetResetAtWindowBoundary(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	// t0 is 2s before a minute boundary; the follow-up burst is 2s after it.
+	t0 := int64(1787061958)
+	timeSource.EXPECT().UnixNow().Return(t0).Times(11)
+	timeSource.EXPECT().UnixNow().Return(t0 + 4).Times(3)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	for i := 0; i < 11; i++ {
+		cache.DoLimit(context.Background(), request, limits)
+	}
+	// 4s elapsed decays only 4/60*10 = 0.67 of a token; still over on the far
+	// side of the boundary.
+	for i := 0; i < 3; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code, "burst request %d must stay rejected across the boundary", i+1)
+	}
+}
+
+// Budget returns gradually at limit/period, not all at once.
+func TestDecayRecovery(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	t0 := int64(1000)
+	timeSource.EXPECT().UnixNow().Return(t0).Times(10)
+	timeSource.EXPECT().UnixNow().Return(t0 + 30).Times(6)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	for i := 0; i < 10; i++ {
+		cache.DoLimit(context.Background(), request, limits)
+	}
+	// 30s at 10/min recovers 5 tokens: 5 admitted, the 6th rejected.
+	for i := 0; i < 5; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code, "recovered request %d should be admitted", i+1)
+	}
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+}
+
+// Rejected requests still increment the counter (parity with the production
+// Lua): a flood while over limit delays recovery.
+func TestRejectedRequestsConsumeBudget(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	t0 := int64(1000)
+	timeSource.EXPECT().UnixNow().Return(t0).Times(15)
+	timeSource.EXPECT().UnixNow().Return(t0 + 30).Times(1)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	// 10 admitted + 5 rejected leaves the counter at 15.
+	for i := 0; i < 15; i++ {
+		cache.DoLimit(context.Background(), request, limits)
+	}
+	// 30s decays 5: counter 10 + this request = 11 > 10, still rejected.
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+}
+
+// Corrupt stored data must reset cleanly, not crash or deny.
+func TestCorruptRedisDataResets(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	rs.Set("decay_domain_key_value", "not-a-decay-record")
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(9), statuses[0].LimitRemaining)
+}
+
+// A backwards clock step must not mint free budget (elapsed clamps to zero).
+func TestBackwardClockStepDoesNotMintBudget(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).Times(1)
+	timeSource.EXPECT().UnixNow().Return(int64(900)).Times(1)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	cache.DoLimit(context.Background(), request, limits)
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	// Second request must count on top of the first (remaining 8), not be
+	// treated as a fresh window (remaining 9).
+	assert.Equal(uint32(8), statuses[0].LimitRemaining)
+}
+
+// Descriptors with no configured limit are admitted without touching Redis.
+func TestNilLimitSkipped(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{nil}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(math.MaxUint32), statuses[0].LimitRemaining)
+	assert.Empty(rs.Keys())
+}
+
+// Two descriptors in one request are limited independently.
+func TestMultipleDescriptorsIndependent(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"keyA", "a"}}, {{"keyB", "b"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("keyA_a"), false, false, false, "", nil, false),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("keyB_b"), false, false, false, "", nil, false),
+	}
+
+	cache.DoLimit(context.Background(), request, limits)
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[1].Code)
+}
+
+// A Redis failure must surface as redis.RedisError, exactly as the fixed-window
+// backend does. The service layer recovers it into a gRPC error, increments the
+// RedisError stat, and Envoy's failure_mode_deny setting then decides whether
+// the request is admitted. Swallowing the error here would both hide the outage
+// from metrics and silently override an operator's fail-closed policy.
+func TestRedisDownSurfacesRedisError(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	client := mkClient(rs.Addr())
+	rs.Close()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(client, timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	defer func() {
+		r := recover()
+		assert.NotNil(r, "a Redis failure must panic so the service layer can classify it")
+		_, isRedisError := r.(redis.RedisError)
+		assert.True(isRedisError, "panic value must be redis.RedisError, got %T", r)
+	}()
+	cache.DoLimit(context.Background(), request, limits)
+	assert.Fail("DoLimit returned normally despite Redis being down")
+}
+
+// Envoy's hits_addend must be honored: one request can consume several hits.
+func TestHitsAddendConsumesMultipleTokens(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 5)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(5), statuses[0].LimitRemaining, "an addend of 5 must consume 5 tokens")
+
+	statuses = cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(0), statuses[0].LimitRemaining)
+
+	statuses = cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+}

--- a/test/redis_decay/cache_impl_test.go
+++ b/test/redis_decay/cache_impl_test.go
@@ -280,8 +280,12 @@ func TestMultipleDescriptorsIndependent(t *testing.T) {
 	assert.Equal(pb.RateLimitResponse_OK, statuses[1].Code)
 }
 
-// Redis being down fails open: requests are admitted, nothing panics.
-func TestRedisDownFailsOpen(t *testing.T) {
+// A Redis failure must surface as redis.RedisError, exactly as the fixed-window
+// backend does. The service layer recovers it into a gRPC error, increments the
+// RedisError stat, and Envoy's failure_mode_deny setting then decides whether
+// the request is admitted. Swallowing the error here would both hide the outage
+// from metrics and silently override an operator's fail-closed policy.
+func TestRedisDownSurfacesRedisError(t *testing.T) {
 	assert := assert.New(t)
 	rs := mustNewRedisServer()
 	controller := gomock.NewController(t)
@@ -299,10 +303,14 @@ func TestRedisDownFailsOpen(t *testing.T) {
 	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
 
-	assert.NotPanics(func() {
-		statuses := cache.DoLimit(context.Background(), request, limits)
-		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
-	})
+	defer func() {
+		r := recover()
+		assert.NotNil(r, "a Redis failure must panic so the service layer can classify it")
+		_, isRedisError := r.(redis.RedisError)
+		assert.True(isRedisError, "panic value must be redis.RedisError, got %T", r)
+	}()
+	cache.DoLimit(context.Background(), request, limits)
+	assert.Fail("DoLimit returned normally despite Redis being down")
 }
 
 // Envoy's hits_addend must be honored: one request can consume several hits.

--- a/test/redis_decay/cache_impl_test.go
+++ b/test/redis_decay/cache_impl_test.go
@@ -1,0 +1,335 @@
+package redis_decay_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"github.com/golang/mock/gomock"
+	gostats "github.com/lyft/gostats"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/redis_decay"
+	"github.com/envoyproxy/ratelimit/test/common"
+	stats "github.com/envoyproxy/ratelimit/test/mocks/stats"
+	mock_utils "github.com/envoyproxy/ratelimit/test/mocks/utils"
+)
+
+func mustNewRedisServer() *miniredis.Miniredis {
+	srv, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	return srv
+}
+
+func mkClient(addr string) redis.Client {
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	return redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", addr, 1,
+		0, 0, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 100*time.Millisecond, false)
+}
+
+// Sunday-path: a fresh key admits the request and reports limit-1 remaining,
+// and the cache key carries no window timestamp (the property that makes the
+// boundary-burst impossible by construction).
+func TestFirstRequestAllowedAndKeyHasNoWindowTimestamp(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(9), statuses[0].LimitRemaining)
+	assert.Equal(uint64(1), limits[0].Stats.TotalHits.Value())
+	assert.Equal(uint64(1), limits[0].Stats.WithinLimit.Value())
+
+	keys := rs.Keys()
+	assert.Len(keys, 1)
+	assert.Equal("decay_domain_key_value", keys[0])
+}
+
+// With time frozen there is no decay: exactly limit requests pass, the next is rejected.
+func TestExhaustionThenOverLimit(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	for i := 0; i < 10; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code, "request %d should be admitted", i+1)
+	}
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+	assert.Equal(uint32(0), statuses[0].LimitRemaining)
+	assert.Equal(uint64(1), limits[0].Stats.OverLimit.Value())
+}
+
+// The defining decay property: crossing a minute boundary right after
+// exhaustion does NOT grant a fresh budget (the fixed-window backend would).
+func TestNoBudgetResetAtWindowBoundary(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	// t0 is 2s before a minute boundary; the follow-up burst is 2s after it.
+	t0 := int64(1787061958)
+	timeSource.EXPECT().UnixNow().Return(t0).Times(11)
+	timeSource.EXPECT().UnixNow().Return(t0 + 4).Times(3)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	for i := 0; i < 11; i++ {
+		cache.DoLimit(context.Background(), request, limits)
+	}
+	// 4s elapsed decays only 4/60*10 = 0.67 of a token; still over on the far
+	// side of the boundary.
+	for i := 0; i < 3; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code, "burst request %d must stay rejected across the boundary", i+1)
+	}
+}
+
+// Budget returns gradually at limit/period, not all at once.
+func TestDecayRecovery(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	t0 := int64(1000)
+	timeSource.EXPECT().UnixNow().Return(t0).Times(10)
+	timeSource.EXPECT().UnixNow().Return(t0 + 30).Times(6)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	for i := 0; i < 10; i++ {
+		cache.DoLimit(context.Background(), request, limits)
+	}
+	// 30s at 10/min recovers 5 tokens: 5 admitted, the 6th rejected.
+	for i := 0; i < 5; i++ {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code, "recovered request %d should be admitted", i+1)
+	}
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+}
+
+// Rejected requests still increment the counter (parity with the production
+// Lua): a flood while over limit delays recovery.
+func TestRejectedRequestsConsumeBudget(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	t0 := int64(1000)
+	timeSource.EXPECT().UnixNow().Return(t0).Times(15)
+	timeSource.EXPECT().UnixNow().Return(t0 + 30).Times(1)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	// 10 admitted + 5 rejected leaves the counter at 15.
+	for i := 0; i < 15; i++ {
+		cache.DoLimit(context.Background(), request, limits)
+	}
+	// 30s decays 5: counter 10 + this request = 11 > 10, still rejected.
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+}
+
+// Corrupt stored data must reset cleanly, not crash or deny.
+func TestCorruptRedisDataResets(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	rs.Set("decay_domain_key_value", "not-a-decay-record")
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(9), statuses[0].LimitRemaining)
+}
+
+// A backwards clock step must not mint free budget (elapsed clamps to zero).
+func TestBackwardClockStepDoesNotMintBudget(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).Times(1)
+	timeSource.EXPECT().UnixNow().Return(int64(900)).Times(1)
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	cache.DoLimit(context.Background(), request, limits)
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	// Second request must count on top of the first (remaining 8), not be
+	// treated as a fresh window (remaining 9).
+	assert.Equal(uint32(8), statuses[0].LimitRemaining)
+}
+
+// Descriptors with no configured limit are admitted without touching Redis.
+func TestNilLimitSkipped(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{nil}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(math.MaxUint32), statuses[0].LimitRemaining)
+	assert.Empty(rs.Keys())
+}
+
+// Two descriptors in one request are limited independently.
+func TestMultipleDescriptorsIndependent(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"keyA", "a"}}, {{"keyB", "b"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(1, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("keyA_a"), false, false, false, "", nil, false),
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("keyB_b"), false, false, false, "", nil, false),
+	}
+
+	cache.DoLimit(context.Background(), request, limits)
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[1].Code)
+}
+
+// Redis being down fails open: requests are admitted, nothing panics.
+func TestRedisDownFailsOpen(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	client := mkClient(rs.Addr())
+	rs.Close()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(client, timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	assert.NotPanics(func() {
+		statuses := cache.DoLimit(context.Background(), request, limits)
+		assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	})
+}
+
+// Envoy's hits_addend must be honored: one request can consume several hits.
+func TestHitsAddendConsumesMultipleTokens(t *testing.T) {
+	assert := assert.New(t)
+	rs := mustNewRedisServer()
+	defer rs.Close()
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	timeSource.EXPECT().UnixNow().Return(int64(1000)).AnyTimes()
+
+	cache := redis_decay.NewDecayRateLimitCacheImpl(mkClient(rs.Addr()), timeSource, "")
+	request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 5)
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	statuses := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(5), statuses[0].LimitRemaining, "an addend of 5 must consume 5 tokens")
+
+	statuses = cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, statuses[0].Code)
+	assert.Equal(uint32(0), statuses[0].LimitRemaining)
+
+	statuses = cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, statuses[0].Code)
+}

--- a/test/service/retry_after_test.go
+++ b/test/service/retry_after_test.go
@@ -1,0 +1,103 @@
+package ratelimit_test
+
+import (
+	"os"
+	"testing"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"golang.org/x/net/context"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/test/common"
+)
+
+// The header is opt-in, matching the existing custom-header flag, so existing
+// deployments see no change in response shape. Enable it for these tests.
+func withRetryAfterEnabled(t *testing.T) {
+	t.Helper()
+	old, had := os.LookupEnv("RETRY_AFTER_HEADER_ENABLED")
+	os.Setenv("RETRY_AFTER_HEADER_ENABLED", "true")
+	t.Cleanup(func() {
+		// restoring an empty string would break envconfig's bool parsing
+		if had {
+			os.Setenv("RETRY_AFTER_HEADER_ENABLED", old)
+		} else {
+			os.Unsetenv("RETRY_AFTER_HEADER_ENABLED")
+		}
+	})
+}
+
+func headerValue(t rateLimitServiceTestSuite, resp *pb.RateLimitResponse, name string) string {
+	for _, h := range resp.ResponseHeadersToAdd {
+		if h.Key == name {
+			return h.Value
+		}
+	}
+	return ""
+}
+
+// depop-routing sets `Retry-After: <period>` on a hard breach
+// (ratelimiting.lua:114). Clients and SDKs use it to back off; without it they
+// retry immediately and keep the bucket saturated.
+func TestRetryAfterSetOnOverLimit(test *testing.T) {
+	withRetryAfterEnabled(test)
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OVER_LIMIT, response.OverallCode)
+	// a MINUTE limit means retry after 60 seconds
+	t.assert.Equal("60", headerValue(t, response, "retry-after"),
+		"Retry-After must carry the limit period in seconds")
+}
+
+// An admitted request must not carry Retry-After — it would tell a healthy
+// client to back off for no reason.
+func TestNoRetryAfterWhenAdmitted(test *testing.T) {
+	withRetryAfterEnabled(test)
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal("", headerValue(t, response, "retry-after"))
+}
+
+// The period must follow the breaching descriptor's own unit, not a default.
+func TestRetryAfterUsesTheBreachingDescriptorsUnit(test *testing.T) {
+	withRetryAfterEnabled(test)
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_HOUR, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal("3600", headerValue(t, response, "retry-after"))
+}

--- a/test/service/soft_breach_test.go
+++ b/test/service/soft_breach_test.go
@@ -8,78 +8,102 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/envoyproxy/ratelimit/src/config"
-	ratelimit "github.com/envoyproxy/ratelimit/src/service"
 	"github.com/envoyproxy/ratelimit/test/common"
 )
 
-func hasSoftBreachHeader(headers []*core.HeaderValue) bool {
+const softBreachHeader = "x-ratelimit-soft-breached"
+
+func hasHeader(headers []*core.HeaderValue, name string) bool {
 	for _, h := range headers {
-		if h.Key == "x-ratelimit-soft-breach" {
+		if h.Key == name {
 			return true
 		}
 	}
 	return false
 }
 
-// One admitted descriptor inside the soft band (remaining <= (1-ratio)*limit)
-// must add the soft-breach header.
-func TestSoftBreachHeaderEmittedInSoftBand(test *testing.T) {
-	ratelimit.SetSoftBreachHeaderRatio(0.7)
-	defer ratelimit.SetSoftBreachHeaderRatio(0)
+// softLimit builds a limit carrying a soft threshold, mirroring depop-routing's
+// per-route rate_limit_soft_count.
+func softLimit(t rateLimitServiceTestSuite, requests, soft uint32) *config.RateLimit {
+	l := config.NewRateLimit(requests, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false)
+	l.SoftRequestsPerUnit = soft
+	return l
+}
 
+// The soft-breach signal must go UPSTREAM so the backend can degrade, matching
+// `proxy_set_header X-RateLimit-Soft-Breached` in service_common.conf. Sending it
+// downstream tells the wrong party entirely.
+func TestSoftBreachSignalsUpstreamNotDownstream(test *testing.T) {
 	t := commonSetup(test)
 	defer t.controller.Finish()
 	service := t.setupBasicService()
 
 	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
-	limits := []*config.RateLimit{
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
-	}
+	limits := []*config.RateLimit{softLimit(t, 10, 7)}
 	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	// 8 used of 10 => inside the soft band (>7), still admitted
 	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
-		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 3}})
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 2}})
 
 	response, err := service.ShouldRateLimit(context.Background(), request)
 	t.assert.Nil(err)
 	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
-	t.assert.True(hasSoftBreachHeader(response.ResponseHeadersToAdd), "remaining 3 of 10 at ratio 0.7 is inside the soft band")
+	t.assert.True(hasHeader(response.RequestHeadersToAdd, softBreachHeader),
+		"soft breach must be added to the UPSTREAM request headers")
+	t.assert.False(hasHeader(response.ResponseHeadersToAdd, softBreachHeader),
+		"soft breach must NOT be returned to the client")
 }
 
-// Plenty of budget left: no header.
-func TestSoftBreachHeaderAbsentBelowThreshold(test *testing.T) {
-	ratelimit.SetSoftBreachHeaderRatio(0.7)
-	defer ratelimit.SetSoftBreachHeaderRatio(0)
-
+// Only descriptors that configure a soft threshold may signal. depop-routing
+// passes soft_count from auth_rate_limit only; the ip/user_agent/client_id
+// limiters pass nil and can never soft-breach.
+func TestNoSoftBreachWhenDescriptorHasNoSoftThreshold(test *testing.T) {
 	t := commonSetup(test)
 	defer t.controller.Finish()
 	service := t.setupBasicService()
 
 	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	// no SoftRequestsPerUnit set — this is the ip/user_agent/client_id shape
 	limits := []*config.RateLimit{
 		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
 	}
 	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	// 9 of 10 used — deep into what would be a soft band if one existed
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 1}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.False(hasHeader(response.RequestHeadersToAdd, softBreachHeader),
+		"a descriptor with no soft threshold must never signal a soft breach")
+}
+
+// Below the soft threshold: silent.
+func TestNoSoftBreachBelowThreshold(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{softLimit(t, 10, 7)}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	// 5 used of 10 => below soft threshold of 7
 	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5}})
 
 	response, err := service.ShouldRateLimit(context.Background(), request)
 	t.assert.Nil(err)
-	t.assert.False(hasSoftBreachHeader(response.ResponseHeadersToAdd), "remaining 5 of 10 at ratio 0.7 is outside the soft band")
+	t.assert.False(hasHeader(response.RequestHeadersToAdd, softBreachHeader))
 }
 
-// A hard breach is not a soft breach: no header on OVER_LIMIT responses.
-func TestSoftBreachHeaderAbsentWhenOverLimit(test *testing.T) {
-	ratelimit.SetSoftBreachHeaderRatio(0.7)
-	defer ratelimit.SetSoftBreachHeaderRatio(0)
-
+// A hard breach is not a soft breach — depop-routing exits before the soft path.
+func TestNoSoftBreachWhenOverLimit(test *testing.T) {
 	t := commonSetup(test)
 	defer t.controller.Finish()
 	service := t.setupBasicService()
 
 	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
-	limits := []*config.RateLimit{
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
-	}
+	limits := []*config.RateLimit{softLimit(t, 10, 7)}
 	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
 	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}})
@@ -87,45 +111,18 @@ func TestSoftBreachHeaderAbsentWhenOverLimit(test *testing.T) {
 	response, err := service.ShouldRateLimit(context.Background(), request)
 	t.assert.Nil(err)
 	t.assert.Equal(pb.RateLimitResponse_OVER_LIMIT, response.OverallCode)
-	t.assert.False(hasSoftBreachHeader(response.ResponseHeadersToAdd))
+	t.assert.False(hasHeader(response.RequestHeadersToAdd, softBreachHeader))
 }
 
-// Feature off (ratio 0): never emit the header.
-func TestSoftBreachHeaderAbsentWhenDisabled(test *testing.T) {
-	ratelimit.SetSoftBreachHeaderRatio(0)
-
+// Landing exactly on the limit is still an admitted request, and depop-routing
+// classifies count > soft as soft while count <= hard, so it signals.
+func TestSoftBreachOnLastAdmittedRequest(test *testing.T) {
 	t := commonSetup(test)
 	defer t.controller.Finish()
 	service := t.setupBasicService()
 
 	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
-	limits := []*config.RateLimit{
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
-	}
-	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
-	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
-		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 1}})
-
-	response, err := service.ShouldRateLimit(context.Background(), request)
-	t.assert.Nil(err)
-	t.assert.False(hasSoftBreachHeader(response.ResponseHeadersToAdd))
-}
-
-// The LAST admitted request (remaining 0, still OK) is a soft breach: the
-// band is count > soft while count <= limit, which includes the request
-// that lands exactly on the limit.
-func TestSoftBreachHeaderOnLastAdmittedRequest(test *testing.T) {
-	ratelimit.SetSoftBreachHeaderRatio(0.7)
-	defer ratelimit.SetSoftBreachHeaderRatio(0)
-
-	t := commonSetup(test)
-	defer t.controller.Finish()
-	service := t.setupBasicService()
-
-	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
-	limits := []*config.RateLimit{
-		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
-	}
+	limits := []*config.RateLimit{softLimit(t, 10, 7)}
 	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
 	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
 		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 0}})
@@ -133,5 +130,14 @@ func TestSoftBreachHeaderOnLastAdmittedRequest(test *testing.T) {
 	response, err := service.ShouldRateLimit(context.Background(), request)
 	t.assert.Nil(err)
 	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
-	t.assert.True(hasSoftBreachHeader(response.ResponseHeadersToAdd), "an admitted request with 0 remaining is a soft breach (Lua parity)")
+	t.assert.True(hasHeader(response.RequestHeadersToAdd, softBreachHeader))
+}
+
+// Config parsing: soft_requests_per_unit must survive YAML -> RateLimit.
+func TestSoftRequestsPerUnitParsedFromConfig(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+
+	l := config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false)
+	t.assert.Equal(uint32(0), l.SoftRequestsPerUnit, "defaults to 0 = feature off, matching the three limiters that pass nil")
 }

--- a/test/service/soft_breach_test.go
+++ b/test/service/soft_breach_test.go
@@ -1,0 +1,137 @@
+package ratelimit_test
+
+import (
+	"testing"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"golang.org/x/net/context"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	ratelimit "github.com/envoyproxy/ratelimit/src/service"
+	"github.com/envoyproxy/ratelimit/test/common"
+)
+
+func hasSoftBreachHeader(headers []*core.HeaderValue) bool {
+	for _, h := range headers {
+		if h.Key == "x-ratelimit-soft-breach" {
+			return true
+		}
+	}
+	return false
+}
+
+// One admitted descriptor inside the soft band (remaining <= (1-ratio)*limit)
+// must add the soft-breach header.
+func TestSoftBreachHeaderEmittedInSoftBand(test *testing.T) {
+	ratelimit.SetSoftBreachHeaderRatio(0.7)
+	defer ratelimit.SetSoftBreachHeaderRatio(0)
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 3}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+	t.assert.True(hasSoftBreachHeader(response.ResponseHeadersToAdd), "remaining 3 of 10 at ratio 0.7 is inside the soft band")
+}
+
+// Plenty of budget left: no header.
+func TestSoftBreachHeaderAbsentBelowThreshold(test *testing.T) {
+	ratelimit.SetSoftBreachHeaderRatio(0.7)
+	defer ratelimit.SetSoftBreachHeaderRatio(0)
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.False(hasSoftBreachHeader(response.ResponseHeadersToAdd), "remaining 5 of 10 at ratio 0.7 is outside the soft band")
+}
+
+// A hard breach is not a soft breach: no header on OVER_LIMIT responses.
+func TestSoftBreachHeaderAbsentWhenOverLimit(test *testing.T) {
+	ratelimit.SetSoftBreachHeaderRatio(0.7)
+	defer ratelimit.SetSoftBreachHeaderRatio(0)
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OVER_LIMIT, response.OverallCode)
+	t.assert.False(hasSoftBreachHeader(response.ResponseHeadersToAdd))
+}
+
+// Feature off (ratio 0): never emit the header.
+func TestSoftBreachHeaderAbsentWhenDisabled(test *testing.T) {
+	ratelimit.SetSoftBreachHeaderRatio(0)
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 1}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.False(hasSoftBreachHeader(response.ResponseHeadersToAdd))
+}
+
+// The LAST admitted request (remaining 0, still OK) is a soft breach: the
+// band is count > soft while count <= limit, which includes the request
+// that lands exactly on the limit.
+func TestSoftBreachHeaderOnLastAdmittedRequest(test *testing.T) {
+	ratelimit.SetSoftBreachHeaderRatio(0.7)
+	defer ratelimit.SetSoftBreachHeaderRatio(0)
+
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 0}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+	t.assert.True(hasSoftBreachHeader(response.ResponseHeadersToAdd), "an admitted request with 0 remaining is a soft breach (Lua parity)")
+}

--- a/test/service/soft_breach_test.go
+++ b/test/service/soft_breach_test.go
@@ -1,0 +1,143 @@
+package ratelimit_test
+
+import (
+	"testing"
+
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	"golang.org/x/net/context"
+
+	"github.com/envoyproxy/ratelimit/src/config"
+	"github.com/envoyproxy/ratelimit/test/common"
+)
+
+const softBreachHeader = "x-ratelimit-soft-breached"
+
+func hasHeader(headers []*core.HeaderValue, name string) bool {
+	for _, h := range headers {
+		if h.Key == name {
+			return true
+		}
+	}
+	return false
+}
+
+// softLimit builds a limit carrying a soft threshold, mirroring depop-routing's
+// per-route rate_limit_soft_count.
+func softLimit(t rateLimitServiceTestSuite, requests, soft uint32) *config.RateLimit {
+	l := config.NewRateLimit(requests, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false)
+	l.SoftRequestsPerUnit = soft
+	return l
+}
+
+// The soft-breach signal must go UPSTREAM so the backend can degrade, matching
+// `proxy_set_header X-RateLimit-Soft-Breached` in service_common.conf. Sending it
+// downstream tells the wrong party entirely.
+func TestSoftBreachSignalsUpstreamNotDownstream(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{softLimit(t, 10, 7)}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	// 8 used of 10 => inside the soft band (>7), still admitted
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 2}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+	t.assert.True(hasHeader(response.RequestHeadersToAdd, softBreachHeader),
+		"soft breach must be added to the UPSTREAM request headers")
+	t.assert.False(hasHeader(response.ResponseHeadersToAdd, softBreachHeader),
+		"soft breach must NOT be returned to the client")
+}
+
+// Only descriptors that configure a soft threshold may signal. depop-routing
+// passes soft_count from auth_rate_limit only; the ip/user_agent/client_id
+// limiters pass nil and can never soft-breach.
+func TestNoSoftBreachWhenDescriptorHasNoSoftThreshold(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	// no SoftRequestsPerUnit set — this is the ip/user_agent/client_id shape
+	limits := []*config.RateLimit{
+		config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false),
+	}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	// 9 of 10 used — deep into what would be a soft band if one existed
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 1}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.False(hasHeader(response.RequestHeadersToAdd, softBreachHeader),
+		"a descriptor with no soft threshold must never signal a soft breach")
+}
+
+// Below the soft threshold: silent.
+func TestNoSoftBreachBelowThreshold(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{softLimit(t, 10, 7)}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	// 5 used of 10 => below soft threshold of 7
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 5}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.False(hasHeader(response.RequestHeadersToAdd, softBreachHeader))
+}
+
+// A hard breach is not a soft breach — depop-routing exits before the soft path.
+func TestNoSoftBreachWhenOverLimit(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{softLimit(t, 10, 7)}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OVER_LIMIT, CurrentLimit: limits[0].Limit, LimitRemaining: 0}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OVER_LIMIT, response.OverallCode)
+	t.assert.False(hasHeader(response.RequestHeadersToAdd, softBreachHeader))
+}
+
+// Landing exactly on the limit is still an admitted request, and depop-routing
+// classifies count > soft as soft while count <= hard, so it signals.
+func TestSoftBreachOnLastAdmittedRequest(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
+	limits := []*config.RateLimit{softLimit(t, 10, 7)}
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(limits[0])
+	t.cache.EXPECT().DoLimit(context.Background(), request, limits).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: limits[0].Limit, LimitRemaining: 0}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(err)
+	t.assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+	t.assert.True(hasHeader(response.RequestHeadersToAdd, softBreachHeader))
+}
+
+// Config parsing: soft_requests_per_unit must survive YAML -> RateLimit.
+func TestSoftRequestsPerUnitParsedFromConfig(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+
+	l := config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_MINUTE, t.statsManager.NewStats("key"), false, false, false, "", nil, false)
+	t.assert.Equal(uint32(0), l.SoftRequestsPerUnit, "defaults to 0 = feature off, matching the three limiters that pass nil")
+}


### PR DESCRIPTION
Adds `BACKEND_TYPE=redis_decay`: a continuously-decaying counter (GCRA family) executed as an atomic Redis EVAL. Unlike the fixed-window redis backend, cache keys carry no window timestamp, so budgets never reset at a boundary and the 2x boundary-burst is impossible by construction. Honors per-descriptor hits_addend. Fail-open on Redis errors. Cluster-safe: EVAL routes by cache key.

Also adds `SOFT_BREACH_HEADER_RATIO`: when set (0..1), admitted requests whose remaining budget falls inside the soft band get an `x-ratelimit-soft-breach: 1` response header, so clients can degrade before hard 429s. Computed generically from CurrentLimit/LimitRemaining, so it works with any cache backend.

Covered by test/redis_decay (real EVAL execution on miniredis: boundary immunity, decay recovery, flood behavior, corrupt data, backward clock, fail-open, hits_addend) and test/service/soft_breach_test.go. All existing tests pass.

Load-tested behind Envoy's ratelimit filter (Istio 1.30 / Gateway API): 3,950 rps sustained on one replica, +2.3ms p50 overhead, exact admission under concurrency (100-budget key admitted exactly 100 of 2,000 concurrent requests).

Refs #32 (rolling window request, open since 2018).