### PR TITLE
invalidate local cache on is_negative_hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@
   - [GRPC server](#grpc-server)
 - [Request Fields](#request-fields)
   - [Negative hits](#negative-hits)
+    - [Local cache invalidation](#local-cache-invalidation)
+      - [Required Redis permissions](#required-redis-permissions)
 - [GRPC Client](#grpc-client)
   - [Commandline flags](#commandline-flags)
 - [Global ShadowMode](#global-shadowmode)
@@ -970,6 +972,19 @@ Each descriptor entry may set the `is_negative_hits` field. When it is `true`, t
 `hits_addend` is subtracted from the rate limit counter instead of being added to it, effectively
 refunding previously consumed capacity.
 
+The feature is gated by the `ENABLE_NEGATIVE_HITS` environment variable, which defaults to `false`.
+While it is off, any request containing a negative-hit descriptor is rejected as a whole with the
+gRPC `UNIMPLEMENTED` code; a negative-hit descriptor is never silently processed as a positive hit.
+Because a rejected batch fails every descriptor in it, callers should send refunds in dedicated
+requests rather than mixing them with positive hits. Rejections are counted in the
+`ratelimit.service.negative_hits_rejected` statistic.
+
+The combination `ENABLE_NEGATIVE_HITS=true`, `BACKEND_TYPE=memcache` and
+`LOCAL_CACHE_SIZE_IN_BYTES>0` refuses to boot: an over-limit counter poisons the local cache and
+there is no invalidation path for memcached, so a refund could leave replicas answering
+`OVER_LIMIT` from the local cache until the window ends. Memcached with negative hits and no local
+cache keeps working.
+
 Negative-hit behavior:
 
 - The counter is floored at `0` and can never go negative. Redis performs the decrement-and-floor
@@ -977,7 +992,47 @@ Negative-hit behavior:
 - A negative-hit descriptor always returns `OK`. It bypasses the over-limit and near-limit checks and
   does not trigger any over-limit side effects (over-limit stats or local-cache poisoning), even when
   the counter is still above the limit after the decrement.
+- Refunds apply to the current window only; the service does not validate which window the original
+  hit was charged in.
 - The requested decrement is counted in the `total_negative_hits` statistic (see [Statistics](#statistics-1)).
+
+### Local cache invalidation
+
+With the Redis backend, a counter that goes over the limit poisons the local cache of the replica
+that observed it: the over-limit answer is then served locally until the window ends. Since a
+refund can bring the counter back under the limit, negative hits combined with a local cache use
+Redis pub/sub to invalidate those entries across replicas: a refund that crosses the counter back
+under its limit publishes the cache key on the `ratelimit:local_cache_invalidation` channel, and
+every replica with a local cache subscribes and deletes the key from its local cache.
+
+- Invalidation is best-effort / at-most-once: messages are never buffered or replayed, so a replica
+  that misses a message (e.g. while reconnecting) keeps the stale entry until the window ends.
+- The subscriber re-dials every `LOCAL_CACHE_INVALIDATION_RESUBSCRIBE_INTERVAL` (default `5m`),
+  re-resolving the sentinel master and refreshing cluster topology. This bounds how long a
+  subscription can stay silently attached to a demoted or removed node (e.g. after a sentinel
+  failover that left the old master reachable but unlinked from the new one).
+- Invalidation is ordered against poisoning: a request whose over-limit verdict was read from Redis
+  before an invalidation arrived does not write the (possibly stale) entry into the local cache.
+  The suppressed insert only costs one extra Redis lookup on a later request.
+- Decrements routed to the dedicated per-second Redis (`REDIS_PERSECOND`) never publish: the
+  subscriber listens only on the main Redis, and per-second windows expire before a stale entry
+  matters.
+- Subscriber statistics: `ratelimit.localcache.invalidation.subscribed` (gauge, 0/1 live
+  subscription state), `ratelimit.localcache.invalidation.received` (messages received) and
+  `ratelimit.localcache.invalidation.deleted` (messages that deleted a local cache entry).
+
+#### Required Redis permissions
+
+With `ENABLE_NEGATIVE_HITS=true`, the identity configured by `REDIS_AUTH` needs the `EVAL`, `GET`
+and `SET` commands for the refund script. With the local cache additionally enabled, the same
+identity also needs `PUBLISH` and `SUBSCRIBE`, and with Redis 7 channel ACLs, access to the
+`&ratelimit:local_cache_invalidation` channel — it is used by both the refund script (publisher)
+and the invalidation subscriber.
+
+A missing `SUBSCRIBE` permission keeps publishing enabled while the subscriber retries forever —
+watch the `subscribed` gauge, every invalidation published in that state is lost. The refund
+script publishes before mutating the counter and mutates it with a single `SET ... EX`, so an ACL
+error at any command fails the refund without applying it.
 
 # GRPC Client
 
@@ -1214,6 +1269,34 @@ mappings: # Requires statsd exporter >= v0.6.0 since it uses the "drop" action.
 
   - match: "ratelimit.service.rate_limit.*.*.*.shadow_mode"
     name: "ratelimit_service_rate_limit_shadow_mode"
+    timer_type: "histogram"
+    labels:
+      domain: "$1"
+      key1: "$2"
+      key2: "$3"
+  - match: "ratelimit.service.negative_hits_rejected"
+    name: "ratelimit_service_negative_hits_rejected"
+    match_metric_type: counter
+
+  - match: "ratelimit.localcache.invalidation.subscribed"
+    name: "ratelimit_localcache_invalidation_subscribed"
+    match_metric_type: gauge
+  - match: "ratelimit.localcache.invalidation.received"
+    name: "ratelimit_localcache_invalidation_received"
+    match_metric_type: counter
+  - match: "ratelimit.localcache.invalidation.deleted"
+    name: "ratelimit_localcache_invalidation_deleted"
+    match_metric_type: counter
+
+  - match: "ratelimit.service.rate_limit.*.*.total_negative_hits"
+    name: "ratelimit_service_rate_limit_total_negative_hits"
+    timer_type: "histogram"
+    labels:
+      domain: "$1"
+      key1: "$2"
+  - match: "ratelimit\\.service\\.rate_limit\\.([^\\.]*)\\.([^\\.]*)\\.([^\\.]*)(\\..*)?\\.total_negative_hits"
+    match_type: regex
+    name: "ratelimit_service_rate_limit_total_negative_hits"
     timer_type: "histogram"
     labels:
       domain: "$1"

--- a/src/limiter/base_limiter.go
+++ b/src/limiter/base_limiter.go
@@ -4,7 +4,6 @@ import (
 	"math"
 	"math/rand"
 
-	"github.com/coocood/freecache"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	logger "github.com/sirupsen/logrus"
 
@@ -14,24 +13,12 @@ import (
 	"github.com/envoyproxy/ratelimit/src/utils"
 )
 
-// DecrementScript atomically decrements a rate limit counter, floored at 0.
-// If the key does not exist there is nothing to refund, so it returns 0 without
-// creating a phantom key.
-const DecrementScript = `
-local current = redis.call('GET', KEYS[1])                   -- get current count
-if current == false then return 0 end                        -- key absent: nothing to refund
-local new_val = math.floor(math.max(0, tonumber(current) - tonumber(ARGV[1]))) -- subtract hits, floor at 0
-redis.call('SET', KEYS[1], tostring(new_val))                -- persist new value
-redis.call('EXPIRE', KEYS[1], tonumber(ARGV[2]))             -- reset TTL
-return new_val                                               -- return count after decrement
-`
-
 type BaseRateLimiter struct {
 	timeSource                 utils.TimeSource
 	JitterRand                 *rand.Rand
 	ExpirationJitterMaxSeconds int64
 	cacheKeyGenerator          CacheKeyGenerator
-	localCache                 *freecache.Cache
+	localCache                 *LocalCacheGuard
 	nearLimitRatio             float32
 	StatsManager               stats.Manager
 	// useCalendarMonth gates the MONTH-unit fix (calendar-aligned window
@@ -103,10 +90,20 @@ func (this *BaseRateLimiter) IsOverLimitThresholdReached(limitInfo *LimitInfo) b
 	return limitInfo.limitAfterIncrease > limitInfo.overLimitThreshold
 }
 
+// GetLocalCacheGenSnapshot returns the invalidation generation to pass into
+// GetResponseDescriptorStatus; take it before the backend read.
+func (this *BaseRateLimiter) GetLocalCacheGenSnapshot() uint64 {
+	if this.localCache == nil {
+		return 0
+	}
+	return this.localCache.GenSnapshot()
+}
+
 // Generates response descriptor status based on cache key, over the limit with local cache, over the limit and
 // near the limit thresholds. Thresholds are checked in order and are mutually exclusive.
+// localCacheGen must be the LocalCacheGenSnapshot value taken before the backend read.
 func (this *BaseRateLimiter) GetResponseDescriptorStatus(key string, limitInfo *LimitInfo,
-	isOverLimitWithLocalCache bool, hitsAddend uint64,
+	isOverLimitWithLocalCache bool, hitsAddend uint64, localCacheGen uint64,
 ) *pb.RateLimitResponse_DescriptorStatus {
 	if key == "" {
 		return this.generateResponseDescriptorStatus(pb.RateLimitResponse_OK,
@@ -141,9 +138,12 @@ func (this *BaseRateLimiter) GetResponseDescriptorStatus(key string, limitInfo *
 				// similar to mongo_1h, mongo_2h, etc. In the hour 1 (0h0m - 0h59m), the cache key is mongo_1h, we start
 				// to get ratelimited in the 50th minute, the ttl of local_cache will be set as 1 hour(0h50m-1h49m).
 				// In the time of 1h1m, since the cache key becomes different (mongo_2h), it won't get ratelimited.
-				err := this.localCache.Set([]byte(key), []byte{}, int(this.ExpirationSeconds(limitInfo.limit.Limit.Unit)))
+				inserted, err := this.localCache.SetIfUnchanged([]byte(key), []byte{},
+					int(this.ExpirationSeconds(limitInfo.limit.Limit.Unit)), localCacheGen)
 				if err != nil {
 					logger.Errorf("Failing to set local cache key: %s", key)
+				} else if !inserted {
+					logger.Debugf("skipped local cache set for %s: invalidation raced the backend read", key)
 				}
 			}
 		} else {
@@ -190,7 +190,7 @@ func (this *BaseRateLimiter) GetResponseDescriptorStatusForNegativeHits(key stri
 }
 
 func NewBaseRateLimit(timeSource utils.TimeSource, jitterRand *rand.Rand, expirationJitterMaxSeconds int64,
-	localCache *freecache.Cache, nearLimitRatio float32, cacheKeyPrefix string, statsManager stats.Manager,
+	localCache *LocalCacheGuard, nearLimitRatio float32, cacheKeyPrefix string, statsManager stats.Manager,
 	useCalendarMonth bool,
 ) *BaseRateLimiter {
 	return &BaseRateLimiter{

--- a/src/limiter/local_cache_guard.go
+++ b/src/limiter/local_cache_guard.go
@@ -1,0 +1,56 @@
+package limiter
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/coocood/freecache"
+)
+
+// LocalCacheGuard orders local cache writes against invalidations: an insert
+// whose verdict predates a processed invalidation is suppressed, so it cannot
+// resurrect the entry the invalidation deleted. The generation is global per
+// replica — a false suppression only costs one extra Redis lookup.
+type LocalCacheGuard struct {
+	cache *freecache.Cache
+	mu    sync.Mutex
+	gen   atomic.Uint64
+}
+
+// NewLocalCacheGuard wraps the given cache; a nil cache yields a nil guard.
+func NewLocalCacheGuard(cache *freecache.Cache) *LocalCacheGuard {
+	if cache == nil {
+		return nil
+	}
+	return &LocalCacheGuard{cache: cache}
+}
+
+func (this *LocalCacheGuard) Get(key []byte) ([]byte, error) {
+	return this.cache.Get(key)
+}
+
+// GenSnapshot returns the invalidation generation; take it before the
+// backend read that may lead to a poisoning insert.
+func (this *LocalCacheGuard) GenSnapshot() uint64 {
+	return this.gen.Load()
+}
+
+// SetIfUnchanged inserts the entry unless an invalidation was processed since
+// the snapshot; it reports whether the insert happened.
+func (this *LocalCacheGuard) SetIfUnchanged(key []byte, value []byte, expireSeconds int, genSnapshot uint64) (bool, error) {
+	this.mu.Lock()
+	defer this.mu.Unlock()
+	if this.gen.Load() != genSnapshot {
+		return false, nil
+	}
+	return true, this.cache.Set(key, value, expireSeconds)
+}
+
+// Invalidate bumps the generation and deletes the entry, reporting whether it
+// existed.
+func (this *LocalCacheGuard) Invalidate(key []byte) bool {
+	this.mu.Lock()
+	defer this.mu.Unlock()
+	this.gen.Add(1)
+	return this.cache.Del(key)
+}

--- a/src/memcached/cache_impl.go
+++ b/src/memcached/cache_impl.go
@@ -70,6 +70,8 @@ func (this *rateLimitMemcacheImpl) DoLimit(
 ) []*pb.RateLimitResponse_DescriptorStatus {
 	logger.Debugf("starting cache lookup")
 
+	localCacheGen := this.baseRateLimiter.GetLocalCacheGenSnapshot()
+
 	// request.HitsAddend could be 0 (default value) if not specified by the caller in the Ratelimit request.
 	hitsAddends := utils.GetHitsAddends(request)
 
@@ -154,7 +156,7 @@ func (this *rateLimitMemcacheImpl) DoLimit(
 			limitInfo := limiter.NewRateLimitInfo(limits[i], limitBeforeIncrease, limitAfterIncrease, 0, 0)
 
 			responseDescriptorStatuses[i] = this.baseRateLimiter.GetResponseDescriptorStatus(cacheKey.Key,
-				limitInfo, isOverLimitWithLocalCache[i], hitsAddends[i].Value)
+				limitInfo, isOverLimitWithLocalCache[i], hitsAddends[i].Value, localCacheGen)
 		}
 	}
 
@@ -355,7 +357,7 @@ func NewRateLimitCacheImpl(client Client, timeSource utils.TimeSource, jitterRan
 		expirationJitterMaxSeconds: expirationJitterMaxSeconds,
 		localCache:                 localCache,
 		nearLimitRatio:             nearLimitRatio,
-		baseRateLimiter:            limiter.NewBaseRateLimit(timeSource, jitterRand, expirationJitterMaxSeconds, localCache, nearLimitRatio, cacheKeyPrefix, statsManager, useCalendarMonth),
+		baseRateLimiter:            limiter.NewBaseRateLimit(timeSource, jitterRand, expirationJitterMaxSeconds, limiter.NewLocalCacheGuard(localCache), nearLimitRatio, cacheKeyPrefix, statsManager, useCalendarMonth),
 	}
 }
 

--- a/src/redis/cache_impl.go
+++ b/src/redis/cache_impl.go
@@ -35,17 +35,33 @@ func NewRateLimiterCacheImplFromSettings(ctx context.Context, s settings.Setting
 		s.RedisCloseConnectionOnReadOnlyError)
 	closer.Closers = append(closer.Closers, otherPool)
 
+	var (
+		withLocalCache       = localCache != nil
+		localCacheGuard      *limiter.LocalCacheGuard
+		publishInvalidations bool
+	)
+	if withLocalCache {
+		localCacheGuard = limiter.NewLocalCacheGuard(localCache)
+		publishInvalidations = s.EnableNegativeHits && localCacheGuard != nil
+		if publishInvalidations {
+			// pub-sub based invalidator for local over limit caches
+			localCacheInvalidator := StartLocalCacheInvalidator(ctx, s, localCacheGuard, srv.Scope())
+			closer.Closers = append(closer.Closers, localCacheInvalidator)
+		}
+	}
+
 	return NewFixedRateLimitCacheImpl(
 		otherPool,
 		perSecondPool,
 		timeSource,
 		jitterRand,
 		expirationJitterMaxSeconds,
-		localCache,
+		localCacheGuard,
 		s.NearLimitRatio,
 		s.CacheKeyPrefix,
 		statsManager,
 		s.StopCacheKeyIncrementWhenOverlimit,
 		s.UseCalendarMonthRateLimit,
+		publishInvalidations,
 	), closer
 }

--- a/src/redis/driver_impl.go
+++ b/src/redis/driver_impl.go
@@ -110,6 +110,16 @@ func effectiveClusterPipelineParallelism(configuredParallelism, poolSize int) in
 	return configuredParallelism
 }
 
+// parseSentinelUrl splits a sentinel REDIS_URL of the form
+// <redis master name>,<sentinel1>,...,<sentineln>.
+func parseSentinelUrl(url string) (masterName string, sentinelAddrs []string, err error) {
+	urls := strings.Split(url, ",")
+	if len(urls) < 2 {
+		return "", nil, fmt.Errorf("Expected master name and a list of urls for the sentinels, in the format: <redis master name>,<sentinel1>,...,<sentineln>")
+	}
+	return urls[0], urls[1:], nil
+}
+
 // createDialer creates a radix.Dialer with timeout, TLS, and auth configuration
 // targetName is used for logging to identify the connection target (e.g., URL, "sentinel(url)")
 func createDialer(timeout time.Duration, useTls bool, tlsConfig *tls.Config, auth string, targetName string) radix.Dialer {
@@ -264,10 +274,13 @@ func newClientImpl(ctx context.Context, scope stats.Scope, useTls bool, auth, re
 	}
 
 	// Validate sentinel URL format early (before retry loop) since it's a configuration error.
+	var sentinelMasterName string
+	var sentinelAddrs []string
 	if strings.ToLower(redisType) == "sentinel" {
-		urls := strings.Split(url, ",")
-		if len(urls) < 2 {
-			panic(RedisError("Expected master name and a list of urls for the sentinels, in the format: <redis master name>,<sentinel1>,...,<sentineln>"))
+		var parseErr error
+		sentinelMasterName, sentinelAddrs, parseErr = parseSentinelUrl(url)
+		if parseErr != nil {
+			panic(RedisError(parseErr.Error()))
 		}
 	}
 
@@ -309,13 +322,12 @@ func newClientImpl(ctx context.Context, scope stats.Scope, useTls bool, auth, re
 			}
 			client, err = clusterConfig.New(ctx, urls)
 		case "sentinel":
-			urls := strings.Split(url, ",")
 			sentinelDialer := createDialer(timeout, useTls, tlsConfig, sentinelAuth, fmt.Sprintf("sentinel(%s)", maskedUrl))
 			sentinelConfig := radix.SentinelConfig{
 				PoolConfig:     poolConfig,
 				SentinelDialer: sentinelDialer,
 			}
-			client, err = sentinelConfig.New(ctx, urls[0], urls[1:])
+			client, err = sentinelConfig.New(ctx, sentinelMasterName, sentinelAddrs)
 		default:
 			panic(RedisError("Unrecognized redis type " + redisType))
 		}
@@ -381,8 +393,17 @@ func (c *clientImpl) PipeAppendWithRoutingKey(pipeline Pipeline, routingKey stri
 	allArgs := make([]interface{}, 0, 1+len(args))
 	allArgs = append(allArgs, key)
 	allArgs = append(allArgs, args...)
+	// The cluster client routes by ActionProperties.Keys, and radix's default
+	// resolver classifies EVAL/EVALSHA as keyless.
+	cfg := radix.CmdConfig{
+		ActionProperties: func(cmd string, args ...string) radix.ActionProperties {
+			props := radix.DefaultActionProperties(cmd, args...)
+			props.Keys = []string{routingKey}
+			return props
+		},
+	}
 	return append(pipeline, PipelineAction{
-		Action: radix.FlatCmd(rcv, cmd, allArgs...),
+		Action: cfg.FlatCmd(rcv, cmd, allArgs...),
 		Key:    routingKey,
 	})
 }

--- a/src/redis/fixed_cache_impl.go
+++ b/src/redis/fixed_cache_impl.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/envoyproxy/ratelimit/src/stats"
 
-	"github.com/coocood/freecache"
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	logger "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -29,7 +28,10 @@ type fixedRateLimitCacheImpl struct {
 	// is used for limits that have a SECOND unit.
 	perSecondClient                    Client
 	stopCacheKeyIncrementWhenOverlimit bool
-	baseRateLimiter                    *limiter.BaseRateLimiter
+	// Refunds crossing back under the limit publish the key on the local
+	// cache invalidation channel (main client only).
+	publishInvalidations bool
+	baseRateLimiter      *limiter.BaseRateLimiter
 }
 
 func pipelineAppend(client Client, pipeline *Pipeline, key string, hitsAddend uint64, result *uint64, expirationSeconds int64) {
@@ -37,25 +39,56 @@ func pipelineAppend(client Client, pipeline *Pipeline, key string, hitsAddend ui
 	*pipeline = client.PipeAppend(*pipeline, nil, "EXPIRE", key, expirationSeconds)
 }
 
-func pipelineAppendDecrement(client Client, pipeline *Pipeline, key string, hitsAddend uint64, result *uint64, expirationSeconds int64) {
+// DecrementScript atomically decrements a rate limit counter, floored at 0;
+// a missing key returns 0 without being created. ARGV: hits, expiration
+// seconds, '1'/'0' publish flag, requests per unit, invalidation channel.
+//
+// The key is published only when the refund crosses back under the limit —
+// one message per poisoning cycle. Command order is load-bearing: Lua does
+// not roll back on runtime errors, so PUBLISH must fail before the counter
+// is mutated and the mutation must be a single SET..EX, or an ACL denial
+// leaves a half-applied refund behind an errored RPC.
+const DecrementScript = `
+local current = redis.call('GET', KEYS[1])
+if current == false then return 0 end
+local old = tonumber(current)
+local new_val = math.floor(math.max(0, old - tonumber(ARGV[1])))
+if ARGV[3] == '1' then
+  local limit = tonumber(ARGV[4])
+  if old > limit and new_val <= limit then
+    redis.call('PUBLISH', ARGV[5], KEYS[1])
+  end
+end
+redis.call('SET', KEYS[1], tostring(new_val), 'EX', tonumber(ARGV[2]))
+return new_val
+`
+
+func pipelineAppendDecrement(client Client, pipeline *Pipeline, key string, hitsAddend uint64, result *uint64,
+	expirationSeconds int64, publishInvalidation bool, requestsPerUnit uint32,
+) {
+	publishFlag := "0"
+	if publishInvalidation {
+		publishFlag = "1"
+	}
 	// EVAL's first positional argument is the script body, not the key, so the
 	// real cache key must be passed explicitly as the routing key. Otherwise, in
 	// Redis Cluster mode the command would be routed using the script text,
 	// causing MOVED/CROSSSLOT errors or misrouting.
-	*pipeline = client.PipeAppendWithRoutingKey(*pipeline, key, result, "EVAL", limiter.DecrementScript, 1, key, hitsAddend, expirationSeconds)
+	*pipeline = client.PipeAppendWithRoutingKey(*pipeline, key, result, "EVAL", DecrementScript, 1, key,
+		hitsAddend, expirationSeconds, publishFlag, requestsPerUnit, LocalCacheInvalidationChannel)
 }
 
-func (this *fixedRateLimitCacheImpl) selectPipeline(cacheKey limiter.CacheKey, pipeline *Pipeline, perSecondPipeline *Pipeline) (Client, *Pipeline) {
+func (this *fixedRateLimitCacheImpl) selectPipeline(cacheKey limiter.CacheKey, pipeline *Pipeline, perSecondPipeline *Pipeline) (client Client, p *Pipeline, onPerSecondRedis bool) {
 	if this.perSecondClient != nil && cacheKey.PerSecond {
 		if *perSecondPipeline == nil {
 			*perSecondPipeline = Pipeline{}
 		}
-		return this.perSecondClient, perSecondPipeline
+		return this.perSecondClient, perSecondPipeline, true
 	}
 	if *pipeline == nil {
 		*pipeline = Pipeline{}
 	}
-	return this.client, pipeline
+	return this.client, pipeline, false
 }
 
 func pipelineAppendtoGet(client Client, pipeline *Pipeline, key string, result *uint64) {
@@ -98,6 +131,9 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 	limits []*config.RateLimit,
 ) []*pb.RateLimitResponse_DescriptorStatus {
 	logger.Debugf("starting cache lookup")
+
+	// pinning before any Redis read so a racing invalidation suppresses stale inserts to the local cache
+	localCacheGen := this.baseRateLimiter.GetLocalCacheGenSnapshot()
 
 	hitsAddends := utils.GetHitsAddends(request)
 
@@ -192,9 +228,12 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 			expirationSeconds += this.baseRateLimiter.JitterRand.Int63n(this.baseRateLimiter.ExpirationJitterMaxSeconds)
 		}
 
-		client, p := this.selectPipeline(cacheKey, &pipeline, &perSecondPipeline)
+		client, p, onPerSecondRedis := this.selectPipeline(cacheKey, &pipeline, &perSecondPipeline)
 		if hitsAddends[i].IsNegative {
-			pipelineAppendDecrement(client, p, cacheKey.Key, hitsAddends[i].Value, &results[i], expirationSeconds)
+			// The subscriber listens only on the main Redis.
+			publishInvalidation := this.publishInvalidations && !onPerSecondRedis
+			pipelineAppendDecrement(client, p, cacheKey.Key, hitsAddends[i].Value, &results[i], expirationSeconds,
+				publishInvalidation, limits[i].Limit.RequestsPerUnit)
 		} else {
 			pipelineAppend(client, p, cacheKey.Key, this.getHitsAddendValue(hitsAddends[i].Value,
 				isCacheKeyOverlimit, isCacheKeyNearlimit, nearlimitIndexes[i]), &results[i], expirationSeconds)
@@ -234,7 +273,7 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 			limitInfo := limiter.NewRateLimitInfo(limits[i], limitBeforeIncrease, limitAfterIncrease, 0, 0)
 
 			responseDescriptorStatuses[i] = this.baseRateLimiter.GetResponseDescriptorStatus(cacheKey.Key,
-				limitInfo, isOverLimitWithLocalCache[i], hitsAddends[i].Value)
+				limitInfo, isOverLimitWithLocalCache[i], hitsAddends[i].Value, localCacheGen)
 		}
 	}
 
@@ -245,13 +284,14 @@ func (this *fixedRateLimitCacheImpl) DoLimit(
 func (this *fixedRateLimitCacheImpl) Flush() {}
 
 func NewFixedRateLimitCacheImpl(client Client, perSecondClient Client, timeSource utils.TimeSource,
-	jitterRand *rand.Rand, expirationJitterMaxSeconds int64, localCache *freecache.Cache, nearLimitRatio float32, cacheKeyPrefix string, statsManager stats.Manager,
-	stopCacheKeyIncrementWhenOverlimit bool, useCalendarMonth bool,
+	jitterRand *rand.Rand, expirationJitterMaxSeconds int64, localCache *limiter.LocalCacheGuard, nearLimitRatio float32, cacheKeyPrefix string, statsManager stats.Manager,
+	stopCacheKeyIncrementWhenOverlimit bool, useCalendarMonth bool, publishInvalidations bool,
 ) limiter.RateLimitCache {
 	return &fixedRateLimitCacheImpl{
 		client:                             client,
 		perSecondClient:                    perSecondClient,
 		stopCacheKeyIncrementWhenOverlimit: stopCacheKeyIncrementWhenOverlimit,
+		publishInvalidations:               publishInvalidations,
 		baseRateLimiter:                    limiter.NewBaseRateLimit(timeSource, jitterRand, expirationJitterMaxSeconds, localCache, nearLimitRatio, cacheKeyPrefix, statsManager, useCalendarMonth),
 	}
 }

--- a/src/redis/local_cache_invalidator.go
+++ b/src/redis/local_cache_invalidator.go
@@ -1,0 +1,274 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/jpillora/backoff"
+	gostats "github.com/lyft/gostats"
+	"github.com/mediocregopher/radix/v4"
+	logger "github.com/sirupsen/logrus"
+
+	"github.com/envoyproxy/ratelimit/src/assert"
+	"github.com/envoyproxy/ratelimit/src/limiter"
+	"github.com/envoyproxy/ratelimit/src/settings"
+	"github.com/envoyproxy/ratelimit/src/utils"
+)
+
+// Cache keys published here are evicted from every replica's local cache.
+const LocalCacheInvalidationChannel = "ratelimit:local_cache_invalidation"
+
+type localCacheInvalidationStats struct {
+	subscribed gostats.Gauge
+	received   gostats.Counter
+	deleted    gostats.Counter
+}
+
+func newLocalCacheInvalidationStats(scope gostats.Scope) localCacheInvalidationStats {
+	invalidationScope := scope.Scope("localcache").Scope("invalidation")
+	return localCacheInvalidationStats{
+		subscribed: invalidationScope.NewGauge("subscribed"),
+		received:   invalidationScope.NewCounter("received"),
+		deleted:    invalidationScope.NewCounter("deleted"),
+	}
+}
+
+// LocalCacheInvalidator deletes cache keys published on the invalidation
+// channel from this replica's local cache. Best-effort, at-most-once: a
+// missed message leaves the stale entry until the window ends.
+//
+// It owns one raw connection instead of reusing the driver's clients: radix
+// pub/sub wraps a single Conn (pooled clients cannot subscribe), and losing
+// it must never take the process down — the loop reconnects forever.
+type LocalCacheInvalidator struct {
+	localCache *limiter.LocalCacheGuard
+	stats      localCacheInvalidationStats
+
+	redisType      string
+	socketType     string
+	url            string
+	dialer         radix.Dialer
+	sentinelDialer radix.Dialer
+
+	// clusterAddrs is refreshed from the live topology on every (re)connect.
+	clusterAddrs        []string
+	sentinelMasterName  string
+	sentinelAddrs       []string
+	addrIndex           int
+	resubscribeInterval time.Duration
+	// An endpoint that accepts and then stalls must not wedge the reconnect
+	// loop away from the remaining candidates.
+	connectTimeout time.Duration
+
+	backoff *backoff.Backoff
+	cancel  context.CancelFunc
+	done    chan struct{}
+}
+
+// StartLocalCacheInvalidator starts the eviction loop against the main Redis.
+func StartLocalCacheInvalidator(ctx context.Context, s settings.Settings, localCache *limiter.LocalCacheGuard, scope gostats.Scope) *LocalCacheInvalidator {
+	assert.Assert(localCache != nil)
+	maskedUrl := utils.MaskCredentialsInUrl(s.RedisUrl)
+	this := &LocalCacheInvalidator{
+		localCache:          localCache,
+		stats:               newLocalCacheInvalidationStats(scope),
+		redisType:           strings.ToLower(s.RedisType),
+		socketType:          s.RedisSocketType,
+		url:                 s.RedisUrl,
+		dialer:              createDialer(s.RedisTimeout, s.RedisTls, s.RedisTlsConfig, s.RedisAuth, maskedUrl),
+		sentinelDialer:      createDialer(s.RedisTimeout, s.RedisTls, s.RedisTlsConfig, s.RedisSentinelAuth, fmt.Sprintf("sentinel(%s)", maskedUrl)),
+		resubscribeInterval: s.LocalCacheInvalidationResubscribeInterval,
+		backoff: &backoff.Backoff{
+			Min:    time.Second,
+			Max:    30 * time.Second,
+			Factor: 2,
+			Jitter: true,
+		},
+		done: make(chan struct{}),
+	}
+	if this.resubscribeInterval <= 0 {
+		this.resubscribeInterval = 5 * time.Minute
+	}
+	this.connectTimeout = s.RedisTimeout
+	if this.connectTimeout <= 0 {
+		this.connectTimeout = 10 * time.Second
+	}
+
+	switch this.redisType {
+	case "single":
+	case "cluster":
+		this.clusterAddrs = strings.Split(this.url, ",")
+	case "sentinel":
+		var err error
+		this.sentinelMasterName, this.sentinelAddrs, err = parseSentinelUrl(this.url)
+		if err != nil {
+			panic(RedisError(err.Error()))
+		}
+	default:
+		panic(RedisError("Unrecognized redis type " + this.redisType))
+	}
+
+	ctx, this.cancel = context.WithCancel(ctx)
+	logger.Warnf("starting local cache invalidation subscriber on redis %s", maskedUrl)
+	go this.run(ctx)
+	return this
+}
+
+func (this *LocalCacheInvalidator) Close() error {
+	this.cancel()
+	<-this.done
+	return nil
+}
+
+func (this *LocalCacheInvalidator) run(ctx context.Context) {
+	defer close(this.done)
+	for {
+		err := this.subscribeAndConsume(ctx)
+		if err != nil && ctx.Err() == nil {
+			logger.Warnf("local cache invalidation subscription lost: %v", err)
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		if err == nil {
+			// Routine session rotation: reconnect immediately.
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(this.backoff.Duration()):
+		}
+	}
+}
+
+func (this *LocalCacheInvalidator) subscribeAndConsume(ctx context.Context) error {
+	conn, err := this.connect(ctx)
+	if err != nil {
+		return err
+	}
+
+	sessionCtx, cancel := context.WithTimeout(ctx, this.resubscribeInterval)
+	defer cancel()
+
+	pubSubConn := radix.PubSubConfig{}.New(conn)
+	defer pubSubConn.Close()
+
+	if err := pubSubConn.Subscribe(sessionCtx, LocalCacheInvalidationChannel); err != nil {
+		return err
+	}
+	this.backoff.Reset()
+	this.stats.subscribed.Set(1)
+	defer this.stats.subscribed.Set(0)
+	logger.Debugf("subscribed to %s for local cache invalidation", LocalCacheInvalidationChannel)
+
+	for {
+		message, err := pubSubConn.Next(sessionCtx)
+		if err != nil {
+			if sessionCtx.Err() != nil && ctx.Err() == nil {
+				logger.Debugf("rotating local cache invalidation subscription")
+				return nil
+			}
+			return err
+		}
+		this.stats.received.Inc()
+		if this.localCache.Invalidate(message.Message) {
+			this.stats.deleted.Inc()
+		}
+	}
+}
+
+// connect establishes a confirmed connection within connectTimeout: radix's
+// pub/sub Subscribe and Ping are flush-only, so the PING round trip is the
+// only bounded proof that the endpoint responds.
+func (this *LocalCacheInvalidator) connect(ctx context.Context) (radix.Conn, error) {
+	ctx, cancel := context.WithTimeout(ctx, this.connectTimeout)
+	defer cancel()
+	conn, err := this.dial(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := conn.Do(ctx, radix.Cmd(nil, "PING")); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (this *LocalCacheInvalidator) dial(ctx context.Context) (radix.Conn, error) {
+	switch this.redisType {
+	case "single":
+		return this.dialer.Dial(ctx, this.socketType, this.url)
+	case "cluster":
+		// Any node works (cluster pub/sub is broadcast), always over TCP:
+		// radix's cluster client ignores REDIS_SOCKET_TYPE (default "unix")
+		// for its host:port seeds, and the subscriber must match.
+		addr := this.clusterAddrs[this.addrIndex%len(this.clusterAddrs)]
+		this.addrIndex++
+		conn, err := this.dialer.Dial(ctx, "tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		this.refreshClusterAddrs(ctx, conn)
+		return conn, nil
+	case "sentinel":
+		return this.dialSentinelMaster(ctx)
+	default:
+		return nil, fmt.Errorf("unrecognized redis type %s", this.redisType)
+	}
+}
+
+// refreshClusterAddrs re-reads the topology so reconnects survive replacement
+// of every bootstrap node; on failure the current list is kept.
+func (this *LocalCacheInvalidator) refreshClusterAddrs(ctx context.Context, conn radix.Conn) {
+	var topo radix.ClusterTopo
+	if err := conn.Do(ctx, radix.Cmd(&topo, "CLUSTER", "SLOTS")); err != nil {
+		logger.Warnf("could not refresh cluster topology for the invalidation subscriber: %v", err)
+		return
+	}
+	if len(topo) == 0 {
+		return
+	}
+	addrs := make([]string, 0, len(topo))
+	for addr := range topo.Map() {
+		addrs = append(addrs, addr)
+	}
+	this.clusterAddrs = addrs
+}
+
+func (this *LocalCacheInvalidator) dialSentinelMaster(ctx context.Context) (radix.Conn, error) {
+	masterName := this.sentinelMasterName
+
+	// A stalled sentinel consumes the whole connect budget; rotating the
+	// start keeps it from starving the healthy ones behind it.
+	start := this.addrIndex
+	this.addrIndex++
+
+	var lastErr error
+	for i := range this.sentinelAddrs {
+		sentinelUrl := this.sentinelAddrs[(start+i)%len(this.sentinelAddrs)]
+		sentinelConn, err := this.sentinelDialer.Dial(ctx, "tcp", sentinelUrl)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		var masterAddr []string
+		err = sentinelConn.Do(ctx, radix.Cmd(&masterAddr, "SENTINEL", "GET-MASTER-ADDR-BY-NAME", masterName))
+		sentinelConn.Close()
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if len(masterAddr) != 2 {
+			lastErr = fmt.Errorf("sentinel did not resolve a master address for %s", masterName)
+			continue
+		}
+
+		return this.dialer.Dial(ctx, "tcp", net.JoinHostPort(masterAddr[0], masterAddr[1]))
+	}
+	return nil, fmt.Errorf("could not resolve master %s through any sentinel: %w", masterName, lastErr)
+}

--- a/src/service/ratelimit.go
+++ b/src/service/ratelimit.go
@@ -22,6 +22,8 @@ import (
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
 	logger "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/envoyproxy/ratelimit/src/assert"
 	"github.com/envoyproxy/ratelimit/src/config"
@@ -55,6 +57,7 @@ type service struct {
 	globalQuotaMode                bool
 	responseDynamicMetadataEnabled bool
 	useCalendarMonthRateLimit      bool
+	enableNegativeHits             bool
 }
 
 func (this *service) SetConfig(updateEvent provider.ConfigUpdateEvent, healthyWithAtLeastOneConfigLoad bool) {
@@ -109,6 +112,14 @@ func (this *service) SetConfig(updateEvent provider.ConfigUpdateEvent, healthyWi
 type serviceError string
 
 func (e serviceError) Error() string {
+	return string(e)
+}
+
+// negativeHitsDisabledError rejects requests containing negative-hit
+// descriptors while ENABLE_NEGATIVE_HITS is off; mapped to UNIMPLEMENTED.
+type negativeHitsDisabledError string
+
+func (e negativeHitsDisabledError) Error() string {
 	return string(e)
 }
 
@@ -190,6 +201,16 @@ func (this *service) shouldRateLimitWorker(
 ) *pb.RateLimitResponse {
 	checkServiceErr(request.Domain != "", "rate limit domain must not be empty")
 	checkServiceErr(len(request.Descriptors) != 0, "rate limit descriptor list must not be empty")
+
+	// A negative hit must never fall through as a positive hit: the whole
+	// request is rejected before the cache call.
+	if !this.enableNegativeHits {
+		for _, descriptor := range request.Descriptors {
+			if descriptor.GetIsNegativeHits() {
+				panic(negativeHitsDisabledError("negative hits are not enabled on this server"))
+			}
+		}
+	}
 
 	snappedConfig, globalShadowMode, globalQuotaMode := this.GetCurrentConfig()
 	limitsToCheck, isUnlimited := this.constructLimitsToCheck(request, ctx, snappedConfig)
@@ -434,6 +455,13 @@ func (this *service) ShouldRateLimit(
 				this.stats.ShouldRateLimit.ServiceError.Inc()
 				finalError = t
 			}
+		case negativeHitsDisabledError:
+			{
+				if this.stats.NegativeHitsRejected != nil {
+					this.stats.NegativeHitsRejected.Inc()
+				}
+				finalError = status.Error(codes.Unimplemented, t.Error())
+			}
 		default:
 			panic(err)
 		}
@@ -453,17 +481,19 @@ func (this *service) GetCurrentConfig() (config.RateLimitConfig, bool, bool) {
 
 func NewService(cache limiter.RateLimitCache, configProvider provider.RateLimitConfigProvider, statsManager stats.Manager,
 	health *server.HealthChecker, clock utils.TimeSource, shadowMode, forceStart bool, healthyWithAtLeastOneConfigLoad bool,
+	enableNegativeHits bool,
 ) RateLimitServiceServer {
 	newService := &service{
-		configLock:        sync.RWMutex{},
-		configUpdateEvent: configProvider.ConfigUpdateEvent(),
-		config:            nil,
-		cache:             cache,
-		stats:             statsManager.NewServiceStats(),
-		health:            health,
-		globalShadowMode:  shadowMode,
-		globalQuotaMode:   false,
-		customHeaderClock: clock,
+		configLock:         sync.RWMutex{},
+		configUpdateEvent:  configProvider.ConfigUpdateEvent(),
+		config:             nil,
+		cache:              cache,
+		stats:              statsManager.NewServiceStats(),
+		health:             health,
+		globalShadowMode:   shadowMode,
+		globalQuotaMode:    false,
+		customHeaderClock:  clock,
+		enableNegativeHits: enableNegativeHits,
 	}
 
 	if !forceStart {

--- a/src/service_cmd/runner/runner.go
+++ b/src/service_cmd/runner/runner.go
@@ -144,6 +144,10 @@ func (runner *Runner) Run() {
 	}()
 
 	s := runner.settings
+	if err := s.Validate(); err != nil {
+		logger.Fatalf("%s", err)
+	}
+
 	if s.TracingEnabled {
 		tp := trace.InitProductionTraceProvider(s.TracingExporterProtocol, s.TracingServiceName, s.TracingServiceNamespace, s.TracingServiceInstanceId, s.TracingSamplingRate)
 		defer func() {
@@ -202,6 +206,7 @@ func (runner *Runner) Run() {
 		s.GlobalShadowMode,
 		s.ForceStartWithoutInitialConfig,
 		s.HealthyWithAtLeastOneConfigLoaded,
+		s.EnableNegativeHits,
 	)
 
 	srv.AddDebugHttpEndpoint(

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"crypto/tls"
+	"errors"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -110,6 +111,14 @@ type Settings struct {
 	CacheKeyPrefix                     string  `envconfig:"CACHE_KEY_PREFIX" default:""`
 	BackendType                        string  `envconfig:"BACKEND_TYPE" default:"redis"`
 	StopCacheKeyIncrementWhenOverlimit bool    `envconfig:"STOP_CACHE_KEY_INCREMENT_WHEN_OVERLIMIT" default:"false"`
+	// EnableNegativeHits gates the `is_negative_hits` descriptor feature (refunds).
+	// When false, requests containing negative-hit descriptors are rejected with
+	// UNIMPLEMENTED — never processed as positive hits.
+	EnableNegativeHits bool `envconfig:"ENABLE_NEGATIVE_HITS" default:"false"`
+	// LocalCacheInvalidationResubscribeInterval bounds one invalidation pub/sub
+	// session, capping how long a subscription can stay silently stranded on a
+	// demoted or removed node.
+	LocalCacheInvalidationResubscribeInterval time.Duration `envconfig:"LOCAL_CACHE_INVALIDATION_RESUBSCRIBE_INTERVAL" default:"5m"`
 	// UseCalendarMonthRateLimit switches MONTH-unit rate limits to a true calendar
 	// month window (the 1st through the last day of the month, UTC) for cache key
 	// bucketing, TTL/expiration, and the reported reset time. Defaults to false,
@@ -265,6 +274,22 @@ type Settings struct {
 }
 
 type Option func(*Settings)
+
+// Validate checks for setting combinations that must not be allowed to boot.
+func (s Settings) Validate() error {
+	// The runner creates a cache for any non-zero size and freecache clamps
+	// sub-minimum sizes up, so a negative value would silently enable the
+	// local cache behind the check below.
+	if s.LocalCacheSizeInBytes < 0 {
+		return errors.New("LOCAL_CACHE_SIZE_IN_BYTES must not be negative")
+	}
+	// Refunds cannot invalidate memcached-backed local cache entries, so an
+	// over-limit key would keep blocking until the window ends.
+	if s.EnableNegativeHits && s.BackendType == "memcache" && s.LocalCacheSizeInBytes > 0 {
+		return errors.New("negative hits cannot be combined with memcached and local cache")
+	}
+	return nil
+}
 
 func NewSettings() Settings {
 	var s Settings

--- a/src/stats/manager.go
+++ b/src/stats/manager.go
@@ -43,6 +43,8 @@ type ServiceStats struct {
 	ConfigLoadError   gostats.Counter
 	ShouldRateLimit   ShouldRateLimitStats
 	GlobalShadowMode  gostats.Counter
+	// Requests rejected while ENABLE_NEGATIVE_HITS is off.
+	NegativeHitsRejected gostats.Counter
 }
 
 // Stats for an individual rate limit config entry.

--- a/src/stats/manager_impl.go
+++ b/src/stats/manager_impl.go
@@ -60,6 +60,7 @@ func (this *ManagerImpl) NewServiceStats() ServiceStats {
 	ret.ConfigLoadError = this.serviceStatsScope.NewCounter("config_load_error")
 	ret.ShouldRateLimit = this.NewShouldRateLimitStats()
 	ret.GlobalShadowMode = this.serviceStatsScope.NewCounter("global_shadow_mode")
+	ret.NegativeHitsRejected = this.serviceStatsScope.NewCounter("negative_hits_rejected")
 	return ret
 }
 

--- a/src/stats/prom/default_mapper.yaml
+++ b/src/stats/prom/default_mapper.yaml
@@ -96,3 +96,31 @@ mappings:
   - match: "ratelimit.service.config_load_error"
     name: "ratelimit_service_config_load_error"
     match_metric_type: counter
+  - match: "ratelimit.service.negative_hits_rejected"
+    name: "ratelimit_service_negative_hits_rejected"
+    match_metric_type: counter
+
+  - match: "ratelimit.localcache.invalidation.subscribed"
+    name: "ratelimit_localcache_invalidation_subscribed"
+    match_metric_type: gauge
+  - match: "ratelimit.localcache.invalidation.received"
+    name: "ratelimit_localcache_invalidation_received"
+    match_metric_type: counter
+  - match: "ratelimit.localcache.invalidation.deleted"
+    name: "ratelimit_localcache_invalidation_deleted"
+    match_metric_type: counter
+
+  - match: "ratelimit.service.rate_limit.*.*.total_negative_hits"
+    name: "ratelimit_service_rate_limit_total_negative_hits"
+    timer_type: "histogram"
+    labels:
+      domain: "$1"
+      key1: "$2"
+  - match: "ratelimit\\.service\\.rate_limit\\.([^\\.]*)\\.([^\\.]*)\\.([^\\.]*)(\\..*)?\\.total_negative_hits"
+    match_type: regex
+    name: "ratelimit_service_rate_limit_total_negative_hits"
+    timer_type: "histogram"
+    labels:
+      domain: "$1"
+      key1: "$2"
+      key2: "$3"

--- a/src/stats/prom/prometheus_sink_test.go
+++ b/src/stats/prom/prometheus_sink_test.go
@@ -185,3 +185,36 @@ func TestFlushResponseTimeCanUseLegacyMilliseconds(t *testing.T) {
 			*m.Metric[0].Histogram.SampleSum == 1000.0
 	}, time.Second, time.Millisecond)
 }
+
+func TestFlushNegativeHitsAndInvalidationMetrics(t *testing.T) {
+	s.FlushCounter("ratelimit.service.negative_hits_rejected", 3)
+	s.FlushGauge("ratelimit.localcache.invalidation.subscribed", 1)
+	s.FlushCounter("ratelimit.localcache.invalidation.received", 5)
+	s.FlushCounter("ratelimit.localcache.invalidation.deleted", 4)
+	assert.Eventually(t, func() bool {
+		metricFamilies, err := prometheus.DefaultGatherer.Gather()
+		if err != nil {
+			return false
+		}
+
+		metrics := make(map[string]*dto.MetricFamily)
+		for _, metricFamily := range metricFamilies {
+			metrics[*metricFamily.Name] = metricFamily
+		}
+
+		rejected, ok := metrics["ratelimit_service_negative_hits_rejected"]
+		if !ok || len(rejected.Metric) != 1 || *rejected.Metric[0].Counter.Value != 3.0 {
+			return false
+		}
+		subscribed, ok := metrics["ratelimit_localcache_invalidation_subscribed"]
+		if !ok || len(subscribed.Metric) != 1 || *subscribed.Metric[0].Gauge.Value != 1.0 {
+			return false
+		}
+		received, ok := metrics["ratelimit_localcache_invalidation_received"]
+		if !ok || len(received.Metric) != 1 || *received.Metric[0].Counter.Value != 5.0 {
+			return false
+		}
+		deleted, ok := metrics["ratelimit_localcache_invalidation_deleted"]
+		return ok && len(deleted.Metric) == 1 && *deleted.Metric[0].Counter.Value == 4.0
+	}, time.Second, time.Millisecond)
+}

--- a/src/utils/multi_closer.go
+++ b/src/utils/multi_closer.go
@@ -12,7 +12,7 @@ type MultiCloser struct {
 func (m *MultiCloser) Close() error {
 	var e error
 	for _, closer := range m.Closers {
-		e = errors.Join(closer.Close())
+		e = errors.Join(e, closer.Close())
 	}
 	return e
 }

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -93,7 +93,9 @@ func TestNegativeHitsIntegration(t *testing.T) {
 	common.WithMultiRedis(t, []common.RedisConfig{
 		{Port: 6383},
 	}, func() {
-		t.Run("Redis", testNegativeHits(makeSimpleRedisSettings(6383, 6380, false, 0)))
+		s := makeSimpleRedisSettings(6383, 6380, false, 0)
+		s.EnableNegativeHits = true
+		t.Run("Redis", testNegativeHits(s))
 	})
 }
 
@@ -132,6 +134,123 @@ func testNegativeHits(s settings.Settings) func(*testing.T) {
 		assert.NoError(err)
 		assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
 		assert.Equal(uint32(47), response.Statuses[0].LimitRemaining)
+	}
+}
+
+// TestNegativeHitsMemcacheIntegration verifies that refunds keep working with
+// the flag on and no local cache on the memcached backend (the boot guard only
+// blocks the combination with a local cache).
+func TestNegativeHitsMemcacheIntegration(t *testing.T) {
+	common.WithMultiMemcache(t, []common.MemcacheConfig{
+		{Port: 6394},
+	}, func() {
+		s := makeSimpleMemcacheSettings([]int{6394}, 0)
+		s.EnableNegativeHits = true
+		t.Run("Memcache", testNegativeHits(s))
+	})
+}
+
+func TestNegativeHitsCrossReplicaInvalidationIntegration(t *testing.T) {
+	common.WithMultiRedis(t, []common.RedisConfig{
+		{Port: 6383},
+	}, func() {
+		sA := makeSimpleRedisSettings(6383, 6380, false, 1000)
+		sA.EnableNegativeHits = true
+
+		sB := makeSimpleRedisSettings(6383, 6380, false, 1000)
+		sB.EnableNegativeHits = true
+		sB.Port = 8085
+		sB.GrpcPort = 8086
+		sB.DebugPort = 8087
+
+		t.Run("Redis", testNegativeHitsCrossReplicaInvalidation(sA, sB))
+	})
+}
+
+func testNegativeHitsCrossReplicaInvalidation(sA, sB settings.Settings) func(*testing.T) {
+	return func(t *testing.T) {
+		runnerA := startTestRunner(t, sA)
+		defer runnerA.Stop()
+		runnerB := startTestRunner(t, sB)
+		defer runnerB.Stop()
+
+		assert := assert.New(t)
+
+		connA, err := grpc.Dial(fmt.Sprintf("localhost:%v", sA.GrpcPort), grpc.WithInsecure())
+		assert.NoError(err)
+		defer connA.Close()
+		clientA := pb.NewRateLimitServiceClient(connA)
+
+		connB, err := grpc.Dial(fmt.Sprintf("localhost:%v", sB.GrpcPort), grpc.WithInsecure())
+		assert.NoError(err)
+		defer connB.Close()
+		clientB := pb.NewRateLimitServiceClient(connB)
+
+		// Both invalidation subscribers must be live before the refund publishes.
+		subscribedA := runnerA.GetStatsStore().NewGauge("ratelimit.localcache.invalidation.subscribed")
+		subscribedB := runnerB.GetStatsStore().NewGauge("ratelimit.localcache.invalidation.subscribed")
+		assert.Eventually(func() bool { return subscribedA.Value() == 1 }, 5*time.Second, 10*time.Millisecond)
+		assert.Eventually(func() bool { return subscribedB.Value() == 1 }, 5*time.Second, 10*time.Millisecond)
+
+		// key3_local has a limit of 10 per hour.
+		desc := [][][2]string{{{"key3_local", "cross"}}}
+
+		// Drive the counter over the limit through replica A (0 -> 11).
+		response, err := clientA.ShouldRateLimit(
+			context.Background(),
+			common.NewRateLimitRequest("another", desc, 11))
+		assert.NoError(err)
+		assert.Equal(pb.RateLimitResponse_OVER_LIMIT, response.OverallCode)
+
+		// Push replica B over the limit too (11 -> 12) so it poisons its own
+		// local cache.
+		response, err = clientB.ShouldRateLimit(
+			context.Background(),
+			common.NewRateLimitRequest("another", desc, 1))
+		assert.NoError(err)
+		assert.Equal(pb.RateLimitResponse_OVER_LIMIT, response.OverallCode)
+
+		// Both replicas now answer from their poisoned local caches.
+		localCacheOverLimitA := runnerA.GetStatsStore().NewCounter("ratelimit.service.rate_limit.another.key3_local.over_limit_with_local_cache")
+		localCacheOverLimitB := runnerB.GetStatsStore().NewCounter("ratelimit.service.rate_limit.another.key3_local.over_limit_with_local_cache")
+
+		response, err = clientA.ShouldRateLimit(
+			context.Background(),
+			common.NewRateLimitRequest("another", desc, 1))
+		assert.NoError(err)
+		assert.Equal(pb.RateLimitResponse_OVER_LIMIT, response.OverallCode)
+		assert.EqualValues(1, localCacheOverLimitA.Value())
+
+		response, err = clientB.ShouldRateLimit(
+			context.Background(),
+			common.NewRateLimitRequest("another", desc, 1))
+		assert.NoError(err)
+		assert.Equal(pb.RateLimitResponse_OVER_LIMIT, response.OverallCode)
+		assert.EqualValues(1, localCacheOverLimitB.Value())
+
+		// Refund through replica A only: 12 - 3 = 9 crosses back under the
+		// limit of 10, publishing an invalidation for every replica.
+		response, err = clientA.ShouldRateLimit(
+			context.Background(),
+			common.NewRateLimitRequestWithNegativeHits("another", desc, []uint64{3}, []bool{true}))
+		assert.NoError(err)
+		assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+
+		// Replica B receives the invalidation and drops its poisoned entry.
+		receivedB := runnerB.GetStatsStore().NewCounter("ratelimit.localcache.invalidation.received")
+		deletedB := runnerB.GetStatsStore().NewCounter("ratelimit.localcache.invalidation.deleted")
+		assert.Eventually(func() bool { return receivedB.Value() == 1 }, 5*time.Second, 10*time.Millisecond)
+		assert.Eventually(func() bool { return deletedB.Value() == 1 }, 5*time.Second, 10*time.Millisecond)
+
+		// Replica B answers from Redis again: 9 + 1 = 10 <= 10 -> OK.
+		response, err = clientB.ShouldRateLimit(
+			context.Background(),
+			common.NewRateLimitRequest("another", desc, 1))
+		assert.NoError(err)
+		assert.Equal(pb.RateLimitResponse_OK, response.OverallCode)
+		assert.EqualValues(0, uint64(response.Statuses[0].LimitRemaining))
+		// B's local cache was not consulted for the final answer.
+		assert.EqualValues(1, localCacheOverLimitB.Value())
 	}
 }
 

--- a/test/limiter/base_limiter_test.go
+++ b/test/limiter/base_limiter_test.go
@@ -205,7 +205,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	localCache := freecache.NewCache(100)
 	localCache.Set([]byte("key"), []byte("value"), 100)
 	sm := mockstats.NewMockStatManager(stats.NewStore(stats.NewNullSink(), false))
-	baseRateLimit := limiter.NewBaseRateLimit(nil, nil, 3600, localCache, 0.8, "", sm, false)
+	baseRateLimit := limiter.NewBaseRateLimit(nil, nil, 3600, limiter.NewLocalCacheGuard(localCache), 0.8, "", sm, false)
 	// Returns true, as local cache contains over limit value for the key.
 	assert.Equal(true, baseRateLimit.IsOverLimitWithLocalCache("key"))
 }
@@ -219,7 +219,7 @@ func TestNoOverLimitWithLocalCache(t *testing.T) {
 	// Returns false, as local cache is nil.
 	assert.Equal(false, baseRateLimit.IsOverLimitWithLocalCache("domain_key_value_1234"))
 	localCache := freecache.NewCache(100)
-	baseRateLimitWithLocalCache := limiter.NewBaseRateLimit(nil, nil, 3600, localCache, 0.8, "", sm, false)
+	baseRateLimitWithLocalCache := limiter.NewBaseRateLimit(nil, nil, 3600, limiter.NewLocalCacheGuard(localCache), 0.8, "", sm, false)
 	// Returns false, as local cache does not contain value for cache key.
 	assert.Equal(false, baseRateLimitWithLocalCache.IsOverLimitWithLocalCache("domain_key_value_1234"))
 }
@@ -230,7 +230,7 @@ func TestGetResponseStatusEmptyKey(t *testing.T) {
 	defer controller.Finish()
 	sm := mockstats.NewMockStatManager(stats.NewStore(stats.NewNullSink(), false))
 	baseRateLimit := limiter.NewBaseRateLimit(nil, nil, 3600, nil, 0.8, "", sm, false)
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("", nil, false, 1)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus("", nil, false, 1, 0)
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
 }
@@ -247,7 +247,7 @@ func TestGetResponseStatusOverLimitWithLocalCache(t *testing.T) {
 	limits := []*config.RateLimit{config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 6, 4, 5)
 	// As `isOverLimitWithLocalCache` is passed as `true`, immediate response is returned with no checks of the limits.
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, true, 2)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, true, 2, 0)
 	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
 	assert.Equal(limits[0].Limit, responseStatus.GetCurrentLimit())
@@ -270,7 +270,7 @@ func TestGetResponseStatusOverLimitWithLocalCacheShadowMode(t *testing.T) {
 	limits := []*config.RateLimit{config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, true, false, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 6, 4, 5)
 	// As `isOverLimitWithLocalCache` is passed as `true`, immediate response is returned with no checks of the limits.
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, true, 2)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, true, 2, 0)
 	// Limit is reached, but response is still OK due to ShadowMode
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
@@ -290,10 +290,10 @@ func TestGetResponseStatusOverLimit(t *testing.T) {
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 	localCache := freecache.NewCache(100)
 	sm := mockstats.NewMockStatManager(statsStore)
-	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, localCache, 0.8, "", sm, false)
+	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, limiter.NewLocalCacheGuard(localCache), 0.8, "", sm, false)
 	limits := []*config.RateLimit{config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 7, 4, 5)
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1, baseRateLimit.LocalCacheGenSnapshot())
 	assert.Equal(pb.RateLimitResponse_OVER_LIMIT, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
 	assert.Equal(limits[0].Limit, responseStatus.GetCurrentLimit())
@@ -315,11 +315,11 @@ func TestGetResponseStatusOverLimitShadowMode(t *testing.T) {
 	statsStore := stats.NewStore(stats.NewNullSink(), false)
 	localCache := freecache.NewCache(100)
 	sm := mockstats.NewMockStatManager(statsStore)
-	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, localCache, 0.8, "", sm, false)
+	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, limiter.NewLocalCacheGuard(localCache), 0.8, "", sm, false)
 	// Key is in shadow_mode: true
 	limits := []*config.RateLimit{config.NewRateLimit(5, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, true, false, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 7, 4, 5)
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1, baseRateLimit.LocalCacheGenSnapshot())
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(0), responseStatus.GetLimitRemaining())
 	assert.Equal(limits[0].Limit, responseStatus.GetCurrentLimit())
@@ -341,7 +341,7 @@ func TestGetResponseStatusBelowLimit(t *testing.T) {
 	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, nil, 0.8, "", sm, false)
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 6, 9, 10)
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1, baseRateLimit.LocalCacheGenSnapshot())
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(4), responseStatus.GetLimitRemaining())
 	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())
@@ -362,7 +362,7 @@ func TestGetResponseStatusBelowLimitShadowMode(t *testing.T) {
 	baseRateLimit := limiter.NewBaseRateLimit(timeSource, nil, 3600, nil, 0.8, "", sm, false)
 	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, true, false, "", nil, false)}
 	limitInfo := limiter.NewRateLimitInfo(limits[0], 2, 6, 9, 10)
-	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1)
+	responseStatus := baseRateLimit.GetResponseDescriptorStatus("key", limitInfo, false, 1, baseRateLimit.LocalCacheGenSnapshot())
 	assert.Equal(pb.RateLimitResponse_OK, responseStatus.GetCode())
 	assert.Equal(uint32(4), responseStatus.GetLimitRemaining())
 	assert.Equal(uint64(0), limits[0].Stats.NearLimit.Value())

--- a/test/mocks/stats/manager.go
+++ b/test/mocks/stats/manager.go
@@ -30,6 +30,7 @@ func (m *MockStatManager) NewServiceStats() stats.ServiceStats {
 	ret.ConfigLoadError = m.store.NewCounter("config_load_error")
 	ret.ShouldRateLimit = m.NewShouldRateLimitStats()
 	ret.GlobalShadowMode = m.store.NewCounter("global_shadow_mode")
+	ret.NegativeHitsRejected = m.store.NewCounter("negative_hits_rejected")
 	return ret
 }
 

--- a/test/redis/bench_test.go
+++ b/test/redis/bench_test.go
@@ -47,7 +47,7 @@ func BenchmarkParallelDoLimit(b *testing.B) {
 			client := redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", "127.0.0.1:6379", poolSize, pipelineWindow, pipelineLimit, nil, false, nil, 10*time.Second, "", "", time.Second, 30*time.Second, 0, false)
 			defer client.Close()
 
-			cache := redis.NewFixedRateLimitCacheImpl(client, nil, utils.NewTimeSourceImpl(), rand.New(utils.NewLockedSource(time.Now().Unix())), 10, nil, 0.8, "", sm, true, false)
+			cache := redis.NewFixedRateLimitCacheImpl(client, nil, utils.NewTimeSourceImpl(), rand.New(utils.NewLockedSource(time.Now().Unix())), 10, nil, 0.8, "", sm, true, false, false)
 			request := common.NewRateLimitRequest("domain", [][][2]string{{{"key", "value"}}}, 1)
 			limits := []*config.RateLimit{config.NewRateLimit(1000000000, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
 

--- a/test/redis/decrement_script_test.go
+++ b/test/redis/decrement_script_test.go
@@ -1,0 +1,118 @@
+package redis_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	gostats "github.com/lyft/gostats"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/ratelimit/src/redis"
+)
+
+func mkSingleRedisClient(addr string) redis.Client {
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	return redis.NewClientImpl(context.Background(), statsStore, false, "", "tcp", "single", addr, 1, 0, 0, nil, false, nil,
+		10*time.Second, "", "", time.Second, 30*time.Second, 100*time.Millisecond, false)
+}
+
+func evalDecrementScript(t *testing.T, client redis.Client, key string, hitsAddend uint64, expirationSeconds int64,
+	publishFlag string, requestsPerUnit uint32,
+) int64 {
+	t.Helper()
+	var result int64
+	err := client.DoCmd(&result, "EVAL", redis.DecrementScript, 1, key, hitsAddend, expirationSeconds, publishFlag,
+		requestsPerUnit, redis.LocalCacheInvalidationChannel)
+	assert.NoError(t, err)
+	return result
+}
+
+// Buffers the subscriber channel: publishing inside miniredis blocks the
+// publishing command until the message is consumed.
+func pumpMessages(sub *miniredis.Subscriber) <-chan string {
+	messages := make(chan string, 100)
+	go func() {
+		for message := range sub.Messages() {
+			messages <- message.Message
+		}
+		close(messages)
+	}()
+	return messages
+}
+
+func drainMessages(messages <-chan string) []string {
+	var drained []string
+	for {
+		select {
+		case message := <-messages:
+			drained = append(drained, message)
+		case <-time.After(100 * time.Millisecond):
+			return drained
+		}
+	}
+}
+
+func TestDecrementScript(t *testing.T) {
+	redisSrv := mustNewRedisServer()
+	defer redisSrv.Close()
+
+	client := mkSingleRedisClient(redisSrv.Addr())
+	defer client.Close()
+
+	sub := redisSrv.NewSubscriber()
+	defer sub.Close()
+	sub.Subscribe(redis.LocalCacheInvalidationChannel)
+	messages := pumpMessages(sub)
+
+	t.Run("absent key returns 0 and does not publish", func(t *testing.T) {
+		assert.EqualValues(t, 0, evalDecrementScript(t, client, "absent_key", 3, 60, "1", 10))
+		assert.False(t, redisSrv.Exists("absent_key"))
+		assert.Empty(t, drainMessages(messages))
+	})
+
+	t.Run("crossing refund publishes the key and resets the TTL", func(t *testing.T) {
+		assert.NoError(t, redisSrv.Set("crossing_key", "12"))
+		redisSrv.SetTTL("crossing_key", 5*time.Second)
+
+		assert.EqualValues(t, 9, evalDecrementScript(t, client, "crossing_key", 3, 60, "1", 10))
+		assert.Equal(t, []string{"crossing_key"}, drainMessages(messages))
+		assert.Equal(t, 60*time.Second, redisSrv.TTL("crossing_key"))
+	})
+
+	t.Run("refund leaving the counter above the limit does not publish", func(t *testing.T) {
+		assert.NoError(t, redisSrv.Set("above_key", "20"))
+
+		assert.EqualValues(t, 17, evalDecrementScript(t, client, "above_key", 3, 60, "1", 10))
+		assert.Empty(t, drainMessages(messages))
+
+		// One message per poisoning cycle: only the refund that finally crosses
+		// back under the limit publishes.
+		assert.EqualValues(t, 10, evalDecrementScript(t, client, "above_key", 7, 60, "1", 10))
+		assert.Equal(t, []string{"above_key"}, drainMessages(messages))
+		assert.EqualValues(t, 8, evalDecrementScript(t, client, "above_key", 2, 60, "1", 10))
+		assert.Empty(t, drainMessages(messages))
+	})
+
+	t.Run("counter floors at zero", func(t *testing.T) {
+		assert.NoError(t, redisSrv.Set("floor_key", "12"))
+
+		assert.EqualValues(t, 0, evalDecrementScript(t, client, "floor_key", 20, 60, "1", 10))
+		assert.Equal(t, []string{"floor_key"}, drainMessages(messages))
+	})
+}
+
+// Radix classifies bare EVAL as keyless; the cache key must reach
+// ActionProperties.Keys or cluster routing breaks.
+func TestDecrementEvalRoutesByCacheKey(t *testing.T) {
+	redisSrv := mustNewRedisServer()
+	defer redisSrv.Close()
+	client := mkSingleRedisClient(redisSrv.Addr())
+	defer client.Close()
+
+	p := client.PipeAppendWithRoutingKey(redis.Pipeline{}, "cache_key", nil, "EVAL",
+		redis.DecrementScript, 1, "cache_key", 3, 60, "1", 10, redis.LocalCacheInvalidationChannel)
+	assert.Equal(t, []string{"cache_key"}, p[0].Action.Properties().Keys)
+	assert.True(t, p[0].Action.Properties().CanRetry)
+}

--- a/test/redis/fixed_cache_impl_test.go
+++ b/test/redis/fixed_cache_impl_test.go
@@ -38,11 +38,11 @@ func TestNegativeHits(t *testing.T) {
 
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_utils.NewMockTimeSource(controller)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false, false)
 
 	// Decrement from a counter at 5, requesting -3. Lua returns 2 (5-3=2).
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
-	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", limiter.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1)).SetArg(2, uint64(2)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", redis.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1), "0", uint32(10), redis.LocalCacheInvalidationChannel).SetArg(2, uint64(2)).DoAndReturn(pipeAppendWithRoutingKey)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequestWithNegativeHits(
@@ -67,11 +67,11 @@ func TestNegativeHitsFloorAtZero(t *testing.T) {
 
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_utils.NewMockTimeSource(controller)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false, false)
 
 	// Counter at 2, requesting -5. Lua floors at 0 and returns 0.
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
-	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", limiter.DecrementScript, 1, "domain_key_value_1234", uint64(5), int64(1)).SetArg(2, uint64(0)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", redis.DecrementScript, 1, "domain_key_value_1234", uint64(5), int64(1), "0", uint32(10), redis.LocalCacheInvalidationChannel).SetArg(2, uint64(0)).DoAndReturn(pipeAppendWithRoutingKey)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequestWithNegativeHits(
@@ -95,14 +95,13 @@ func TestNegativeHitsSkipsOverLimitCheck(t *testing.T) {
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_utils.NewMockTimeSource(controller)
 	localCache := freecache.NewCache(100)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, localCache, 0.8, "", sm, false, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, limiter.NewLocalCacheGuard(localCache), 0.8, "", sm, false, false, false)
 
-	// Set the key as over-limit in local cache.
 	localCache.Set([]byte("domain_key_value_1234"), []byte{}, 60)
 
 	// Even though the key is in the over-limit local cache, negative hits should still proceed.
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
-	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", limiter.DecrementScript, 1, "domain_key_value_1234", uint64(2), int64(1)).SetArg(2, uint64(8)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", redis.DecrementScript, 1, "domain_key_value_1234", uint64(2), int64(1), "0", uint32(10), redis.LocalCacheInvalidationChannel).SetArg(2, uint64(8)).DoAndReturn(pipeAppendWithRoutingKey)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequestWithNegativeHits(
@@ -128,11 +127,11 @@ func TestNegativeHitsStillOverLimitReturnsOK(t *testing.T) {
 
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_utils.NewMockTimeSource(controller)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false, false)
 
 	// Counter at 15, requesting -3. Lua returns 12, which is still above the limit of 10.
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
-	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", limiter.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1)).SetArg(2, uint64(12)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", redis.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1), "0", uint32(10), redis.LocalCacheInvalidationChannel).SetArg(2, uint64(12)).DoAndReturn(pipeAppendWithRoutingKey)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequestWithNegativeHits(
@@ -159,12 +158,12 @@ func TestNegativeHitsWithStopCacheKeyIncrementWhenOverlimit(t *testing.T) {
 
 	client := mock_redis.NewMockClient(controller)
 	timeSource := mock_utils.NewMockTimeSource(controller)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, true, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, true, false, false)
 
 	// Counter at 5, requesting -3. Lua returns 2. No GET pre-check should be issued for
 	// the negative hit, only the EVAL decrement.
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
-	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", limiter.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1)).SetArg(2, uint64(2)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", redis.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1), "0", uint32(10), redis.LocalCacheInvalidationChannel).SetArg(2, uint64(2)).DoAndReturn(pipeAppendWithRoutingKey)
 	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
 
 	request := common.NewRateLimitRequestWithNegativeHits(
@@ -175,6 +174,63 @@ func TestNegativeHitsWithStopCacheKeyIncrementWhenOverlimit(t *testing.T) {
 	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
 	assert.Equal(uint64(8), uint64(result[0].LimitRemaining))
 	assert.Equal(uint64(3), limits[0].Stats.TotalNegativeHits.Value())
+}
+
+// TestNegativeHitsPublishInvalidation verifies that when the cache is built with
+// publishInvalidations=true, decrements pass the publish flag, the limit and the
+// invalidation channel to the Lua script.
+func TestNegativeHitsPublishInvalidation(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+
+	client := mock_redis.NewMockClient(controller)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	localCache := freecache.NewCache(100)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, limiter.NewLocalCacheGuard(localCache), 0.8, "", sm, false, false, true)
+
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	client.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", redis.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1), "1", uint32(10), redis.LocalCacheInvalidationChannel).SetArg(2, uint64(2)).DoAndReturn(pipeAppendWithRoutingKey)
+	client.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{3}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(8), uint64(result[0].LimitRemaining))
+}
+
+// TestNegativeHitsPerSecondClientNeverPublishes verifies that decrements routed to
+// the dedicated per-second client always pass the publish flag as '0': the
+// invalidation subscriber listens only on the main Redis.
+func TestNegativeHitsPerSecondClientNeverPublishes(t *testing.T) {
+	assert := assert.New(t)
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+	sm := stats.NewMockStatManager(statsStore)
+
+	client := mock_redis.NewMockClient(controller)
+	perSecondClient := mock_redis.NewMockClient(controller)
+	timeSource := mock_utils.NewMockTimeSource(controller)
+	localCache := freecache.NewCache(100)
+	cache := redis.NewFixedRateLimitCacheImpl(client, perSecondClient, timeSource, rand.New(rand.NewSource(1)), 0, limiter.NewLocalCacheGuard(localCache), 0.8, "", sm, false, false, true)
+
+	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
+	perSecondClient.EXPECT().PipeAppendWithRoutingKey(gomock.Any(), "domain_key_value_1234", gomock.Any(), "EVAL", redis.DecrementScript, 1, "domain_key_value_1234", uint64(3), int64(1), "0", uint32(10), redis.LocalCacheInvalidationChannel).SetArg(2, uint64(2)).DoAndReturn(pipeAppendWithRoutingKey)
+	perSecondClient.EXPECT().PipeDo(gomock.Any(), gomock.Any()).Return(nil)
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"domain", [][][2]string{{{"key", "value"}}}, []uint64{3}, []bool{true})
+	limits := []*config.RateLimit{config.NewRateLimit(10, pb.RateLimitResponse_RateLimit_SECOND, sm.NewStats("key_value"), false, false, false, "", nil, false)}
+
+	result := cache.DoLimit(context.Background(), request, limits)
+	assert.Equal(pb.RateLimitResponse_OK, result[0].Code)
+	assert.Equal(uint64(8), uint64(result[0].LimitRemaining))
 }
 
 func TestRedis(t *testing.T) {
@@ -209,9 +265,9 @@ func testRedis(usePerSecondRedis bool) func(*testing.T) {
 		timeSource := mock_utils.NewMockTimeSource(controller)
 		var cache limiter.RateLimitCache
 		if usePerSecondRedis {
-			cache = redis.NewFixedRateLimitCacheImpl(client, perSecondClient, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false)
+			cache = redis.NewFixedRateLimitCacheImpl(client, perSecondClient, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false, false)
 		} else {
-			cache = redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false)
+			cache = redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false, false)
 		}
 
 		timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
@@ -356,7 +412,7 @@ func TestOverLimitWithLocalCache(t *testing.T) {
 	sink := common.NewTestStatSink()
 	statsStore := gostats.NewStore(sink, false)
 	sm := stats.NewMockStatManager(statsStore)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, localCache, 0.8, "", sm, false, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, limiter.NewLocalCacheGuard(localCache), 0.8, "", sm, false, false, false)
 
 	localCacheScopeName := "localcache"
 	localCacheStats := limiter.NewLocalCacheStats(localCache, statsStore.Scope(localCacheScopeName))
@@ -463,7 +519,7 @@ func TestNearLimit(t *testing.T) {
 	timeSource := mock_utils.NewMockTimeSource(controller)
 	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
 	sm := stats.NewMockStatManager(statsStore)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false, false)
 
 	// Test Near Limit Stats. Under Near Limit Ratio
 	timeSource.EXPECT().UnixNow().Return(int64(1000000)).MaxTimes(3)
@@ -646,7 +702,7 @@ func TestRedisWithJitter(t *testing.T) {
 	jitterSource := mock_utils.NewMockJitterRandSource(controller)
 	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
 	sm := stats.NewMockStatManager(statsStore)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(jitterSource), 3600, nil, 0.8, "", sm, false, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(jitterSource), 3600, nil, 0.8, "", sm, false, false, false)
 
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
 	jitterSource.EXPECT().Int63().Return(int64(100))
@@ -678,7 +734,7 @@ func TestOverLimitWithLocalCacheShadowRule(t *testing.T) {
 	sink := common.NewTestStatSink()
 	statsStore := gostats.NewStore(sink, false)
 	sm := stats.NewMockStatManager(statsStore)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, localCache, 0.8, "", sm, false, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, limiter.NewLocalCacheGuard(localCache), 0.8, "", sm, false, false, false)
 
 	localCacheScopeName := "localcache"
 	localCacheStats := limiter.NewLocalCacheStats(localCache, statsStore.Scope(localCacheScopeName))
@@ -796,7 +852,7 @@ func TestRedisTracer(t *testing.T) {
 	client := mock_redis.NewMockClient(controller)
 
 	timeSource := mock_utils.NewMockTimeSource(controller)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, nil, 0.8, "", sm, false, false, false)
 
 	timeSource.EXPECT().UnixNow().Return(int64(1234)).MaxTimes(3)
 
@@ -825,7 +881,7 @@ func TestOverLimitWithStopCacheKeyIncrementWhenOverlimitConfig(t *testing.T) {
 	sink := common.NewTestStatSink()
 	statsStore := gostats.NewStore(sink, false)
 	sm := stats.NewMockStatManager(statsStore)
-	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, localCache, 0.8, "", sm, true, false)
+	cache := redis.NewFixedRateLimitCacheImpl(client, nil, timeSource, rand.New(rand.NewSource(1)), 0, limiter.NewLocalCacheGuard(localCache), 0.8, "", sm, true, false, false)
 
 	localCacheScopeName := "localcache"
 	localCacheStats := limiter.NewLocalCacheStats(localCache, statsStore.Scope(localCacheScopeName))

--- a/test/redis/local_cache_invalidator_test.go
+++ b/test/redis/local_cache_invalidator_test.go
@@ -1,0 +1,307 @@
+package redis_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/coocood/freecache"
+	gostats "github.com/lyft/gostats"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/ratelimit/src/limiter"
+	"github.com/envoyproxy/ratelimit/src/redis"
+	"github.com/envoyproxy/ratelimit/src/settings"
+)
+
+func makeInvalidatorSettings(addr string) settings.Settings {
+	var s settings.Settings
+	s.RedisType = "SINGLE"
+	s.RedisSocketType = "tcp"
+	s.RedisUrl = addr
+	s.RedisTimeout = 1 * time.Second
+	return s
+}
+
+type invalidatorFixture struct {
+	cache      *freecache.Cache
+	guard      *limiter.LocalCacheGuard
+	subscribed gostats.Gauge
+	received   gostats.Counter
+	deleted    gostats.Counter
+}
+
+func startInvalidator(t *testing.T, s settings.Settings) *invalidatorFixture {
+	cache := freecache.NewCache(1024)
+	store := gostats.NewStore(gostats.NewNullSink(), false)
+	f := &invalidatorFixture{
+		cache:      cache,
+		guard:      limiter.NewLocalCacheGuard(cache),
+		subscribed: store.NewGauge("localcache.invalidation.subscribed"),
+		received:   store.NewCounter("localcache.invalidation.received"),
+		deleted:    store.NewCounter("localcache.invalidation.deleted"),
+	}
+	invalidator := redis.StartLocalCacheInvalidator(context.Background(), s, f.guard, store)
+	t.Cleanup(func() { invalidator.Close() })
+	return f
+}
+
+func (f *invalidatorFixture) awaitSubscribed(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	assert.Eventually(t, func() bool { return f.subscribed.Value() == 1 }, timeout, 10*time.Millisecond)
+}
+
+func (f *invalidatorFixture) cached(key string) bool {
+	_, err := f.cache.Get([]byte(key))
+	return err == nil
+}
+
+func (f *invalidatorFixture) awaitInvalidated(t *testing.T, key string) {
+	t.Helper()
+	assert.Eventually(t, func() bool { return !f.cached(key) }, 5*time.Second, 10*time.Millisecond)
+}
+
+func publish(t *testing.T, client redis.Client, key string) {
+	t.Helper()
+	assert.NoError(t, client.DoCmd(nil, "PUBLISH", redis.LocalCacheInvalidationChannel, key))
+}
+
+func TestLocalCacheInvalidatorConfigValidation(t *testing.T) {
+	assert := assert.New(t)
+	localCache := limiter.NewLocalCacheGuard(freecache.NewCache(1024))
+	statsStore := gostats.NewStore(gostats.NewNullSink(), false)
+
+	assert.Panics(func() {
+		redis.StartLocalCacheInvalidator(context.Background(), makeInvalidatorSettings("localhost:6379"), nil, statsStore)
+	}, "nil local cache")
+
+	badType := makeInvalidatorSettings("localhost:6379")
+	badType.RedisType = "clustered"
+	assert.Panics(func() {
+		redis.StartLocalCacheInvalidator(context.Background(), badType, localCache, statsStore)
+	}, "unrecognized redis type")
+
+	badSentinel := makeInvalidatorSettings("mymaster")
+	badSentinel.RedisType = "sentinel"
+	assert.Panics(func() {
+		redis.StartLocalCacheInvalidator(context.Background(), badSentinel, localCache, statsStore)
+	}, "sentinel url without sentinel addresses")
+}
+
+func TestLocalCacheInvalidator(t *testing.T) {
+	assert := assert.New(t)
+	redisSrv := mustNewRedisServer()
+	defer redisSrv.Close()
+	client := mkSingleRedisClient(redisSrv.Addr())
+	defer client.Close()
+
+	f := startInvalidator(t, makeInvalidatorSettings(redisSrv.Addr()))
+	f.awaitSubscribed(t, 5*time.Second)
+
+	assert.NoError(f.cache.Set([]byte("poisoned_key"), []byte{}, 60))
+	publish(t, client, "poisoned_key")
+	f.awaitInvalidated(t, "poisoned_key")
+	assert.EqualValues(1, f.deleted.Value())
+
+	publish(t, client, "unknown_key")
+	assert.Eventually(func() bool { return f.received.Value() == 2 }, 5*time.Second, 10*time.Millisecond)
+	assert.EqualValues(1, f.deleted.Value())
+}
+
+func TestLocalCacheInvalidatorReconnects(t *testing.T) {
+	assert := assert.New(t)
+	redisSrv := mustNewRedisServer()
+	addr := redisSrv.Addr()
+
+	f := startInvalidator(t, makeInvalidatorSettings(addr))
+	f.awaitSubscribed(t, 5*time.Second)
+
+	redisSrv.Close()
+	assert.Eventually(func() bool { return f.subscribed.Value() == 0 }, 10*time.Second, 10*time.Millisecond)
+
+	restartedSrv := miniredis.NewMiniRedis()
+	assert.NoError(restartedSrv.StartAddr(addr))
+	defer restartedSrv.Close()
+	f.awaitSubscribed(t, 30*time.Second)
+
+	assert.NoError(f.cache.Set([]byte("poisoned_key"), []byte{}, 60))
+	client := mkSingleRedisClient(addr)
+	defer client.Close()
+	publish(t, client, "poisoned_key")
+	f.awaitInvalidated(t, "poisoned_key")
+}
+
+func TestLocalCacheInvalidatorClusterDialsTcp(t *testing.T) {
+	redisSrv := mustNewRedisServer()
+	defer redisSrv.Close()
+	client := mkSingleRedisClient(redisSrv.Addr())
+	defer client.Close()
+
+	// REDIS_SOCKET_TYPE defaults to unix; cluster subscriptions must dial TCP
+	// like radix's cluster client does.
+	s := makeInvalidatorSettings(redisSrv.Addr())
+	s.RedisType = "cluster"
+	s.RedisSocketType = "unix"
+
+	f := startInvalidator(t, s)
+	f.awaitSubscribed(t, 5*time.Second)
+
+	assert.NoError(t, f.cache.Set([]byte("poisoned_key"), []byte{}, 60))
+	publish(t, client, "poisoned_key")
+	f.awaitInvalidated(t, "poisoned_key")
+}
+
+func TestLocalCacheInvalidatorRotatesSubscription(t *testing.T) {
+	redisSrv := mustNewRedisServer()
+	defer redisSrv.Close()
+	client := mkSingleRedisClient(redisSrv.Addr())
+	defer client.Close()
+
+	s := makeInvalidatorSettings(redisSrv.Addr())
+	s.LocalCacheInvalidationResubscribeInterval = 200 * time.Millisecond
+
+	f := startInvalidator(t, s)
+	f.awaitSubscribed(t, 5*time.Second)
+
+	time.Sleep(600 * time.Millisecond)
+
+	// The publish is retried: a message landing in the short unsubscribed gap
+	// between sessions is legitimately dropped (at-most-once delivery).
+	assert.NoError(t, f.cache.Set([]byte("poisoned_key"), []byte{}, 60))
+	assert.Eventually(t, func() bool {
+		publish(t, client, "poisoned_key")
+		return !f.cached("poisoned_key")
+	}, 5*time.Second, 50*time.Millisecond)
+	f.awaitSubscribed(t, 5*time.Second)
+}
+
+func TestLocalCacheInvalidatorSuppressesRacedInsert(t *testing.T) {
+	assert := assert.New(t)
+	redisSrv := mustNewRedisServer()
+	defer redisSrv.Close()
+	client := mkSingleRedisClient(redisSrv.Addr())
+	defer client.Close()
+
+	f := startInvalidator(t, makeInvalidatorSettings(redisSrv.Addr()))
+	f.awaitSubscribed(t, 5*time.Second)
+
+	// A snapshot taken before the invalidation must not insert afterwards; a
+	// fresh one must.
+	snap := f.guard.GenSnapshot()
+	publish(t, client, "poisoned_key")
+	assert.Eventually(func() bool { return f.received.Value() == 1 }, 5*time.Second, 10*time.Millisecond)
+
+	inserted, err := f.guard.SetIfUnchanged([]byte("poisoned_key"), []byte{}, 60, snap)
+	assert.NoError(err)
+	assert.False(inserted)
+	assert.False(f.cached("poisoned_key"))
+
+	inserted, err = f.guard.SetIfUnchanged([]byte("poisoned_key"), []byte{}, 60, f.guard.GenSnapshot())
+	assert.NoError(err)
+	assert.True(inserted)
+	assert.True(f.cached("poisoned_key"))
+}
+
+func TestLocalCacheInvalidatorSkipsStalledEndpoint(t *testing.T) {
+	stalled, conns := newStalledListener(t)
+	defer stalled.Close()
+	defer conns.closeAll()
+
+	redisSrv := mustNewRedisServer()
+	defer redisSrv.Close()
+
+	s := makeInvalidatorSettings(stalled.Addr().String() + "," + redisSrv.Addr())
+	s.RedisType = "cluster"
+	s.RedisTimeout = 500 * time.Millisecond
+
+	f := startInvalidator(t, s)
+	f.awaitSubscribed(t, 10*time.Second)
+}
+
+func TestLocalCacheInvalidatorRotatesPastStalledSentinel(t *testing.T) {
+	stalled, conns := newStalledListener(t)
+	defer stalled.Close()
+	defer conns.closeAll()
+
+	redisSrv := mustNewRedisServer()
+	defer redisSrv.Close()
+	masterHost, masterPort, err := net.SplitHostPort(redisSrv.Addr())
+	assert.NoError(t, err)
+
+	sentinel := newFakeSentinel(t, masterHost, masterPort)
+	defer sentinel.Close()
+
+	s := makeInvalidatorSettings("mymaster," + stalled.Addr().String() + "," + sentinel.Addr().String())
+	s.RedisType = "sentinel"
+	s.RedisTimeout = 500 * time.Millisecond
+
+	f := startInvalidator(t, s)
+	f.awaitSubscribed(t, 15*time.Second)
+}
+
+// stalledConns retains accepted connections: an unreferenced net.Conn can be
+// closed by its runtime finalizer, faking a timely failure.
+type stalledConns struct {
+	mu    sync.Mutex
+	conns []net.Conn
+}
+
+func (s *stalledConns) add(c net.Conn) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.conns = append(s.conns, c)
+}
+
+func (s *stalledConns) closeAll() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, c := range s.conns {
+		c.Close()
+	}
+}
+
+// newStalledListener accepts TCP connections and never responds on them.
+func newStalledListener(t *testing.T) (net.Listener, *stalledConns) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conns := &stalledConns{}
+	go func() {
+		for {
+			c, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			conns.add(c)
+		}
+	}()
+	return listener, conns
+}
+
+// newFakeSentinel answers every connection with the given master address; the
+// reply is written without reading the request and waits in the buffer.
+func newFakeSentinel(t *testing.T, masterHost, masterPort string) net.Listener {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reply := fmt.Sprintf("*2\r\n$%d\r\n%s\r\n$%d\r\n%s\r\n",
+		len(masterHost), masterHost, len(masterPort), masterPort)
+	go func() {
+		for {
+			c, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				_, _ = c.Write([]byte(reply))
+			}(c)
+		}
+	}()
+	return listener
+}

--- a/test/service/ratelimit_test.go
+++ b/test/service/ratelimit_test.go
@@ -20,8 +20,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/envoyproxy/ratelimit/src/trace"
@@ -76,6 +78,7 @@ type rateLimitServiceTestSuite struct {
 	statsManager          stats.Manager
 	statStore             gostats.Store
 	mockClock             utils.TimeSource
+	enableNegativeHits    bool
 }
 
 type MockClock struct {
@@ -114,7 +117,7 @@ func (this *rateLimitServiceTestSuite) setupBasicService() ratelimit.RateLimitSe
 
 	testSpanExporter.Reset()
 
-	svc := ratelimit.NewService(this.cache, this.configProvider, this.statsManager, this.health, MockClock{now: int64(2222)}, false, false, false)
+	svc := ratelimit.NewService(this.cache, this.configProvider, this.statsManager, this.health, MockClock{now: int64(2222)}, false, false, false, this.enableNegativeHits)
 	barrier.wait() // wait for initial config load
 	return svc
 }
@@ -514,7 +517,7 @@ func TestInitialLoadError(test *testing.T) {
 		return nil, config.RateLimitConfigError("load error")
 	})
 	go func() { t.configUpdateEventChan <- t.configUpdateEvent }() // initial config update from provider
-	service := ratelimit.NewService(t.cache, t.configProvider, t.statsManager, t.health, t.mockClock, false, false, false)
+	service := ratelimit.NewService(t.cache, t.configProvider, t.statsManager, t.health, t.mockClock, false, false, false, false)
 	barrier.wait()
 
 	request := common.NewRateLimitRequest("test-domain", [][][2]string{{{"hello", "world"}}}, 1)
@@ -605,7 +608,7 @@ func TestServiceHealthStatus(test *testing.T) {
 
 	// Set up the service
 	t.configProvider.EXPECT().ConfigUpdateEvent().Return(t.configUpdateEventChan).Times(1)
-	_ = ratelimit.NewService(t.cache, t.configProvider, t.statsManager, hc, MockClock{now: int64(2222)}, false, true, healthyWithAtLeastOneConfigLoaded)
+	_ = ratelimit.NewService(t.cache, t.configProvider, t.statsManager, hc, MockClock{now: int64(2222)}, false, true, healthyWithAtLeastOneConfigLoaded, false)
 
 	// Health check request
 	req := &healthpb.HealthCheckRequest{
@@ -636,7 +639,7 @@ func TestServiceHealthStatusAtLeastOneConfigLoaded(test *testing.T) {
 	t.configUpdateEvent.EXPECT().GetConfig().DoAndReturn(func() (config.RateLimitConfig, any) {
 		return t.config, nil
 	}).Times(2)
-	service := ratelimit.NewService(t.cache, t.configProvider, t.statsManager, hc, MockClock{now: int64(2222)}, false, true, healthyWithAtLeastOneConfigLoaded)
+	service := ratelimit.NewService(t.cache, t.configProvider, t.statsManager, hc, MockClock{now: int64(2222)}, false, true, healthyWithAtLeastOneConfigLoaded, false)
 	// Health check request
 	req := &healthpb.HealthCheckRequest{
 		Service: "ratelimit",
@@ -1291,4 +1294,61 @@ func TestServiceMixedModeWithShadowMode(test *testing.T) {
 
 	// Verify global shadow mode counter is incremented
 	t.assert.EqualValues(1, t.statStore.NewCounter("global_shadow_mode").Value())
+}
+
+func TestNegativeHitsRejectedWhenFlagOff(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	// The rejection happens before the config lookup and the cache call, so
+	// neither the config nor the cache mock expects any call here.
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"test-domain", [][][2]string{{{"hello", "world"}}}, []uint64{3}, []bool{true})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(response)
+	t.assert.Equal(codes.Unimplemented, status.Code(err))
+	t.assert.EqualValues(1, t.statStore.NewCounter("negative_hits_rejected").Value())
+	t.assert.EqualValues(0, t.statStore.NewCounter("call.should_rate_limit.service_error").Value())
+}
+
+func TestNegativeHitsRejectedWhenFlagOffMixedBatch(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	service := t.setupBasicService()
+
+	// A single negative-hit descriptor fails the whole batch, including the
+	// positive descriptor in it.
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"test-domain", [][][2]string{{{"foo", "bar"}}, {{"hello", "world"}}}, []uint64{1, 3}, []bool{false, true})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	t.assert.Nil(response)
+	t.assert.Equal(codes.Unimplemented, status.Code(err))
+	t.assert.EqualValues(1, t.statStore.NewCounter("negative_hits_rejected").Value())
+}
+
+func TestNegativeHitsAllowedWhenFlagOn(test *testing.T) {
+	t := commonSetup(test)
+	defer t.controller.Finish()
+	t.enableNegativeHits = true
+	service := t.setupBasicService()
+
+	request := common.NewRateLimitRequestWithNegativeHits(
+		"test-domain", [][][2]string{{{"hello", "world"}}}, []uint64{3}, []bool{true})
+	t.config.EXPECT().GetLimit(context.Background(), "test-domain", request.Descriptors[0]).Return(nil)
+	t.cache.EXPECT().DoLimit(context.Background(), request, []*config.RateLimit{nil}).Return(
+		[]*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0}})
+
+	response, err := service.ShouldRateLimit(context.Background(), request)
+	common.AssertProtoEqual(
+		t.assert,
+		&pb.RateLimitResponse{
+			OverallCode: pb.RateLimitResponse_OK,
+			Statuses:    []*pb.RateLimitResponse_DescriptorStatus{{Code: pb.RateLimitResponse_OK, CurrentLimit: nil, LimitRemaining: 0}},
+		},
+		response)
+	t.assert.Nil(err)
+	t.assert.EqualValues(0, t.statStore.NewCounter("negative_hits_rejected").Value())
 }

--- a/test/settings/settings_test.go
+++ b/test/settings/settings_test.go
@@ -1,0 +1,28 @@
+package settings_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/envoyproxy/ratelimit/src/settings"
+)
+
+func TestValidateNegativeHitsBackendCombinations(t *testing.T) {
+	makeSettings := func(enableNegativeHits bool, backendType string, localCacheSizeInBytes int) settings.Settings {
+		var s settings.Settings
+		s.EnableNegativeHits = enableNegativeHits
+		s.BackendType = backendType
+		s.LocalCacheSizeInBytes = localCacheSizeInBytes
+		return s
+	}
+
+	assert.Error(t, makeSettings(true, "memcache", 1000).Validate())
+
+	assert.NoError(t, makeSettings(true, "memcache", 0).Validate())
+	assert.NoError(t, makeSettings(true, "redis", 1000).Validate())
+	assert.NoError(t, makeSettings(false, "memcache", 1000).Validate())
+
+	// freecache clamps a negative size up to a real cache, bypassing the guard.
+	assert.Error(t, makeSettings(true, "memcache", -1).Validate())
+}


### PR DESCRIPTION
**Problem**

is_negative_hits (https://github.com/envoyproxy/ratelimit/pull/1140) lets a descriptor decrement previously consumed quota, but refunds are invisible to the local over-limit cache: once a replica cached a key as over limit, a refund that freed quota in Redis kept being answered OVER_LIMIT from every replica's local cache until the window ended which degrades the feature on long windows

**Suggested design**

- Introduce feature flag ENABLE_NEGATIVE_HITS (default off). While off, a request containing a negative-hit descriptor is rejected with UNIMPLEMENTED
- Refuse to boot the one unfixable combination: negative hits + memcached + local cache (this PR does not add any support for the invalidations with memcached as a backend). Memcached refunds without a local cache enabled keep working.
- Add Redis pub-sub backed invalidation routine: at-most-once guarantee, single added connection per replica + local cache gen-based guard for eliminating races between invalidation and stale insert

P.S. Agent also added some missing tests for touched components, look fine