### PR TITLE
fix(ci): update Scorecard action to use GHCR image

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The [Scorecard job](https://github.com/envoyproxy/ratelimit/actions/runs/34384025001/job/102575648658) fails before analysis starts when downloading `gcr.io/openssf/scorecard-action:v2.4.0`. GCR rejects the pull because billing is disabled for the upstream Google Cloud project, and all three attempts fail.

Update `ossf/scorecard-action` from v2.4.0 to v2.4.4, pinned to its full commit SHA. The new release downloads `ghcr.io/ossf/scorecard-action:v2.4.4`, avoiding the unavailable GCR image. The existing workflow inputs remain compatible.

Validation: parsed the workflow YAML, checked its inputs against the pinned action metadata, confirmed anonymous access to the GHCR image manifest (HTTP 200), and ran `git diff --check`. Full CI has not been run locally.

Signed-off-by: Yuki Sawa <8774197+ysawa0@users.noreply.github.com>
